### PR TITLE
Fix for capistrano-rbenv compatibility

### DIFF
--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -76,6 +76,7 @@ end
 namespace :load do
   task :defaults do
     set :bundle_bins, fetch(:bundle_bins, []).push('honeybadger')
+    set :rbenv_map_bins, fetch(:rbenv_map_bins, []).push('honeybadger')
     set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
   end
 end


### PR DESCRIPTION
Same issue as #112, but for [capistrano-rbenv](https://github.com/capistrano/rbenv).