### PR TITLE
Explicit config types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Use explicit types for config options when casting from ENV.
+
+  *Joshua Wood*
+
 * Add exceptions.unwrap to config.
 
   *Joshua Wood*

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -179,6 +179,7 @@ module Honeybadger
             say(tab_indent(hierarchy.size) << "#{key}:")
             indent = tab_indent(hierarchy.size+1)
             say(indent + "Description: #{Config::OPTIONS[dotted_key][:description]}")
+            say(indent + "Type: #{Config::OPTIONS[dotted_key].fetch(:type, String).name.split('::').last}")
             say(indent + "Default: #{Config::OPTIONS[dotted_key][:default].inspect}")
             say(indent + "Current: #{value.inspect}")
           end

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -25,8 +25,6 @@ module Honeybadger
 
     KEY_REPLACEMENT = Regexp.new('[^a-z\d_]', Regexp::IGNORECASE).freeze
 
-    DISALLOWED_KEYS = [:'config.path'].freeze
-
     DOTTED_KEY = Regexp.new('\A([^\.]+)\.(.+)\z').freeze
 
     NOT_BLANK = Regexp.new('\S').freeze
@@ -136,16 +134,16 @@ module Honeybadger
       end
     end
 
-    # Internal: Path to honeybadger.yml configuration file; this should be the root
-    # directory if no path was specified.
+    # Internal: Path to honeybadger.yml configuration file; this should be the
+    # root directory if no path was specified.
     #
     # Returns the Pathname configuration path.
     def config_path
-      locate_absolute_path(Array(self[:'config.path']).first, self[:root])
+      config_paths.first
     end
 
     def config_paths
-      Array(self[:'config.path']).map do |c|
+      Array(ENV['HONEYBADGER_CONFIG_PATH'] || get(:'config.path')).map do |c|
         locate_absolute_path(c, self[:root])
       end
     end

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -2,6 +2,8 @@ require 'socket'
 
 module Honeybadger
   class Config
+    class Boolean; end
+
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
                       'ActionController::InvalidAuthenticityToken',
