### PR TITLE
remove headers from trace metadata for controller events

### DIFF
--- a/lib/honeybadger/trace.rb
+++ b/lib/honeybadger/trace.rb
@@ -205,7 +205,7 @@ module Honeybadger
 
     class ActionController < Base
       def payload
-        event.payload.reject {|k, v| k == :params }
+        event.payload.reject {|k, v| k == :params || k == :headers }
       end
 
       def to_s


### PR DESCRIPTION
Rails 5 adds a new attribute to the event payload for controller events.
This is the `headers` attribute, an instance of `ActionDispatch::Http::Headers`.

The honeybadger gem doesn't use the `headers` attribute. This commit
prevents it from being added to the payload sent to honeybager's API.

The reason we have to remove the `headers` attribute is because it
doesn't just contain HTTP headers. It contains a bunch of internal rails
objects, including an instance of the rails logger. The result of this
is that `headers.to_json` causes an IOError, as the JSON library
attempts to read from the logger's copy of STDOUT.