### PR TITLE
Fix capistrano warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Handle `Errno::ENETUNREACH` error when contacting server. -@tank-bohr
 - Remove `ActionDispatch::Http::Headers` from trace payload (fixes `IOError`
   when JSON encoding traces in Rails 5).
+- Fix "`invoke("git:set_current_revision")` already invoked" warning in
+  Capistrano 3.6.
 
 ## [2.6.0] - 2016-04-22
 ### Added

--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -71,7 +71,7 @@ end
 
 namespace :deploy do
   task :set_current_revision do
-    # noop -- we just want to make sure this task exists priror to Capistrano
+    # noop -- we just want to make sure this task exists prior to Capistrano
     # 3.2, since we depend on it.
   end
 end

--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -69,6 +69,13 @@ namespace :honeybadger do
   end
 end
 
+namespace :deploy do
+  task :set_current_revision do
+    # noop -- we just want to make sure this task exists priror to Capistrano
+    # 3.2, since we depend on it.
+  end
+end
+
 namespace :load do
   task :defaults do
     set :bundle_bins, fetch(:bundle_bins, []).push('honeybadger')

--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -4,10 +4,9 @@ namespace :honeybadger do
   end
 
   desc 'Notify Honeybadger of the deployment.'
-  task :deploy => :env do
+  task :deploy => [:env, :'deploy:set_current_revision'] do
     next if sshkit_outdated?
     if server = fetch(:honeybadger_server)
-      invoke "#{scm}:set_current_revision"
       revision = fetch(:current_revision)
 
       on server do |host|


### PR DESCRIPTION
This fixes the following warning, introduced in Capistrano 3.6:

```
 Skipping task `git:set_current_revision'.
Capistrano tasks may only be invoked once. Since task
`git:set_current_revision' was previously invoked,
invoke("git:set_current_revision") at

home/user/.rvm/gems/ruby-2.3.1@project/gems/honeybadger-2.6.0/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap:10
will be skipped.
If you really meant to run this task again, first call
Rake::Task["git:set_current_revision"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join
the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
```

Prior to Capistrano 3.2 it will be up to the user to ensure that the
`:current_revision` option is populated before executing the
`honeybadger:deploy` task (I think this should normally be the case when
deploying).