### PR TITLE
Add delayed_job_attempt_threshold config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Honeybadger 1.16.5 ##
 
+* Add `delayed_job_attempt_threshold` configuration variable. Notifications will not be sent until this threshold is reached.
+
+  *Tadas Tamosauskas*
+
 * Ignore ActionController::UnknownFormat by default.
   
   *Sergey Rezvanov*

--- a/lib/honeybadger/configuration.rb
+++ b/lib/honeybadger/configuration.rb
@@ -10,7 +10,7 @@ module Honeybadger
                :user_information, :feedback, :rescue_rake_exceptions, :source_extract_radius,
                :send_request_session, :debug, :fingerprint, :hostname, :features, :metrics,
                :log_exception_on_send_failure, :send_local_variables, :traces,
-               :trace_threshold, :unwrap_exceptions].freeze
+               :trace_threshold, :unwrap_exceptions, :delayed_job_attempt_threshold].freeze
 
     # The API key for your project, found on the project edit form.
     attr_accessor :api_key
@@ -135,6 +135,9 @@ module Honeybadger
     # Which features the API says we have
     attr_accessor :features
 
+    # Do not notify unless Delayed Job attempts reaches or exceeds this value
+    attr_accessor :delayed_job_attempt_threshold
+
     DEFAULT_PARAMS_FILTERS = %w(password password_confirmation).freeze
 
     DEFAULT_BACKTRACE_FILTERS = [
@@ -201,6 +204,7 @@ module Honeybadger
       @feedback                      = true
       @trace_threshold               = 2000
       @unwrap_exceptions             = true
+      @delayed_job_attempt_threshold = 0
     end
 
     # Public: Takes a block and adds it to the list of backtrace filters. When

--- a/lib/honeybadger/integrations/delayed_job/plugin.rb
+++ b/lib/honeybadger/integrations/delayed_job/plugin.rb
@@ -24,7 +24,7 @@ module Honeybadger
                   :attempts      => job.attempts,
                   :queue         => job.queue
                 }
-              )
+              ) if job.attempts.to_i >= ::Honeybadger.configuration.delayed_job_attempt_threshold.to_i
               raise error
             ensure
               ::Honeybadger.context.clear!

--- a/spec/honeybadger/integrations/delayed_job_spec.rb
+++ b/spec/honeybadger/integrations/delayed_job_spec.rb
@@ -64,6 +64,19 @@ if DELAYED_JOB_INSTALLED
           Honeybadger.should_receive(:notify_or_ignore).once
         end
       end
+
+      context "and a threshold is set" do
+        let(:method_name) { :will_raise }
+
+        before { ::Honeybadger.configuration.delayed_job_attempt_threshold = 2 }
+        after { ::Honeybadger.configuration.delayed_job_attempt_threshold = 0 }
+
+        it "does not notify Honeybadger on first occurence" do
+          Honeybadger.should_not_receive(:notify_or_ignore)
+
+          worker.work_off
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This allows to set a threshold for Honeybadger notifications for Delayed Job.

Oftentimes it's useful to let DJ retry the jobs before polluting HB with notifications i.e. third party web services can time-out the first time, but succeed eventually. There is nothing a developer can do about it and it does not make sense to notify them unless it fails N consecutive times.

Let me know if the approach is correct and if I need to add anything to the documentation.
