### PR TITLE
Report Sinatra errors

### DIFF
--- a/lib/honeybadger/rack.rb
+++ b/lib/honeybadger/rack.rb
@@ -34,21 +34,22 @@ module Honeybadger
     end
 
     def notify_honeybadger(exception,env)
-      Honeybadger.notify_or_ignore(exception,:rack_env => env) unless ignored_user_agent?(env)
+      Honeybadger.notify_or_ignore(exception, :rack_env => env) unless ignored_user_agent?(env)
     end
 
     def call(env)
       begin
         response = @app.call(env)
       rescue Exception => raised
-        env['honeybadger.error_id'] = notify_honeybadger(raised,env)
+        env['honeybadger.error_id'] = notify_honeybadger(raised, env)
         raise
       ensure
         Honeybadger.context.clear!
       end
 
-      if env['rack.exception']
-        env['honeybadger.error_id'] = notify_honeybadger(env['rack.exception'],env)
+      framework_exception = env['rack.exception'] || env['sinatra.error']
+      if framework_exception
+        env['honeybadger.error_id'] = notify_honeybadger(framework_exception, env)
       end
 
       response


### PR DESCRIPTION
Even though Honeybadger claims to support Sinatra natively, my Sinatra app didn't report errors until I added this code:

``` ruby
  error do |e|
    request.env['rack.exception'] = request.env['sinatra.error']
  end
```

This patch changes `Honeybadger::Rack` to also check the `sinatra.error` env, and report it as well.
