### PR TITLE
Notify class and method name of failed Delayed::Job

### DIFF
--- a/lib/honeybadger/integrations/delayed_job/plugin.rb
+++ b/lib/honeybadger/integrations/delayed_job/plugin.rb
@@ -17,6 +17,8 @@ module Honeybadger
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
                 :backtrace     => error.backtrace,
+                :component     => job.payload_object.object.class,
+                :action        => job.payload_object.method_name,
                 :context       => {
                   :job_id        => job.id,
                   :handler       => job.handler,

--- a/lib/honeybadger/integrations/delayed_job/plugin.rb
+++ b/lib/honeybadger/integrations/delayed_job/plugin.rb
@@ -17,7 +17,7 @@ module Honeybadger
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
                 :backtrace     => error.backtrace,
-                  :context       => {
+                :context       => {
                   :job_id        => job.id,
                   :handler       => job.handler,
                   :last_error    => job.last_error,


### PR DESCRIPTION
For better error visibility of delayed_job failures, notifying an object class name as a component and a method name as an action. This will make delayed job errors from different class/methods reported separately on www.honeybadger.io. 

For instance, both `1.delay.+("")` and `"".delay.+(1)` raise `TypeError`, which will be reported separately as below.

## Current

`1.delay.+("")` and `"".delay.+(1)` 

![error__8497101_in_wantedly_-_honeybadger](https://cloud.githubusercontent.com/assets/43811/4501554/9e0369e8-4aae-11e4-9859-1a44abb96f28.png)


## With the change

`1.delay.+("")`

![error__8497061_in_wantedly_-_honeybadger](https://cloud.githubusercontent.com/assets/43811/4501515/cdb0b886-4aad-11e4-86d5-4c1174f3abd5.png)

`"".delay.+(1)`

![error__8497085_in_wantedly_-_honeybadger](https://cloud.githubusercontent.com/assets/43811/4501512/a6560ade-4aad-11e4-8477-473db8ef2fa3.png)


