### PR TITLE
Avoid unnecessary object allocations.

### DIFF
--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -129,9 +129,9 @@ module Honeybadger
       result
     end
 
-    def context(hash = {})
+    def context(hash = nil)
       Thread.current[:honeybadger_context] ||= {}
-      Thread.current[:honeybadger_context].merge!(hash)
+      Thread.current[:honeybadger_context].merge!(hash) unless hash.nil?
       self
     end
 


### PR DESCRIPTION
Unfortunately I couldn't get the honeybadger test suite to run, so I wouldn't merge this without verifying it doesn't break anything.  But the change itself is pretty innocuous.

Basically, if `context` is called without an argument, the hash shouldn't be created.  It's only used for a no-op `merge!` call, so it's really not needed.  Yet the object must be created and GC'd and the no-op method must be called.  Replacing it with a nil? check incurs negligible overhead in cases where an argument is supplied while reducing object churn.

As an example, this is currently called without an argument as part of the Rack middleware.  So every single request to an app ends up creating one of these hashes that it does nothing with.
