### PR TITLE
Support ruby 2.1 with Exception#cause

### DIFF
--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -178,15 +178,10 @@ module Honeybadger
     end
 
     def unwrap_exception(exception)
-      if exception.respond_to?(:original_exception)
-        exception.original_exception
-      elsif exception.respond_to?(:continued_exception)
-        exception.continued_exception
-      elsif exception.respond_to?(:cause)
-        exception.cause
-      else
-        exception
-      end
+      exception.respond_to?(:original_exception) && exception.original_exception ||
+      exception.respond_to?(:continued_exception) && exception.continued_exception ||
+      exception.respond_to?(:cause) && exception.cause ||
+      exception
     end
   end
 end


### PR DESCRIPTION
Ruby 2.1 supports preserving original exception when re-raising by providing `#cause` method.
