### PR TITLE
Don't sleep in ensure.

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -300,12 +300,12 @@ module Honeybadger
     def work
       flush_metrics if metrics.flush?
       flush_traces if traces.flush?
+      sleep(delay)
     rescue StandardError => e
       error {
         msg = "error in agent thread class=%s message=%s\n\t%s"
         sprintf(msg, e.class, e.message.dump, Array(e.backtrace).join("\n\t"))
       }
-    ensure
       sleep(delay)
     end
 


### PR DESCRIPTION
This should fix #186. I'm planning to do a larger threading overhaul to address our usage of `Thread.kill` in the future.