### PR TITLE
Fixes crash on unicorn start

### DIFF
--- a/lib/honeybadger/backend/server.rb
+++ b/lib/honeybadger/backend/server.rb
@@ -20,11 +20,12 @@ module Honeybadger
       HTTP_ERRORS = [Timeout::Error,
                      Errno::EINVAL,
                      Errno::ECONNRESET,
+                     Errno::ECONNREFUSED,
+                     Errno::ENETUNREACH,
                      EOFError,
                      Net::HTTPBadResponse,
                      Net::HTTPHeaderSyntaxError,
                      Net::ProtocolError,
-                     Errno::ECONNREFUSED,
                      OpenSSL::SSL::SSLError,
                      SocketError].freeze
 


### PR DESCRIPTION
This fix prevents unicorn crash when ipv4 interface is absent.

During initialization process honeybadger does ping request and unicorn crashes due to `Errno::ENETUNREACH` exception isn't handled in `Server` backend

`Network is unreachable - connect(2) for "api.honeybadger.io" port 443`