### PR TITLE
Add sidekiq.attempt_threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Configure sidekiq.attempt_threshold to suppress notifications until retry
+  threshold is reached.
+
+  *Joshua Wood*
+
 * Prevent Sinatra from using the same middleware more than once and add
   sinatra.enabled setting (default true) to disable auto-initialization
   of Sinatra.

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -266,6 +266,11 @@ module Honeybadger
         default: 0,
         type: Integer
       },
+      :'sidekiq.attempt_threshold' => {
+        description: 'The number of attempts before notifications will be sent.',
+        default: 0,
+        type: Integer
+      },
       :'sinatra.enabled' => {
         description: 'Enable Sinatra auto-initialization.',
         default: true,


### PR DESCRIPTION
This is a port of #98 to 2.0. Sidekiq errors will not be sent to Honeybadger until they exceed `sidekiq.attempt_threshold` (default is `0`). Error notifications are always sent on the last job (when the retry limit is exceeded).