### PR TITLE
Allow custom ca bundle path for secure connections

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -162,6 +162,8 @@ module Honeybadger
     def ca_bundle_path
       if self[:'connection.system_ssl_cert_chain'] && File.exist?(OpenSSL::X509::DEFAULT_CERT_FILE)
         OpenSSL::X509::DEFAULT_CERT_FILE
+      elsif self[:'connection.ssl_ca_bundle_path']
+        self[:'connection.ssl_ca_bundle_path']
       else
         local_cert_path
       end

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -136,6 +136,11 @@ module Honeybadger
         default: false,
         type: Boolean
       },
+      :'connection.ssl_ca_bundle_path' => {
+        description: 'Use this ca bundle when establishing secure connections.',
+        default: nil,
+        type: String
+      },
       :'connection.http_open_timeout' => {
         description: 'The HTTP open timeout when connecting to the server.',
         default: 2,

--- a/spec/unit/honeybadger/util/http_spec.rb
+++ b/spec/unit/honeybadger/util/http_spec.rb
@@ -144,6 +144,14 @@ describe Honeybadger::Util::HTTP do
       expect(http.ca_file).to eq OpenSSL::X509::DEFAULT_CERT_FILE
     end
 
+    it "uses a custom ca bundle if asked to" do
+      config[:'connection.ssl_ca_bundle_path'] = '/test/blargh.crt'
+
+      http = subject.send(:setup_http_connection)
+      expect(http.ca_file).not_to eq config.local_cert_path
+      expect(http.ca_file).to eq '/test/blargh.crt'
+    end
+
     it "uses the default cert (OpenSSL::X509::DEFAULT_CERT_FILE) only if explicitly told to" do
       allow(File).to receive(:exist?).with(OpenSSL::X509::DEFAULT_CERT_FILE).and_return(true)
       http = subject.send(:setup_http_connection)


### PR DESCRIPTION
Under JRuby, `OpenSSL::X509::DEFAULT_CERT_FILE` returns a path to the java keystore, which is not in the PEM format [required by Net::HTTP#ca_file](http://www.rubydoc.info/stdlib/net/Net/HTTP#ca_file-instance_method). This effectively renders the `:'connection.system_ssl_cert_chain'` option a noop under JRuby.

To work around this issue, I've added the `:'connection.ssl_ca_bundle_path'` option.