### PR TITLE
Check that we respond to retry_criteria_valid?

### DIFF
--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -21,7 +21,7 @@ module Honeybadger
         end
 
         def send_exception?(e, args)
-          if defined?(::Resque::Plugins::Retry)
+          if respond_to?(:retry_criteria_valid?)
             begin
               if ::Honeybadger::Agent.config[:'resque.resque_retry.send_exceptions_when_retrying']
                 true

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -4,8 +4,6 @@ require 'honeybadger/agent'
 
 class TestWorker
   extend Honeybadger::Plugins::Resque::Extension
-  def self.retry_criteria_valid?(e)
-  end
 end
 
 describe TestWorker do
@@ -52,24 +50,33 @@ describe TestWorker do
   end
 
   describe "::around_perform_with_honeybadger" do
-    describe "without resque-retry installed" do
-      it_behaves_like "clears the context"
-      it_behaves_like "reports exceptions"
-      it_behaves_like "raises exceptions"
+    describe "with worker not extending Resque::Plugins::Retry" do
+      context "when send exceptions on retry enabled" do
+        before { ::Honeybadger::Agent.config[:'resque.resque_retry.send_exceptions_when_retrying'] = true }
+        it_behaves_like "clears the context"
+        it_behaves_like "reports exceptions"
+        it_behaves_like "raises exceptions"
+      end
+
+      context "when send exceptions on retry disabled" do
+        before { ::Honeybadger::Agent.config[:'resque.resque_retry.send_exceptions_when_retrying'] = false }
+        it_behaves_like "clears the context"
+        it_behaves_like "reports exceptions"
+        it_behaves_like "raises exceptions"
+      end
     end
 
-    describe "with resque-retry installed" do
+    describe "with worker extending Resque::Plugins::Retry" do
       let(:retry_criteria_valid) { false }
       before do
-        unless defined?(Resque)
-          Object.const_set(:Resque, Module.new).
-            tap {|c| c.const_set(:Plugins, Module.new).
-            tap {|c| c.const_set(:Retry, Module.new) } }
+        class TestWorker
+          extend Honeybadger::Plugins::Resque::Extension
+          def self.retry_criteria_valid?(e)
+          end
         end
         allow(described_class).to receive(:retry_criteria_valid?).
           and_return(retry_criteria_valid)
       end
-      after { Object.send(:remove_const, :Resque) }
 
       context "when send exceptions on retry enabled" do
         before { ::Honeybadger::Agent.config[:'resque.resque_retry.send_exceptions_when_retrying'] = true }
@@ -102,6 +109,19 @@ describe TestWorker do
           it_behaves_like "clears the context"
           it_behaves_like "does not report exceptions"
           it_behaves_like "raises exceptions"
+        end
+
+        context "and retry_criteria_valid? raises exception" do
+          before do
+            allow(described_class).to receive(:retry_criteria_valid?).and_raise(StandardError)
+          end
+
+          it "should report error to honeybadger" do
+            expect(Honeybadger).to receive(:notify).with(StandardError, hash_including(parameters: {job_arguments: [1, 2, 3]}))
+            expect {
+              described_class.around_perform_with_honeybadger(1, 2, 3)
+            }.to raise_error(StandardError)
+          end
         end
 
       end


### PR DESCRIPTION
Added specs covering resque-retry installed but not extended in worker class, cover exception thrown during retry_criteria_valid? call.

@joshuap This fixes an issue if the resque-retry gem was installed, a job not extending Resque::Plugins::Retry runs, and an exception is encountered, we tried to call retry_criteria_valid?, and it's not defined. Added specs over this, and the code added yesterday that wraps the whole thing in begin/rescue/end. 