### PR TITLE
Encode data as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ examples of notifying Honeybadger asynchronously:
       @queue = :cobra_alert
 
       def self.perform(notice)
-        Honeybadger.sender.send_to_honeybadger(notice)
+        Honeybadger.sender.send_to_honeybadger(notice.to_json)
       end
     end
 


### PR DESCRIPTION
When Resque pulls the data off the queue, it parses it as json.
Sender#send_to_honeybadger expects a json-encoded payload, not a Hash.
