### PR TITLE
Fix deploy cmd exit code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Exit with 1 from deploy command when request fails but ignore the failures in
+  the capistrano task.
+
+  *Joshua Wood*
+
 * Support Resque natively.
 
   *Joshua Wood*

--- a/lib/honeybadger/backend/debug.rb
+++ b/lib/honeybadger/backend/debug.rb
@@ -8,6 +8,7 @@ module Honeybadger
     class Debug < Null
       def notify(feature, payload)
         logger.unknown("notifying debug backend of feature=#{feature}\n\t#{payload.to_json}")
+        return Response.new(ENV['DEBUG_BACKEND_STATUS'].to_i, nil) if ENV['DEBUG_BACKEND_STATUS']
         super
       end
     end

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -47,6 +47,7 @@ module Honeybadger
           say("Deploy notification for #{payload[:environment]} complete.", :green)
         else
           say("Deploy notification failed: #{response.code}", :red)
+          exit(1)
         end
       rescue => e
         say("An error occurred during deploy notification: #{e}\n\t#{e.backtrace.join("\n\t")}", :red)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -12,13 +12,24 @@ feature "Installing honeybadger via the cli" do
       end
     end
 
-    scenario "when the configuration file already exists" do
+    scenario "when the configuration file is valid" do
       before { config.write }
 
       it "outputs successful result" do
         assert_cmd('honeybadger deploy -e production')
         expect(all_output).to match /complete/i
         expect(all_output).to match /production/i
+      end
+    end
+
+    scenario "the request fails" do
+      before { config.write }
+      before { set_env('DEBUG_BACKEND_STATUS', '500') }
+
+      it "outputs successful result" do
+        expect(cmd('honeybadger deploy -e production')).to exit_with(1)
+        expect(all_output).not_to match /complete/i
+        expect(all_output).to match /500/i
       end
     end
   end

--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -35,7 +35,7 @@ namespace :honeybadger do
         end
 
         within release_path do
-          execute executable, options
+          execute executable, options, raise_on_non_zero_exit: false
         end
 
         info 'Honeybadger notification complete.'

--- a/vendor/capistrano-honeybadger/lib/honeybadger/capistrano/legacy.rb
+++ b/vendor/capistrano-honeybadger/lib/honeybadger/capistrano/legacy.rb
@@ -31,7 +31,7 @@ module Honeybadger
               logger.info 'DRY RUN: Notification not actually run.'
             else
               result = ''
-              run(notify_options, :once => true, :pty => false) { |ch, stream, data| result << data }
+              run("#{ notify_options }; true", :once => true, :pty => false) { |ch, stream, data| result << data }
             end
             logger.info 'Honeybadger Notification Complete.'
           end


### PR DESCRIPTION
This moves failure handling to Capistrano where we still ignore failures so that we don't kill the deployment when deploy notification times out.