### PR TITLE
Remove trailing whitespace

### DIFF
--- a/generators/honeybadger/templates/honeybadger_tasks.rake
+++ b/generators/honeybadger/templates/honeybadger_tasks.rake
@@ -1,7 +1,7 @@
 # Don't load anything when running the gems:* tasks.
 # Otherwise, honeybadger will be considered a framework gem.
 # https://thoughtbot.lighthouseapp.com/projects/14221/tickets/629
-unless ARGV.any? {|a| a =~ /^gems/} 
+unless ARGV.any? {|a| a =~ /^gems/}
 
   Dir[File.join(Rails.root, 'vendor', 'gems', 'honeybadger-*')].each do |vendored_notifier|
     $: << File.join(vendored_notifier, 'lib')


### PR DESCRIPTION
The single trailing whitespace can be a pain if you have a 
precommit hook that removes whitespace.
