### PR TITLE
Allow plugin names in config to be symbols or strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Fixed
+- Allow plugin names in config to be symbols or strings (#177).
 
 ## [2.5.1] - 2016-02-22
 ### Fixed

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -255,9 +255,9 @@ api_key: '#{self[:api_key]}'
     end
 
     def load_plugin?(name)
-      return false if Array(self[:'plugins.skip']).include?(name)
-      return true  if self[:plugins].nil?
-      Array(self[:plugins]).include?(name)
+      return false if includes_token?(self[:'plugins.skip'], name)
+      return true unless self[:plugins].kind_of?(Array)
+      includes_token?(self[:plugins], name)
     end
 
     def ping
@@ -307,6 +307,17 @@ api_key: '#{self[:api_key]}'
     end
 
     private
+
+    # Internal: Does collection include the String value or Symbol value?
+    #
+    # obj - The Array object, if present.
+    # value - The value which may exist within Array obj.
+    #
+    # Returns true or false.
+    def includes_token?(obj, value)
+      return false unless obj.kind_of?(Array)
+      obj.map(&:to_sym).include?(value.to_sym)
+    end
 
     def ping_payload
       {

--- a/spec/unit/honeybadger/plugin_spec.rb
+++ b/spec/unit/honeybadger/plugin_spec.rb
@@ -62,19 +62,19 @@ describe Honeybadger::Plugin do
 
   describe ".load!" do
     it "loads all satisfied instances" do
-      Honeybadger::Plugin.instances.replace({'one' => mock_plugin, 'two' => mock_plugin})
+      Honeybadger::Plugin.instances.replace({:one => mock_plugin, :two => mock_plugin})
       Honeybadger::Plugin.load!(config)
     end
 
     it "skips all unsatisfied instances" do
-      Honeybadger::Plugin.instances.replace({'one' => mock_plugin(false), 'two' => mock_plugin(false)})
+      Honeybadger::Plugin.instances.replace({:one => mock_plugin(false), :two => mock_plugin(false)})
       Honeybadger::Plugin.load!(config)
     end
 
     context "when skipped by configuration" do
       before do
-        config[:plugins] = ['two']
-        Honeybadger::Plugin.instances.replace({'one' => mock_plugin(true, false), 'two' => mock_plugin(true)})
+        config[:plugins] = ['two', :three]
+        Honeybadger::Plugin.instances.replace({:one => mock_plugin(true, false), :two => mock_plugin(true), :three => mock_plugin(true)})
       end
 
       it "skips instances" do


### PR DESCRIPTION
Fixes #177.