### PR TITLE
Send the request body.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Send the request body.
+
+  *Joshua Wood*
+
 * Add events to instrumented traces (i.e. in background jobs).
 
   *Joshua Wood*

--- a/lib/honeybadger/rack/request_hash.rb
+++ b/lib/honeybadger/rack/request_hash.rb
@@ -10,9 +10,22 @@ module Honeybadger
         self[:action] = self[:params]['action']
         self[:session] = extract_session(request)
         self[:cgi_data] = extract_cgi_data(request)
+        self[:body] = extract_body(request)
       end
 
       private
+
+      def extract_body(request)
+        return unless request.body
+
+        begin
+          request.body.read
+        ensure
+          request.body.rewind
+        end
+      rescue => e
+        "Error: #{e.message}"
+      end
 
       def extract_url(request)
         request.env['honeybadger.request.url'] || request.url

--- a/lib/honeybadger/util/request_payload.rb
+++ b/lib/honeybadger/util/request_payload.rb
@@ -11,7 +11,8 @@ module Honeybadger
         action: nil,
         params: {}.freeze,
         session: {}.freeze,
-        cgi_data: {}.freeze
+        cgi_data: {}.freeze,
+        body: nil
       }.freeze
 
       # Internal: allowed keys.


### PR DESCRIPTION
This sends the full request body, however #140 will truncate the body string to 2048 bytes (along with everything else).