### PR TITLE
Moves ensure block to end of processing during rack middleware

### DIFF
--- a/lib/honeybadger/rack/error_notifier.rb
+++ b/lib/honeybadger/rack/error_notifier.rb
@@ -44,8 +44,6 @@ module Honeybadger
         rescue Exception => raised
           env['honeybadger.error_id'] = notify_honeybadger(raised, env)
           raise
-        ensure
-          Honeybadger.context.clear!
         end
 
         framework_exception = env['rack.exception'] || env['sinatra.error']
@@ -54,6 +52,8 @@ module Honeybadger
         end
 
         response
+      ensure
+        Honeybadger.context.clear!
       end
     end
   end


### PR DESCRIPTION
In sinatra based applications I have been missing the reported context. Moving the ensure block to the end of the call method seems to fix this.

I am unsure of how to test this in the rspec tests or I would have provided a demonstrable test. If you can provide guidance I'd be happy to update the pull request to include tests.
