### PR TITLE
Make TTY configurable for Rake reporting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Rails 5 support.
+- Support overriding TTY behavior in rake reporter.
 
 ## Fixed
 - Capistrano 3 `undefined method `verbosity'` bugfix.

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -223,7 +223,7 @@ module Honeybadger
       },
       :'exceptions.rescue_rake' => {
         description: 'Enable rescuing exceptions in rake tasks.',
-        default: true,
+        default: !STDOUT.tty?,
         type: Boolean
       },
       :'exceptions.source_radius' => {

--- a/lib/honeybadger/init/rake.rb
+++ b/lib/honeybadger/init/rake.rb
@@ -10,12 +10,10 @@ module Honeybadger
     end
 
     def display_error_message_with_honeybadger(ex)
-      if !self.tty_output?
-        Honeybadger.notify_or_ignore(ex, origin: :rake, component: reconstruct_command_line)
-        Honeybadger.context.clear!
-      end
-
+      Honeybadger.notify(ex, origin: :rake, component: reconstruct_command_line)
       display_error_message_without_honeybadger(ex)
+    ensure
+      Honeybadger.context.clear!
     end
 
     def reconstruct_command_line

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -227,7 +227,9 @@ module Honeybadger
     attr_reader :config, :opts, :context, :stats, :now, :pid, :causes, :sanitizer, :request_sanitizer
 
     def ignore_by_origin?
-      opts[:origin] == :rake && !config[:'exceptions.rescue_rake']
+      return false if opts[:origin] != :rake
+      return false if config[:'exceptions.rescue_rake']
+      true
     end
 
     def ignore_by_callbacks?

--- a/spec/features/rake_spec.rb
+++ b/spec/features/rake_spec.rb
@@ -15,16 +15,27 @@ feature "Rescuing exceptions in a rake task" do
         set_env('HONEYBADGER_EXCEPTIONS_RESCUE_RAKE', 'false')
       end
 
-      it "reports the exception to Honeybadger" do
+      it "doesn't report the exception to Honeybadger" do
         expect(cmd('rake honeybadger')).to exit_with(1)
         assert_no_notification
       end
     end
 
     context "shell is attached" do
-      it "reports the exception to Honeybadger" do
+      it "doesn't report the exception to Honeybadger" do
         expect(cmd('rake honeybadger_autodetect_from_terminal')).to exit_with(1)
         assert_no_notification
+      end
+
+      context "rake reporting is enabled" do
+        before do
+          set_env('HONEYBADGER_EXCEPTIONS_RESCUE_RAKE', 'true')
+        end
+
+        it "reports the exception to Honeybadger" do
+          expect(cmd('rake honeybadger_autodetect_from_terminal')).to exit_with(1)
+          assert_notification('error' => {'class' => 'RuntimeError', 'message' => 'RuntimeError: Jim has left the building :('})
+        end
       end
     end
   end

--- a/spec/fixtures/Rakefile
+++ b/spec/fixtures/Rakefile
@@ -6,23 +6,26 @@ require 'honeybadger'
 
 # Should catch exception
 task :honeybadger do
-  Honeybadger.start
   stub_tty_output(false)
+  Honeybadger.start
   raise_exception
 end
 
 # Should not catch exception as tty_output is true
 task :honeybadger_autodetect_from_terminal do
-  Honeybadger.start
   stub_tty_output(true)
+  Honeybadger.start
   raise_exception
 end
 
 def stub_tty_output(value)
-  Rake.application.instance_eval do
-    @tty_output_stub = value
-    def tty_output?
-      @tty_output_stub
+  if value
+    def STDOUT.tty?
+      true
+    end
+  else
+    def STDOUT.tty?
+      false
     end
   end
 end


### PR DESCRIPTION
I'm still pondering the implications of this change. Basically the idea is this:

- By default rake exceptions are enabled, but only when not attached to a terminal.
- Explicitly enabling rake exceptions means exceptions should be reported always.
- Explicitly disabling rake exceptions means exceptions should be reported never.