### PR TITLE
Add support for honeybadger_user with Capistrano 2

### DIFF
--- a/vendor/capistrano-honeybadger/lib/honeybadger/capistrano/legacy.rb
+++ b/vendor/capistrano-honeybadger/lib/honeybadger/capistrano/legacy.rb
@@ -15,7 +15,7 @@ module Honeybadger
           task :deploy, :except => { :no_release => true } do
             rails_env = fetch(:rails_env, 'production')
             honeybadger_env = fetch(:honeybadger_env, fetch(:rails_env, 'production'))
-            local_user = ENV['USER'] || ENV['USERNAME']
+            local_user = fetch(:honeybadger_user, ENV['USER'] || ENV['USERNAME'])
             executable = fetch(:honeybadger, "#{fetch(:bundle_cmd, 'bundle')} exec honeybadger")
             async_notify = fetch(:honeybadger_async_notify, false)
             directory = fetch(:honeybadger_deploy_dir, configuration.current_release)


### PR DESCRIPTION
The `honeybadger_user` option is mentioned in the documentation, but the legacy support for Capistrano v2 did not use it. This commit updates the v2 deploy task to fetch `honeybadger_user` the same way the v3 task uses it.