### PR TITLE
Update default ignore list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Update default ignored exceptions to include the latest Rails rescue
+  responses. (see issue #107)
+
+  *Joshua Wood*
+
 * Fix bug when processing source extract for action_view templates.
 
   *Joshua Wood*

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -4,12 +4,19 @@ module Honeybadger
   class Config
     class Boolean; end
 
-    IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
-                      'ActionController::RoutingError',
-                      'ActionController::InvalidAuthenticityToken',
-                      'ActionController::UnknownAction',
-                      'ActionController::UnknownFormat',
+    IGNORE_DEFAULT = ['ActionController::RoutingError',
                       'AbstractController::ActionNotFound',
+                      'ActionController::MethodNotAllowed',
+                      'ActionController::UnknownHttpMethod',
+                      'ActionController::NotImplemented',
+                      'ActionController::UnknownFormat',
+                      'ActionController::InvalidAuthenticityToken',
+                      'ActionController::InvalidCrossOriginRequest',
+                      'ActionDispatch::ParamsParser::ParseError',
+                      'ActionController::BadRequest',
+                      'ActionController::ParameterMissing',
+                      'ActiveRecord::RecordNotFound',
+                      'ActionController::UnknownAction',
                       'CGI::Session::CookieStore::TamperedWithCookie',
                       'Mongoid::Errors::DocumentNotFound',
                       'Sinatra::NotFound'].map(&:freeze).freeze


### PR DESCRIPTION
This references #107 and ignores the entire list of Rails' rescue
responses:

https://github.com/rails/rails/blob/116695b25890e2587923d4a237ce4107e3adb145/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb#L8-L20