### PR TITLE
Fix for capistrano-rvm compatibility

### DIFF
--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -76,6 +76,7 @@ end
 namespace :load do
   task :defaults do
     set :bundle_bins, fetch(:bundle_bins, []).push('honeybadger')
+    set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
   end
 end
 


### PR DESCRIPTION
This fixes an issue where the `honeybadger deploy` command fails during deployment when you are using the [capistrano-rvm](https://github.com/capistrano/rvm) gem. The failure message is: `bash: bundle: command not found`.

After some digging I discovered that the capistrano-rvm gem has a list of commands to which it will automatically appends the appropriate rvm commands, just like capistrano-bundler.

It's not mentioned in their documentation, but you can see it used in the load:defaults task [here](https://github.com/capistrano/rvm/blob/master/lib/capistrano/tasks/rvm.rake).