### PR TITLE
Fix CALLER_FILE regex

### DIFF
--- a/lib/honeybadger/plugin.rb
+++ b/lib/honeybadger/plugin.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 
 module Honeybadger
   class Plugin
-    CALLER_FILE = Regexp.new('\A([^:]+)(?=(:\d+))').freeze
+    CALLER_FILE = Regexp.new('\A(?:\w:)?([^:]+)(?=(:\d+))').freeze
 
     class << self
       @@instances = {}


### PR DESCRIPTION
File paths on Windows often start with a drive letter in the form of `\w:`. This solves the exception on Windows where the gem isn't able to load plugins via call stack detection.