@@ -17,195 +19,243 @@ module Honeybadger
     OPTIONS = {
       api_key: {
         description: 'The API key for your Honeybadger project.',
-        default: nil
+        default: nil,
+        type: String
       },
       env: {
         description: 'The current application\'s environment name.',
-        default: ENV['HONEYBADGER_ENV'] || ENV['RACK_ENV']
+        default: ENV['HONEYBADGER_ENV'] || ENV['RACK_ENV'],
+        type: String
       },
       report_data: {
         description: 'Enable/disable reporting of data. Defaults to true for non-development environments.',
-        default: nil
+        default: nil,
+        type: Boolean
       },
       root: {
         description: 'The project\'s absolute root path.',
-        default: Dir.pwd
+        default: Dir.pwd,
+        type: String
       },
       hostname: {
         description: 'The hostname of the current box.',
-        default: Socket.gethostname
+        default: Socket.gethostname,
+        type: String
       },
       backend: {
         description: 'An alternate backend to use for reporting data.',
-        default: nil
+        default: nil,
+        type: String
       },
       debug: {
         description: 'Forces metrics and traces to be reported every 10 seconds rather than 60.',
-        default: false
+        default: false,
+        type: Boolean
       },
       disabled: {
         description: 'Prevents Honeybadger from starting entirely.',
-        default: false
+        default: false,
+        type: Boolean
       },
       development_environments: {
         description: 'Environments which will not report data by default (use report_data to enable/disable explicitly).',
-        default: DEVELOPMENT_ENVIRONMENTS
+        default: DEVELOPMENT_ENVIRONMENTS,
+        type: Array
       },
       :'send_data_at_exit' => {
         description: 'Send remaining data when Ruby exits.',
-        default: true
+        default: true,
+        type: Boolean
       },
       plugins: {
         description: 'An optional list of plugins to load. Default is to load all plugins.',
-        default: nil
+        default: nil,
+        type: Array
       },
       :'plugins.skip' => {
         description: 'An optional list of plugins to skip.',
-        default: nil
+        default: nil,
+        type: Array
       },
       :'config.path' => {
         description: 'The path (absolute, or relative from config.root) to the project\'s YAML configuration file.',
-        default: ENV['HONEYBADGER_CONFIG_PATH'] || ['honeybadger.yml', 'config/honeybadger.yml']
+        default: ENV['HONEYBADGER_CONFIG_PATH'] || ['honeybadger.yml', 'config/honeybadger.yml'],
+        type: String
       },
       :'logging.path' => {
         description: 'The path (absolute, or relative from config.root) to the log file.',
-        default: nil
+        default: nil,
+        type: String
       },
       :'logging.level' => {
         description: 'The log level.',
-        default: 'INFO'
+        default: 'INFO',
+        type: String
       },
       :'logging.debug' => {
         description: 'Override debug logging.',
-        default: nil
+        default: nil,
+        type: Boolean
       },
       :'logging.tty_level' => {
         description: 'Level to log when attached to a terminal (anything < logging.level will always be ignored).',
-        default: 'DEBUG'
+        default: 'DEBUG',
+        type: String
       },
       :'connection.secure' => {
         description: 'Use SSL when sending data.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'connection.host' => {
         description: 'The host to use when sending data.',
-        default: 'api.honeybadger.io'.freeze
+        default: 'api.honeybadger.io'.freeze,
+        type: String
       },
       :'connection.port' => {
         description: 'The port to use when sending data.',
-        default: nil
+        default: nil,
+        type: Integer
       },
       :'connection.system_ssl_cert_chain' => {
         description: 'Use the system\'s SSL certificate chain (if available).',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'connection.http_open_timeout' => {
         description: 'The HTTP open timeout when connecting to the server.',
-        default: 2
+        default: 2,
+        type: Integer
       },
       :'connection.http_read_timeout' => {
         description: 'The HTTP read timeout when connecting to the server.',
-        default: 5
+        default: 5,
+        type: Integer
       },
       :'connection.proxy_host' => {
         description: 'The proxy host to use when sending data.',
-        default: nil
+        default: nil,
+        type: String
       },
       :'connection.proxy_port' => {
         description: 'The proxy port to use when sending data.',
-        default: nil
+        default: nil,
+        type: Integer
       },
       :'connection.proxy_user' => {
         description: 'The proxy user to use when sending data.',
-        default: nil
+        default: nil,
+        type: String
       },
       :'connection.proxy_pass' => {
         description: 'The proxy password to use when sending data.',
-        default: nil
+        default: nil,
+        type: String
       },
       :'request.filter_keys' => {
         description: 'A list of keys to filter when sending request data.',
-        default: ['password'.freeze, 'password_confirmation'.freeze].freeze
+        default: ['password'.freeze, 'password_confirmation'.freeze].freeze,
+        type: Array
       },
       :'request.disable_session' => {
         description: 'Prevent session from being sent with request data.',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'request.disable_params' => {
         description: 'Prevent params from being sent with request data.',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'request.disable_environment' => {
         description: 'Prevent Rack environment from being sent with request data.',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'request.disable_url' => {
         description: 'Prevent url from being sent with request data (Rack environment may still contain it in some cases).',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'user_informer.enabled' => {
         description: 'Enable the UserInformer middleware.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'user_informer.info' => {
         description: 'Replacement string for HTML comment in templates.',
-        default: 'Honeybadger Error {{error_id}}'.freeze
+        default: 'Honeybadger Error {{error_id}}'.freeze,
+        type: String
       },
       :'feedback.enabled' => {
         description: 'Enable the UserFeedback middleware.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'exceptions.enabled' => {
         description: 'Enable automatic reporting of exceptions.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'exceptions.ignore' => {
         description: 'A list of additional exceptions to ignore (includes default ignored exceptions).',
-        default: IGNORE_DEFAULT
+        default: IGNORE_DEFAULT,
+        type: Array
       },
       :'exceptions.ignore_only' => {
         description: 'A list of exceptions to ignore (overrides the default ignored exceptions).',
-        default: [].freeze
+        default: [].freeze,
+        type: Array
       },
       :'exceptions.ignored_user_agents' => {
         description: 'A list of user agents to ignore.',
-        default: [].freeze
+        default: [].freeze,
+        type: Array
       },
       :'exceptions.rescue_rake' => {
         description: 'Enable rescuing exceptions in rake tasks.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'exceptions.source_radius' => {
         description: 'The number of lines before and after the source when reporting snippets.',
-        default: 2
+        default: 2,
+        type: Integer
       },
       :'exceptions.local_variables' => {
         description: 'Enable sending local variables. Requires binding_of_caller to be loaded.',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'exceptions.unwrap' => {
         description: 'Reports #original_exception or #cause one level up from rescued exception when available.',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'metrics.enabled' => {
         description: 'Enable sending metrics.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'metrics.gc_profiler' => {
         description: 'Enable sending GC metrics (GC::Profiler must be enabled)',
-        default: false
+        default: false,
+        type: Boolean
       },
       :'traces.enabled' => {
         description: 'Enable sending traces.',
-        default: true
+        default: true,
+        type: Boolean
       },
       :'traces.threshold' => {
         description: 'The threshold in seconds to send traces.',
-        default: 2000
+        default: 2000,
+        type: Integer
       },
       :'delayed_job.attempt_threshold' => {
         description: 'The number of attempts before notifications will be sent.',
-        default: 0
+        default: 0,
+        type: Integer
       }
     }.freeze
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -16,6 +16,8 @@ module Honeybadger
 
     DEVELOPMENT_ENVIRONMENTS = ['development', 'test', 'cucumber'].map(&:freeze).freeze
 
+    DEFAULT_PATHS = ['honeybadger.yml', 'config/honeybadger.yml'].map(&:freeze).freeze
+
     OPTIONS = {
       api_key: {
         description: 'The API key for your Honeybadger project.',
@@ -79,7 +81,7 @@ module Honeybadger
       },
       :'config.path' => {
         description: 'The path (absolute, or relative from config.root) to the project\'s YAML configuration file.',
-        default: ENV['HONEYBADGER_CONFIG_PATH'] || ['honeybadger.yml', 'config/honeybadger.yml'],
+        default: DEFAULT_PATHS,
         type: String
       },
       :'logging.path' => {

--- a/lib/honeybadger/config/env.rb
+++ b/lib/honeybadger/config/env.rb
@@ -9,7 +9,6 @@ module Honeybadger
         env.each_pair do |k,v|
           next unless k.match(CONFIG_KEY)
           next unless config_key = CONFIG_MAPPING[$1] || $1.downcase.to_sym
-          next if DISALLOWED_KEYS.include?(config_key)
           self[config_key] = cast_value(v, OPTIONS[config_key][:type])
         end
       end

--- a/lib/honeybadger/config/yaml.rb
+++ b/lib/honeybadger/config/yaml.rb
@@ -5,6 +5,8 @@ require 'erb'
 module Honeybadger
   class Config
     class Yaml < ::Hash
+      DISALLOWED_KEYS = [:'config.path'].freeze
+
       def initialize(path, env = 'production')
         @path = path.kind_of?(Pathname) ? path : Pathname.new(path)
 

--- a/spec/unit/honeybadger/config/env_spec.rb
+++ b/spec/unit/honeybadger/config/env_spec.rb
@@ -3,7 +3,7 @@ require 'honeybadger/config'
 describe Honeybadger::Config::Env do
   before do
     ENV['HONEYBADGER_API_KEY'] = 'asdf'
-    ENV['HONEYBADGER_ENABLED'] = 'true'
+    ENV['HONEYBADGER_EXCEPTIONS_ENABLED'] = 'false'
     ENV['HONEYBADGER_ENV'] = 'production'
     ENV['HONEYBADGER_LOGGING_PATH'] = 'log/'
     ENV['HONEYBADGER_EXCEPTIONS_IGNORE'] = 'Foo, Bar, Baz'
@@ -12,8 +12,8 @@ describe Honeybadger::Config::Env do
   it { should be_a Hash }
 
   specify { expect(subject[:api_key]).to eq 'asdf' }
-  specify { expect(subject[:enabled]).to eq true }
   specify { expect(subject[:env]).to eq 'production' }
   specify { expect(subject[:'logging.path']).to eq 'log/' }
   specify { expect(subject[:'exceptions.ignore']).to eq ['Foo', 'Bar', 'Baz'] }
+  specify { expect(subject[:'exceptions.enabled']).to eq false }
 end

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -13,14 +13,14 @@ describe Honeybadger::Config do
   describe "#initialize" do
     context "with multiple forms of config" do
       it "overrides config with options" do
-        config = Honeybadger::Config.new(logger: NULL_LOGGER, enabled: false)
-        expect(config[:enabled]).to eq false
+        config = Honeybadger::Config.new(logger: NULL_LOGGER, disabled: true)
+        expect(config[:disabled]).to eq true
       end
 
       it "prefers ENV to options" do
-        ENV['HONEYBADGER_ENABLED'] = 'true'
-        config = Honeybadger::Config.new(logger: NULL_LOGGER, enabled: false)
-        expect(config[:enabled]).to eq true
+        ENV['HONEYBADGER_DISABLED'] = 'true'
+        config = Honeybadger::Config.new(logger: NULL_LOGGER, disabled: false)
+        expect(config[:disabled]).to eq true
       end
 
       it "prefers file to options" do
@@ -103,7 +103,7 @@ describe Honeybadger::Config do
   end
 
   describe "#get" do
-    let(:instance) { Honeybadger::Config.new({logger: NULL_LOGGER, enabled: false, debug: true}.merge!(opts)) }
+    let(:instance) { Honeybadger::Config.new({logger: NULL_LOGGER, disabled: true, debug: true}.merge!(opts)) }
     let(:opts) { {} }
 
     context "when a normal option doesn't exist" do
@@ -138,7 +138,7 @@ describe Honeybadger::Config do
   end
 
   describe "#ping" do
-    let(:instance) { Honeybadger::Config.new(logger: NULL_LOGGER, enabled: false, debug: true) }
+    let(:instance) { Honeybadger::Config.new(logger: NULL_LOGGER, disabled: true, debug: true) }
     let(:logger) { instance.logger }
     let(:body) { {'top' => 'foo'} }
 


### PR DESCRIPTION
Fix for #125.

* Adds explicit types for config options.
* Uses config types to cast values from ENV.
* Adds type documentation to `honeybadger config` command.