### PR TITLE
add method to get current context

### DIFF
--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -171,6 +171,20 @@ module Honeybadger
     self
   end
 
+
+  # Public: Get global context for the current request.
+  #
+  #
+  # Examples:
+  #
+  #   Honeybadger.context({my_data: 'my value'})
+  #   Honeybadger.get_context #now returns {my_data: 'my value'}
+  #
+  # Returns hash or nil.
+  def get_context
+    Thread.current[:__honeybadger_context]
+  end
+
   # Internal: Clears the global context
   def clear!
     Thread.current[:__honeybadger_context] = nil

--- a/spec/unit/honeybadger_spec.rb
+++ b/spec/unit/honeybadger_spec.rb
@@ -58,6 +58,10 @@ describe Honeybadger do
       expect(Thread.current[:__honeybadger_context]).to eq({foo: :bar, bar: :baz})
     end
 
+    it "gets current context" do
+      expect(described_class.get_context).to eq(c)
+    end
+
     it "clears the context" do
       expect { described_class.context.clear! }.to change { Thread.current[:__honeybadger_context] }.from(c).to(nil)
     end


### PR DESCRIPTION
There is a method for adding to the current context `Honeybadger.context(hash)` but I didn't see a public method for getting the current_context.  In the interest of being symmetrical I've added get_context.

My personal use case for this is that the context is not only a great thing to have for Honeybadger errors, but I wanted something like that to add context unobtrusively for other types of logs.  Loggly for example.  

Honeybadger already has vendor support for rack and Sidekiq middleware for clearing the context for each new request / job, and what's fair context for Honeybadger might as well be context for my Loggly logging as well, so why not just log what I want into Loggly merged on top of the current Honeybadger context: `Honeybadger.get_context`
