### PR TITLE
Fixed compatibility with capistrano-chruby

### DIFF
--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -76,6 +76,7 @@ end
 namespace :load do
   task :defaults do
     set :bundle_bins, fetch(:bundle_bins, []).push('honeybadger')
+    set :chruby_map_bins, fetch(:chruby_map_bins, []).push('honeybadger')
     set :rbenv_map_bins, fetch(:rbenv_map_bins, []).push('honeybadger')
     set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
   end


### PR DESCRIPTION
Added honeybadger to the list of binaries recognized by [capistrano-chruby](https://github.com/capistrano/chruby). Hopefully this will be the last ruby manager that needs to be added. :smiley: