### PR TITLE
assync notify for capistrano task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Honeybadger 1.7.0 (Unreleased) ##
 
+* Added option to run capistrano deploy notification asynchronously 
+
+ *Sergey Efremov*
+
 ## Honeybadger 1.6.2 ##
 
 * Fail gracefully when Rack params cannot be parsed

--- a/README.md
+++ b/README.md
@@ -222,8 +222,16 @@ can set the `:honeybadger_deploy_task` in your *config/deploy.rb* file:
 set :honeybadger_deploy_task, 'honeybadger:deploy_with_environment'
 ```
 
+You can run deploy notification task asynchronously. 
+Just add `:honeybadger_async_notify` in your *config/deploy.rb* file:
+
+```ruby
+set :honeybadger_async_notify, true
+````
+
 If you would prefer to notify Honeybadger locally without using rake,
 check out our blog post: [Honeybadger and Capistrano: the metal way](http://honeybadger.io/blog/2012/10/06/honeybadger-and-capistrano/).
+
 
 ### Heroku
 

--- a/lib/honeybadger/capistrano.rb
+++ b/lib/honeybadger/capistrano.rb
@@ -19,14 +19,14 @@ module Honeybadger
             rake_task = fetch(:honeybadger_deploy_task, 'honeybadger:deploy')
             local_user = ENV['USER'] || ENV['USERNAME']
             executable = RUBY_PLATFORM.downcase.include?('mswin') ? fetch(:rake, 'rake.bat') : fetch(:rake, 'rake')
-            assync_notify = fetch(:honeybadger_assync_notify, false)
+            async_notify = fetch(:honeybadger_async_notify, false)
             directory = configuration.current_release
             notify_command = "cd #{directory};"
-            notify_command << " nohup" if assync_notify
+            notify_command << " nohup" if async_notify
             notify_command << " #{executable} RAILS_ENV=#{rails_env} #{rake_task} TO=#{honeybadger_env} REVISION=#{current_revision} REPO=#{repository} USER=#{local_user}"
             notify_command << " DRY_RUN=true" if dry_run
             notify_command << " API_KEY=#{ENV['API_KEY']}" if ENV['API_KEY']
-            notify_command << " >> /dev/null 2>&1 &" if assync_notify
+            notify_command << " >> /dev/null 2>&1 &" if async_notify
             logger.info "Notifying Honeybadger of Deploy (#{notify_command})"
             if configuration.dry_run
               logger.info "DRY RUN: Notification not actually run."


### PR DESCRIPTION
Added ability to set `set :honeybadger_assync_notify, true` in deploy.rb and run rake honeybadger:deploy via nohup. 
