### PR TITLE
Don’t freeze global instances of true and false

### DIFF
--- a/lib/honeybadger/monitor/trace.rb
+++ b/lib/honeybadger/monitor/trace.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 module Honeybadger
   module Monitor
     class Trace
-      UUIDS_ENABLED = SecureRandom.respond_to?(:uuid).freeze
+      UUIDS_ENABLED = SecureRandom.respond_to?(:uuid)
 
       attr_reader :id, :duration, :key
 


### PR DESCRIPTION
In Ruby, `true` and `false` are global singleton instances. Freezing
them may lead to unexpected behaviour in some projects.

This code may have been introduced because of the common practice of
freezing other constants (such as arrays). I see no benefit in
freezing `true` or `false` themselves here.

Our particular problem in our projects comes from the special casing
of frozen variables with Rails[1]. This in combination of the Honeybadger code
causes some of our test to fail.

Although it would be good to fix this behaviour in Rails too, since
I believe the freezing here wasn’t intentional and many others will
be using honeybadger with Rails it would be good to fix it here too.

Also see a similar problem our team has had in the past with the sass gem [2].

[1] https://github.com/rails/rails/blob/v4.0.4/actionpack/lib/action_controller/test_case.rb#L194-L195
[2] https://github.com/sass/sass/issues/1210