### PR TITLE
Tiny readability refactors for a few complex methods

### DIFF
--- a/lib/honeybadger/agent/metrics_collection.rb
+++ b/lib/honeybadger/agent/metrics_collection.rb
@@ -23,14 +23,12 @@ module Honeybadger
       # in the array. If only a single value is provided in the array, that is
       # returned
       def percentile(threshold)
-        if (count > 1)
-          self.sort!
-          # strip off the top 100-threshold
-          threshold_index = (((100 - threshold).to_f / 100) * count).round
-          self[0..-threshold_index].last
-        else
-          self.first
-        end
+        return self.first unless count > 1
+
+        self.sort!
+        # strip off the top 100-threshold
+        threshold_index = (((100 - threshold).to_f / 100) * count).round
+        self[0..-threshold_index].last
       end
 
       # Calculates the mean squared error of values in the array

--- a/lib/honeybadger/trace.rb
+++ b/lib/honeybadger/trace.rb
@@ -32,18 +32,16 @@ module Honeybadger
     end
 
     def add_query(event)
-      if event.duration < 6
-        ce = clean_event(event)
-        return unless ce.render?
-        query = ce.to_s
-        if @fast_queries[query]
-          @fast_queries[query][:duration] += ce.event.duration
-          @fast_queries[query][:count] += 1
-        else
-          @fast_queries[query] = { :duration => ce.event.duration, :count => 1 }
-        end
+      return add(event) unless event.duration < 6
+
+      ce = clean_event(event)
+      return unless ce.render?
+      query = ce.to_s
+      if @fast_queries[query]
+        @fast_queries[query][:duration] += ce.event.duration
+        @fast_queries[query][:count] += 1
       else
-        add(event)
+        @fast_queries[query] = { :duration => ce.event.duration, :count => 1 }
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -29,8 +29,8 @@ module Helpers
   end
 
   def stub_notice!(*args, &block)
-     stub_notice(*args, &block).tap do |notice|
-       allow(Honeybadger::Notice).to receive(:new).and_return(notice)
+    stub_notice(*args, &block).tap do |notice|
+      allow(Honeybadger::Notice).to receive(:new).and_return(notice)
     end
   end
 end


### PR DESCRIPTION
While doing a bit of source diving I noticed a couple super minor readability improvements. Added guard clauses to reduce nesting in 3 methods. Also found one method with some extra leading whitespace.

I'm not sure if you even want pull requests of this nature, but figured I'd punt it over anyway.

Cheers!