### PR TITLE
Automatically report unhandled exceptions at exit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Added
+- Automatically report unhandled exceptions at exit.
 
 ## [2.5.3] - 2016-03-10
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     addressable (2.3.6)
     allocation_stats (0.1.5)
-    appraisal (1.0.2)
+    appraisal (2.1.0)
       bundler
       rake
       thor (>= 0.14.0)
@@ -86,7 +86,7 @@ GEM
     pry-byebug (3.1.0)
       byebug (~> 4.0)
       pry (~> 0.10)
-    rake (10.3.2)
+    rake (11.1.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ You can use any of the options below in your config file, or in the environment.
 |`exceptions.ignore_only`         | Array   | A list of exception class names to ignore (overrides defaults).<br/>_Default: `[]`_|
 |`exceptions.` `ignored_user_agents` | Array   | A list of user agents to ignore.<br/>_Default: `[]`_|
 |`exceptions.rescue_rake`         | Boolean | Enable rescuing exceptions in rake tasks.<br/>_Default: `true` when run in background; `false` when run in terminal._|
+|`exceptions.notify_at_exit`      | Boolean | Report unhandled exception when Ruby crashes (at\_exit).<br/>_Default: `true`._|
 |`exceptions.source_radius`       | Integer | The number of lines before and after the source when reporting snippets.<br/>_Default: `2`_|
 |`exceptions.local_variables`     | Boolean | Enable sending local variables. Requires the [binding_of_caller gem](https://rubygems.org/gems/binding_of_caller).<br/>_Default: `false`_|
 |`exceptions.unwrap`              | Boolean | Reports #original_exception or #cause one level up from rescued exception when available.<br/>_Default: `false`_|

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - git submodule update
     # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/23
     - rvm @global do gem uninstall bundler -ax
-    - gem install bundler
+    - gem install bundler -v 1.10.6
     - gem install rubygems-bundler
   post:
     - bundle exec appraisal install

--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,19 @@ dependencies:
   pre:
     - git submodule init
     - git submodule update
-    # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/23
+
+    # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/32?u=eric
+    - gem -v
     - rvm @global do gem uninstall bundler -ax
-    - gem install bundler -v 1.10.6
+    - rvm install rubygems 2.4.8 --force
+    - gem -v
+
+    # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/23
+    - bundle -v
+    - rvm @global do gem uninstall bundler -ax
+    - gem install bundler -v 1.11.2
     - gem install rubygems-bundler
+    - bundle -v
   post:
     - bundle exec appraisal install
     - gem regenerate_binstubs

--- a/circle.yml
+++ b/circle.yml
@@ -7,17 +7,13 @@ dependencies:
     - git submodule update
 
     # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/32?u=eric
-    - gem -v
     - rvm @global do gem uninstall bundler -ax
     - rvm install rubygems 2.4.8 --force
-    - gem -v
 
     # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/23
-    - bundle -v
     - rvm @global do gem uninstall bundler -ax
     - gem install bundler -v 1.11.2
     - gem install rubygems-bundler
-    - bundle -v
   post:
     - bundle exec appraisal install
     - gem regenerate_binstubs

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,13 @@ dependencies:
   pre:
     - git submodule init
     - git submodule update
+    # https://discuss.circleci.com/t/bundler-fails-to-find-appropriate-version-despite-installing-appropriate-version-earlier-in-the-build/2815/23
+    - rvm @global do gem uninstall bundler -ax
     - gem install bundler
+    - gem install rubygems-bundler
   post:
     - bundle exec appraisal install
+    - gem regenerate_binstubs
 test:
   override:
     - bundle exec appraisal rspec

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,6 @@ dependencies:
     - git submodule update
     - gem install bundler
   post:
-    - gem install bundler --install-dir=/home/ubuntu/honeybadger-ruby/vendor/bundle/ruby/2.2.0
     - bundle exec appraisal install
 test:
   override:

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -154,6 +154,7 @@ module Honeybadger
           exit_status = $!.status if $!.is_a?(SystemExit)
         end
 
+        notify_at_exit($!)
         stop if config[:'send_data_at_exit']
         self.class.at_exit.call if self.class.at_exit
 
@@ -341,6 +342,14 @@ module Honeybadger
         push(:traces, traces) unless traces.empty?
         init_traces
       end
+    end
+
+    def notify_at_exit(ex)
+      return unless ex
+      return unless config[:'exceptions.notify_at_exit']
+      return if ex.is_a?(SystemExit)
+
+      notice(exception: ex, component: 'at_exit')
     end
   end
 end

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -227,8 +227,13 @@ module Honeybadger
         type: Array
       },
       :'exceptions.rescue_rake' => {
-        description: 'Enable rescuing exceptions in rake tasks.',
+        description: 'Enable reporting exceptions in rake tasks.',
         default: !STDOUT.tty?,
+        type: Boolean
+      },
+      :'exceptions.notify_at_exit' => {
+        description: 'Report unhandled exception when Ruby crashes (at_exit).',
+        default: true,
         type: Boolean
       },
       :'exceptions.source_radius' => {

--- a/spec/features/at_exit_spec.rb
+++ b/spec/features/at_exit_spec.rb
@@ -1,0 +1,24 @@
+feature "Rescuing exceptions at exit" do
+  let(:crash_cmd) { "ruby #{ FIXTURES_PATH.join('ruby_crash.rb') }" }
+
+  before do
+    set_env('HONEYBADGER_API_KEY', 'asdf')
+    set_env('HONEYBADGER_LOGGING_LEVEL', 'DEBUG')
+  end
+
+  it "reports the exception to Honeybadger" do
+    expect(cmd(crash_cmd)).to exit_with(1)
+    assert_notification('error' => {'class' => 'RuntimeError', 'message' => 'RuntimeError: badgers!'})
+  end
+
+  context "rake reporting is disabled" do
+    before do
+      set_env('HONEYBADGER_EXCEPTIONS_NOTIFY_AT_EXIT', 'false')
+    end
+
+    it "doesn't report the exception to Honeybadger" do
+      expect(cmd(crash_cmd)).to exit_with(1)
+      assert_no_notification
+    end
+  end
+end

--- a/spec/fixtures/ruby_crash.rb
+++ b/spec/fixtures/ruby_crash.rb
@@ -1,0 +1,3 @@
+require 'honeybadger'
+Honeybadger.start
+raise 'badgers!'


### PR DESCRIPTION
This causes exceptions in Rails runner code as well as any exception
which crashes a Ruby program to be automatically reported to
Honeybadger, as discussed in #150.