### PR TITLE
array.find(x) expects x to be a method not a value

### DIFF
--- a/lib/honeybadger/shared_tasks.rb
+++ b/lib/honeybadger/shared_tasks.rb
@@ -37,7 +37,7 @@ namespace :honeybadger do
       end
 
       heroku_rails_env = heroku_var('RAILS_ENV', ENV['APP'])
-      heroku_api_key = heroku_var('HONEYBADGER_API_KEY', ENV['APP']).split.find(Honeybadger.configuration.api_key) {|x| x =~ /\S/ }
+      heroku_api_key = heroku_var('HONEYBADGER_API_KEY', ENV['APP']).split.find(lambda { Honeybadger.configuration.api_key }) {|x| x =~ /\S/ }
 
       unless heroku_api_key =~ /\S/ && heroku_rails_env =~ /\S/
         puts "WARNING: We were unable to detect the configuration from your Heroku environment."


### PR DESCRIPTION
Josh, this is a fix for the problem reported in helpscout ticket 550. 

Please test before merging. I don't have time to right now. 
