### PR TITLE
Honeybadger.notify returns false if it has not been configured. Fixes #25

### DIFF
--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -99,9 +99,10 @@ module Honeybadger
     #             :environment_name - The application environment name.
     #             :context          - Custom hash to send
     #
-    # Returns exception ID from Honeybadger on success, false on failure
+    # Returns exception ID from Honeybadger on success, false on failure or if
+    # the badger hasn't been configured yet.
     def notify(exception, options = {})
-      send_notice(build_notice_for(exception, options))
+      @configuration.nil? ? false : send_notice(build_notice_for(exception, options))
     end
 
     # Public: Sends the notice unless it is one of the default ignored exceptions

--- a/test/unit/notice_test.rb
+++ b/test/unit/notice_test.rb
@@ -22,6 +22,11 @@ class NoticeTest < Test::Unit::TestCase
                       :env         => { 'three' => 'four' } }.update(attrs))
   end
 
+  should "notify only when configured" do
+    Honeybadger.instance_variable_set(:@configuration, nil)
+    assert_equal false, Honeybadger.notify('example')
+  end
+
   should "deliver to sender" do
     sender = stub_sender!
     notice = build_notice


### PR DESCRIPTION
:boom::boom: :dragon:
