### PR TITLE
Filter HTTP_COOKIE in request cgi_data

### DIFF
--- a/lib/honeybadger/util/request_payload.rb
+++ b/lib/honeybadger/util/request_payload.rb
@@ -28,6 +28,9 @@ module Honeybadger
 
         payload[:session] = opts[:session][:data] if opts[:session] && opts[:session][:data]
         payload[:url] = sanitizer.filter_url(payload[:url]) if payload[:url]
+        if payload[:cgi_data]["HTTP_COOKIE"]
+          payload[:cgi_data]["HTTP_COOKIE"] = sanitizer.filter_cookies(payload[:cgi_data]["HTTP_COOKIE"])
+        end
 
         payload
       end

--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -53,6 +53,17 @@ module Honeybadger
         end
       end
 
+      def filter_cookies(request_cookies)
+        return request_cookies unless filters
+
+        parsed_cookies = CGI::Cookie.parse(request_cookies)
+        sanitized_cookies = sanitize(parsed_cookies)
+        sanitized_cookies.map do |k, v|
+          v = v.join(',') if v.is_a?(Array)
+          "#{k}=#{v}"
+        end.join("; ")
+      end
+
       def filter_url(url)
         return url unless filters
 

--- a/spec/unit/honeybadger/util/request_payload_spec.rb
+++ b/spec/unit/honeybadger/util/request_payload_spec.rb
@@ -5,6 +5,10 @@ class TestSanitizer
     data
   end
 
+  def filter_cookies(string)
+    string
+  end
+
   def filter_url(string)
     string
   end
@@ -49,6 +53,11 @@ describe Honeybadger::Util::RequestPayload do
     it "sanitizes the url key" do
       expect(sanitizer).to receive(:filter_url).with('foo/bar')
       described_class.build({ sanitizer: sanitizer, url: 'foo/bar' })
+    end
+
+    it "sanitizes the request cookies" do
+      expect(sanitizer).to receive(:filter_cookies).with('abc=hello')
+      described_class.build({ sanitizer: sanitizer, cgi_data: { "HTTP_COOKIE" => "abc=hello" } })
     end
 
     it "converts Hash to JSON" do

--- a/spec/unit/honeybadger/util/sanitizer_spec.rb
+++ b/spec/unit/honeybadger/util/sanitizer_spec.rb
@@ -141,6 +141,16 @@ describe Honeybadger::Util::Sanitizer do
     end
   end
 
+  describe '#filter_cookies' do
+    let!(:filters) { ["abc", :def, /private/] }
+
+    let!(:cookies) {"abc=123; def=456; ghi=789; private_param=prra"}
+    let(:filtered_cookies) {"abc=[FILTERED]; def=[FILTERED]; ghi=789; private_param=[FILTERED]"}
+    subject { described_class.new(filters: filters).filter_cookies(cookies) }
+
+    it { should eq filtered_cookies }
+  end
+
   def assert_serializes(*keys)
     [File.open(__FILE__), Proc.new { puts "boo!" }, Module.new].each do |object|
       hash = {


### PR DESCRIPTION
We noticed that honeybadger was not filtering values in HTTP_COOKIE that we had set in our `Rails.application.config.filter_parameters`. This led to them appearing in both the environment section and cookies section on Honeybadger.

This PR introduces a new `filter_cookies` to the `Util::Sanitizer` that is responsible for taking  a cookie string and sanitizing any sensitive values. We call this while building the request payload to ensure that sensitive values present in the HTTP_COOKIE are not sent to Honeybadger.
