### PR TITLE
Fix url sanitization for strings with regex special characters.

### DIFF
--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -76,7 +76,7 @@ module Honeybadger
         filtered_url = url.to_s.dup
         filtered_url.scan(/(?:^|&|\?)([^=?&]+)=([^&]+)/).each do |m|
           next unless filter_key?(m[0])
-          filtered_url.gsub!(/#{m[1]}/, FILTERED_REPLACEMENT)
+          filtered_url.gsub!(/#{Regexp.escape(m[1])}/, FILTERED_REPLACEMENT)
         end
 
         filtered_url


### PR DESCRIPTION
The url filtering mechanism can run into a string that has regex special characters which currently do not get escaped, which can wreck the replacement logic.

For example, a query parameter value that has a leading space gets URL-escaped to '+', which throws a Regex error because '+' is a special character that is not valid as the leading character in a regular expression.