### PR TITLE
Update Changelog URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ en:
 
 ## Changelog
 
-See https://github.com/honeybadger-io/honeybadger-ruby/releases
+See https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md
 
 ## Contributing
 


### PR DESCRIPTION
The current URL (GitHub releases page) is not very useful, because the GitHub releases feature isn't used - it only shows the tags and not what changed. `CHANGELOG.md` is a much more useful link.