### PR TITLE
Track component and action for delayed jobs, also set context for all nested calls to notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
   *Panos Korros*
 
-All events ents logged within a delayed_job even those logged by Honeybadger.notify inherit the context of the delayed job and include the job_id, attempts, last_error and queue
-
-
 * All events logged within a delayed_job even those logged by Honeybadger.notify inherit the context of the delayed job and include the job_id, attempts, last_error and queue
 
   *Panos Korros*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+* Exceptions with the same type but caused within different delayed jobs are not grouped together. They have their component and action set so that the application class name and excecuted action is displayed in the UI.
+
+  *Panos Korros*
+
+All events ents logged within a delayed_job even those logged by Honeybadger.notify inherit the context of the delayed job and include the job_id, attempts, last_error and queue
+
+
+* All events logged within a delayed_job even those logged by Honeybadger.notify inherit the context of the delayed job and include the job_id, attempts, last_error and queue
+
+  *Panos Korros*
+
 * Detect ActionDispatch::TestProcess being included globally, fix issue locally,
   warn the user.
 

--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -12,7 +12,11 @@ module Honeybadger
                 block.call(job)
               end
             rescue Exception => error
+              component = job.payload_object.object.is_a?(Class) ? job.payload_object.object.name : job.payload_object.object.class.name rescue nil
+
               ::Honeybadger.notify_or_ignore(
+                :component     => component,
+                :action        => job.payload_object.method_name.to_s,
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
                 :backtrace     => error.backtrace,

--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -19,11 +19,17 @@ module Honeybadger
                 block.call(job)
               end
             rescue Exception => error
-              component = job.payload_object.object.is_a?(Class) ? job.payload_object.object.name : job.payload_object.object.class.name rescue nil
+              begin #buildin suport for Delayed::PerformableMethod
+                component = job.payload_object.object.is_a?(Class) ? job.payload_object.object.name : job.payload_object.object.class.name
+                action    = job.payload_object.method_name.to_s
+              rescue #fallback to support all other classes
+                component = job.payload_object.class.name
+                action    = 'perform'
+              end
 
               ::Honeybadger.notify_or_ignore(
                 :component     => component,
-                :action        => job.payload_object.method_name.to_s,
+                :action        => action,
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
                 :backtrace     => error.backtrace

--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -8,6 +8,13 @@ module Honeybadger
         callbacks do |lifecycle|
           lifecycle.around(:invoke_job) do |job, &block|
             begin
+              ::Honeybadger.context(
+                :job_id        => job.id,
+                :handler       => job.handler,
+                :last_error    => job.last_error,
+                :attempts      => job.attempts,
+                :queue         => job.queue
+              )
               ::Honeybadger::Trace.instrument("#{job.payload_object.class}#perform", {source: 'delayed_job', jid: job.id, class: job.payload_object.class.name}) do
                 block.call(job)
               end
@@ -19,14 +26,7 @@ module Honeybadger
                 :action        => job.payload_object.method_name.to_s,
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
-                :backtrace     => error.backtrace,
-                  :context       => {
-                  :job_id        => job.id,
-                  :handler       => job.handler,
-                  :last_error    => job.last_error,
-                  :attempts      => job.attempts,
-                  :queue         => job.queue
-                }
+                :backtrace     => error.backtrace
               ) if job.attempts.to_i >= ::Honeybadger::Agent.config[:'delayed_job.attempt_threshold'].to_i
               raise error
             ensure

--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -31,6 +31,8 @@ module Honeybadger
               end
             rescue Exception => error
               ::Honeybadger.notify_or_ignore(
+                :component     => component,
+                :action        => action,
                 :error_class   => error.class.name,
                 :error_message => "#{ error.class.name }: #{ error.message }",
                 :backtrace     => error.backtrace


### PR DESCRIPTION
In our project we use lots of delayed jobs and currently errors with the same exception type are all grouped together. This doesn't allow us to keep track of errors correctly because errors in one component are hidden between errors for other components.

This change sets the component and action correctly for methods called on objects or classes
For example:
''.delay.sub(1,100)
String.delay.new

also I set the context at the beginning of the method so that all nested calls to Honeybadger.notify inherit the delayed job context.