### PR TITLE
Rescue OpenSSL exceptions in backend calls

### DIFF
--- a/lib/honeybadger/backend/server.rb
+++ b/lib/honeybadger/backend/server.rb
@@ -25,6 +25,7 @@ module Honeybadger
                      Net::HTTPHeaderSyntaxError,
                      Net::ProtocolError,
                      Errno::ECONNREFUSED,
+                     OpenSSL::SSL::SSLError,
                      SocketError].freeze
 
       def initialize(config)


### PR DESCRIPTION
We were performing some routine "lets change the time of the server and prod our app" in our integration environment and hit a bit of a blocker booting our app.

I'd expect the honeybadger gem to ignore the SSL errors resulting from the invalid SSL certificate, but we were seeing the following exception raised HB tried to ping the backend, crashing the app.

    /opt/rubies/2.1.8/lib/ruby/2.1.0/net/http.rb:923:in `connect': SSL_connect returned=1 errno=0 state=error: certificate verify failed (OpenSSL::SSL::SSLError)

Obviously this is suboptimal - this PR simply adds this exception class to the set of exceptions rescued and ignored.