### PR TITLE
Be stricter when sanitizing objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+## Fixed
+- Be stricter when sanitizing recursive objects (allow only `Hash`, `Array`,
+  `Set`).  This fixes a bug where some gems (such as the dropbox gem)
+  monkeypatch `#to_hash` on `Array`.
 
 ## [2.3.1] - 2015-11-20
 ## Fixed

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -174,7 +174,7 @@ module Honeybadger
           token: id,
           class: s(error_class),
           message: s(error_message),
-          backtrace: s(backtrace),
+          backtrace: s(backtrace.to_a),
           source: s(source),
           fingerprint: s(fingerprint),
           tags: s(tags),
@@ -447,7 +447,7 @@ module Honeybadger
         c << {
           class: e.class.name,
           message: e.message,
-          backtrace: parse_backtrace(e.backtrace || caller)
+          backtrace: parse_backtrace(e.backtrace || caller).to_a
         }
         i += 1
       end

--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -3,8 +3,6 @@ require 'set'
 module Honeybadger
   module Util
     class Sanitizer
-      OBJECT_WHITELIST = [Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass]
-
       FILTERED_REPLACEMENT = '[FILTERED]'.freeze
 
       TRUNCATION_REPLACEMENT = '[TRUNCATED]'.freeze
@@ -32,9 +30,8 @@ module Honeybadger
           stack << data.object_id
         end
 
-        if data.kind_of?(String)
-          self.class.sanitize_string(data)
-        elsif data.respond_to?(:to_hash)
+        case data
+        when Hash
           return '[max depth reached]' if depth >= max_depth
           hash = data.to_hash
           new_hash = {}
@@ -47,14 +44,16 @@ module Honeybadger
             end
           end
           new_hash
-        elsif data.respond_to?(:to_ary)
+        when Array, Set
           return '[max depth reached]' if depth >= max_depth
-          data.to_ary.map do |value|
+          data.to_a.map do |value|
             sanitize(value, depth+1, stack)
           end.compact
-        elsif OBJECT_WHITELIST.any? {|c| data.kind_of?(c) }
+        when Numeric, TrueClass, FalseClass, NilClass
           data
-        else
+        when String
+          self.class.sanitize_string(data.to_s)
+        else # all other objects:
           self.class.sanitize_string(data.to_s)
         end
       end
@@ -120,7 +119,7 @@ module Honeybadger
       attr_reader :max_depth, :filters
 
       def recursive?(data)
-        data.respond_to?(:to_hash) || data.respond_to?(:to_ary)
+        data.kind_of?(Hash) || data.kind_of?(Array) || data.kind_of?(Set)
       end
 
       def filter_key?(key)

--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -24,7 +24,7 @@ module Honeybadger
       end
 
       def sanitize(data, depth = 0, stack = nil)
-        if recursive?(data)
+        if data.kind_of?(Hash) || data.kind_of?(Array) || data.kind_of?(Set)
           return '[possible infinite recursion halted]' if stack && stack.include?(data.object_id)
           stack = stack ? stack.dup : Set.new
           stack << data.object_id
@@ -117,10 +117,6 @@ module Honeybadger
       private
 
       attr_reader :max_depth, :filters
-
-      def recursive?(data)
-        data.kind_of?(Hash) || data.kind_of?(Array) || data.kind_of?(Set)
-      end
 
       def filter_key?(key)
         return false unless filters


### PR DESCRIPTION
This fixes a bug where some gems (such as the dropbox gem) monkeypatch `#to_hash` on `Array`.