### PR TITLE
Change README example to Ruby 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Here's an example of sending some user-specific information in a Rails
 
     before_filter do
       Honeybadger.context({
-        user_id: current_user.id,
-        user_email: current_user.email
+        :user_id => current_user.id,
+        :user_email => current_user.email
       }) if current_user
     end
 


### PR DESCRIPTION
Change the Honeybadger.context code example so it works with older Ruby versions. Prevents copy+paste issues and wasting time debugging.
