### PR TITLE
Don't choke on non-Exception causes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Fix breakage relating to Exceptions containing a :cause attribute which is not
+  itself an Exception.
+
+  *Gabe da Silveira*
+
 * Allow API key to be overridden from `Honeybadger.notify`.
 
   *Joshua Wood*

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -423,11 +423,11 @@ module Honeybadger
     # Returns the Exception cause.
     def exception_cause(exception)
       e = exception
-      if e.respond_to?(:cause) && e.cause
+      if e.respond_to?(:cause) && e.cause && e.cause.is_a?(Exception)
         e.cause
-      elsif e.respond_to?(:original_exception) && e.original_exception
+      elsif e.respond_to?(:original_exception) && e.original_exception && e.original_exception.is_a?(Exception)
         e.original_exception
-      elsif e.respond_to?(:continued_exception) && e.continued_exception
+      elsif e.respond_to?(:continued_exception) && e.continued_exception && e.continued_exception.is_a?(Exception)
         e.continued_exception
       end
     end

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -841,6 +841,15 @@ describe Honeybadger::Notice do
           expect(causes.size).to eq 5
         end
       end
+
+      context "when raising #{error_class} with a non-exception cause" do
+        it "includes empty cause in payload" do
+          exception = error_class.new('badgers!')
+          exception.cause = "Some reason you werent expecting"
+          causes = build_notice(exception: exception).as_json[:error][:causes]
+          expect(causes.size).to eq 0
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The previous code blows up if it is passed an Exception object with
a :cause method that is not an Exception (or at least doesn't respond to
:message, :backtrace, etc).

I ran into this in the wild with the etcd-ruby gem:

https://github.com/ranjib/etcd-ruby/blob/master/lib/etcd/exceptions.rb

It was extremely painful to debug since the exception was intermittent and not reproducible in development, so at first I didn't think it had anything to do with Honeybadger.