### PR TITLE
Consolidate require statements.

### DIFF
--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -1,4 +1,3 @@
-require 'forwardable'
 require 'honeybadger/const'
 
 module Honeybadger

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -1,10 +1,3 @@
-require 'forwardable'
-
-require 'honeybadger/version'
-require 'honeybadger/config'
-require 'honeybadger/notice'
-require 'honeybadger/plugin'
-require 'honeybadger/logging'
 module Honeybadger
   # Internal: A broker for the configuration and the workers.
   class Agent

--- a/lib/honeybadger/agent/batch.rb
+++ b/lib/honeybadger/agent/batch.rb
@@ -1,5 +1,3 @@
-require 'securerandom'
-
 module Honeybadger
   class Agent
     class Batch

--- a/lib/honeybadger/agent/worker.rb
+++ b/lib/honeybadger/agent/worker.rb
@@ -1,7 +1,3 @@
-require 'forwardable'
-require 'net/http'
-
-require 'honeybadger/logging'
 require 'honeybadger/agent/null_worker'
 
 module Honeybadger

--- a/lib/honeybadger/backend.rb
+++ b/lib/honeybadger/backend.rb
@@ -1,4 +1,4 @@
-require 'forwardable'
+require 'honeybadger/backend/base'
 
 module Honeybadger
   module Backend
@@ -17,7 +17,6 @@ module Honeybadger
       mapping[backend] or raise(BackendError, "Unable to locate backend: #{backend}")
     end
 
-    autoload :Base, 'honeybadger/backend/base'
     autoload :Server, 'honeybadger/backend/server'
     autoload :Test, 'honeybadger/backend/test'
     autoload :Null, 'honeybadger/backend/null'

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -1,9 +1,3 @@
-require 'forwardable'
-require 'net/http'
-require 'json'
-
-require 'honeybadger/logging'
-
 module Honeybadger
   module Backend
     class Response

--- a/lib/honeybadger/backend/debug.rb
+++ b/lib/honeybadger/backend/debug.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/backend/null'
-
 module Honeybadger
   module Backend
     # Internal: Logs the notice payload rather than sending it. The purpose of

--- a/lib/honeybadger/backend/null.rb
+++ b/lib/honeybadger/backend/null.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/backend/base'
-
 module Honeybadger
   module Backend
     class Null < Base

--- a/lib/honeybadger/backend/server.rb
+++ b/lib/honeybadger/backend/server.rb
@@ -1,11 +1,3 @@
-require 'net/http'
-require 'json'
-require 'zlib'
-require 'openssl'
-
-require 'honeybadger/backend/base'
-require 'honeybadger/util/http'
-
 module Honeybadger
   module Backend
     class Server < Base

--- a/lib/honeybadger/backend/test.rb
+++ b/lib/honeybadger/backend/test.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/backend/null'
-
 module Honeybadger
   module Backend
     class Test < Null

--- a/lib/honeybadger/backtrace.rb
+++ b/lib/honeybadger/backtrace.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Honeybadger
   # Internal: Front end to parsing the backtrace for each notice
   class Backtrace

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -1,16 +1,4 @@
-require 'pathname'
-require 'delegate'
-require 'logger'
-require 'fileutils'
-require 'openssl'
-
-require 'honeybadger/version'
-require 'honeybadger/logging'
-require 'honeybadger/backend'
 require 'honeybadger/config/defaults'
-require 'honeybadger/util/http'
-require 'honeybadger/logging'
-require 'honeybadger/rack/request_hash'
 
 module Honeybadger
   class Config

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -1,5 +1,3 @@
-require 'socket'
-
 module Honeybadger
   class Config
     class Boolean; end

--- a/lib/honeybadger/config/yaml.rb
+++ b/lib/honeybadger/config/yaml.rb
@@ -1,7 +1,3 @@
-require 'pathname'
-require 'yaml'
-require 'erb'
-
 module Honeybadger
   class Config
     class Yaml < ::Hash

--- a/lib/honeybadger/const.rb
+++ b/lib/honeybadger/const.rb
@@ -1,3 +1,20 @@
+require 'delegate'
+require 'erb'
+require 'fileutils'
+require 'forwardable'
+require 'json'
+require 'logger'
+require 'net/http'
+require 'openssl'
+require 'pathname'
+require 'securerandom'
+require 'set'
+require 'singleton'
+require 'socket'
+require 'uri'
+require 'yaml'
+require 'zlib'
+
 require 'honeybadger/version'
 
 module Honeybadger
@@ -14,11 +31,12 @@ module Honeybadger
     autoload :UserFeedback, 'honeybadger/rack/user_feedback'
     autoload :UserInformer, 'honeybadger/rack/user_informer'
     autoload :RequestHash, 'honeybadger/rack/request_hash'
+    autoload :MetricsReporter, 'honeybadger/rack/metrics_reporter'
   end
 
   module Util
     autoload :Sanitizer, 'honeybadger/util/sanitizer'
-    autoload :RequestSanitizer, 'honeybadger/util/request_sanitizer'
+    autoload :RequestPayload, 'honeybadger/util/request_payload'
     autoload :Stats, 'honeybadger/util/stats'
     autoload :HTTP, 'honeybadger/util/http'
   end

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -1,11 +1,4 @@
 require 'rails'
-require 'yaml'
-
-require 'honeybadger/util/sanitizer'
-require 'honeybadger/util/request_payload'
-require 'honeybadger/rack/error_notifier'
-require 'honeybadger/rack/user_informer'
-require 'honeybadger/rack/user_feedback'
 
 module Honeybadger
   module Init

--- a/lib/honeybadger/logging.rb
+++ b/lib/honeybadger/logging.rb
@@ -1,7 +1,3 @@
-require 'logger'
-require 'singleton'
-require 'delegate'
-
 module Honeybadger
   module Logging
     PREFIX = '** [Honeybadger] '.freeze

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -1,13 +1,3 @@
-require 'json'
-require 'securerandom'
-require 'forwardable'
-
-require 'honeybadger/version'
-require 'honeybadger/backtrace'
-require 'honeybadger/util/stats'
-require 'honeybadger/util/sanitizer'
-require 'honeybadger/util/request_payload'
-
 module Honeybadger
   NOTIFIER = {
     name: 'honeybadger-ruby'.freeze,

--- a/lib/honeybadger/plugin.rb
+++ b/lib/honeybadger/plugin.rb
@@ -1,5 +1,3 @@
-require 'forwardable'
-
 module Honeybadger
   class Plugin
     CALLER_FILE = Regexp.new('\A(?:\w:)?([^:]+)(?=(:\d+))').freeze

--- a/lib/honeybadger/plugins/delayed_job.rb
+++ b/lib/honeybadger/plugins/delayed_job.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/plugin'
-
 module Honeybadger
   Plugin.register do
     requirement { defined?(::Delayed::Plugin) }

--- a/lib/honeybadger/plugins/delayed_job/plugin.rb
+++ b/lib/honeybadger/plugins/delayed_job/plugin.rb
@@ -1,5 +1,4 @@
 require 'delayed_job'
-require 'honeybadger'
 
 module Honeybadger
   module Plugins

--- a/lib/honeybadger/plugins/local_variables.rb
+++ b/lib/honeybadger/plugins/local_variables.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger/backtrace'
-
 module Honeybadger
   module Plugins
     module LocalVariables

--- a/lib/honeybadger/plugins/passenger.rb
+++ b/lib/honeybadger/plugins/passenger.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger/agent'
-
 module Honeybadger
   module Plugins
     module Passenger

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/plugin'
-
 module Honeybadger
   module Plugins
     module Rails

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger'
-
 module Honeybadger
   module Plugins
     module Resque

--- a/lib/honeybadger/plugins/shoryuken.rb
+++ b/lib/honeybadger/plugins/shoryuken.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger'
-
 module Honeybadger
   module Plugins
     module Shoryuken

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger'
-
 module Honeybadger
   module Plugins
     module Sidekiq

--- a/lib/honeybadger/plugins/sucker_punch.rb
+++ b/lib/honeybadger/plugins/sucker_punch.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/plugin'
-
 module Honeybadger
   Plugin.register do
     requirement { defined?(::SuckerPunch) }

--- a/lib/honeybadger/plugins/thor.rb
+++ b/lib/honeybadger/plugins/thor.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger'
-
 module Honeybadger
   module Plugins
     module Thor

--- a/lib/honeybadger/plugins/unicorn.rb
+++ b/lib/honeybadger/plugins/unicorn.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger/agent'
-
 module Honeybadger
   module Plugins
     module Unicorn

--- a/lib/honeybadger/plugins/warden.rb
+++ b/lib/honeybadger/plugins/warden.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/plugin'
-
 module Honeybadger
   Plugin.register do
     requirement { defined?(::Warden::Manager.after_set_user) }

--- a/lib/honeybadger/rack/error_notifier.rb
+++ b/lib/honeybadger/rack/error_notifier.rb
@@ -1,6 +1,4 @@
 require 'rack/request'
-require 'honeybadger'
-require 'forwardable'
 
 module Honeybadger
   module Rack

--- a/lib/honeybadger/rack/metrics_reporter.rb
+++ b/lib/honeybadger/rack/metrics_reporter.rb
@@ -1,5 +1,3 @@
-require 'honeybadger'
-
 module Honeybadger
   module Rack
     class MetricsReporter

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -1,7 +1,3 @@
-require 'erb'
-require 'uri'
-require 'forwardable'
-
 begin
   require 'i18n'
 rescue LoadError

--- a/lib/honeybadger/rack/user_informer.rb
+++ b/lib/honeybadger/rack/user_informer.rb
@@ -1,5 +1,3 @@
-require 'forwardable'
-
 module Honeybadger
   module Rack
     class UserInformer

--- a/lib/honeybadger/util/http.rb
+++ b/lib/honeybadger/util/http.rb
@@ -1,12 +1,3 @@
-require 'forwardable'
-require 'net/http'
-require 'json'
-require 'zlib'
-require 'openssl'
-
-require 'honeybadger/version'
-require 'honeybadger/logging'
-
 module Honeybadger
   module Util
     class HTTP

--- a/lib/honeybadger/util/request_payload.rb
+++ b/lib/honeybadger/util/request_payload.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/util/sanitizer'
-
 module Honeybadger
   module Util
     # Internal: Constructs/sanitizes request data for notices

--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Honeybadger
   module Util
     class Sanitizer

--- a/spec/unit/honeybadger/agent/null_worker_spec.rb
+++ b/spec/unit/honeybadger/agent/null_worker_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/agent/worker'
-require 'honeybadger/agent/null_worker'
-
 describe Honeybadger::Agent::NullWorker do
   [:push, :shutdown, :shutdown!, :flush, :start].each do |method|
     it "responds to #{method}" do

--- a/spec/unit/honeybadger/agent/worker_spec.rb
+++ b/spec/unit/honeybadger/agent/worker_spec.rb
@@ -1,11 +1,3 @@
-require 'timecop'
-require 'thread'
-
-require 'honeybadger/agent/worker'
-require 'honeybadger/config'
-require 'honeybadger/backend'
-require 'honeybadger/notice'
-
 describe Honeybadger::Agent::Worker do
   let(:instance) { described_class.new(config, feature) }
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, backend: 'null') }

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/agent'
-require 'timecop'
-
 describe Honeybadger::Agent do
   describe "instance methods" do
     let!(:instance) { described_class.new(config) }

--- a/spec/unit/honeybadger/backend/base_spec.rb
+++ b/spec/unit/honeybadger/backend/base_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/backend/base'
-require 'honeybadger/config'
-
 describe Honeybadger::Backend::Response do
   context "when successful" do
     subject { described_class.new(201) }

--- a/spec/unit/honeybadger/backend/debug_spec.rb
+++ b/spec/unit/honeybadger/backend/debug_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/backend/debug'
-require 'honeybadger/config'
-
 describe Honeybadger::Backend::Debug do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }
   let(:logger) { config.logger }

--- a/spec/unit/honeybadger/backend/null_spec.rb
+++ b/spec/unit/honeybadger/backend/null_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/backend/null'
-require 'honeybadger/config'
-
 describe Honeybadger::Backend::Null do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER) }
   let(:logger) { config.logger }

--- a/spec/unit/honeybadger/backend/server_spec.rb
+++ b/spec/unit/honeybadger/backend/server_spec.rb
@@ -1,7 +1,3 @@
-require 'logger'
-require 'honeybadger/backend/server'
-require 'honeybadger/config'
-
 describe Honeybadger::Backend::Server do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, api_key: 'abc123') }
   let(:logger) { config.logger }

--- a/spec/unit/honeybadger/backend/test_spec.rb
+++ b/spec/unit/honeybadger/backend/test_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/backend/test'
-require 'honeybadger/config'
-
 describe Honeybadger::Backend::Test do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER) }
   let(:logger) { config.logger }

--- a/spec/unit/honeybadger/backtrace_spec.rb
+++ b/spec/unit/honeybadger/backtrace_spec.rb
@@ -1,8 +1,3 @@
-require 'stringio'
-require 'honeybadger/backtrace'
-require 'honeybadger/config'
-require 'honeybadger/notice'
-
 describe Honeybadger::Backtrace do
   let(:config) { Honeybadger::Config.new }
 

--- a/spec/unit/honeybadger/config/env_spec.rb
+++ b/spec/unit/honeybadger/config/env_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/config'
-
 describe Honeybadger::Config::Env do
   before do
     ENV['HONEYBADGER_API_KEY'] = 'asdf'

--- a/spec/unit/honeybadger/config/yaml_spec.rb
+++ b/spec/unit/honeybadger/config/yaml_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/config'
-
 describe Honeybadger::Config::Yaml do
   subject { described_class.new(path, env) }
   let(:path) { FIXTURES_PATH.join('honeybadger.yml') }

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -1,7 +1,3 @@
-require 'honeybadger/config'
-require 'honeybadger/backend/base'
-require 'net/http'
-
 describe Honeybadger::Config do
   it { should_not be_valid }
 

--- a/spec/unit/honeybadger/logging_spec.rb
+++ b/spec/unit/honeybadger/logging_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/logging'
-require 'honeybadger/config'
-
 LOG_SEVERITIES = [:debug, :info, :warn, :error, :fatal].freeze
 
 describe Honeybadger::Logging::Base do

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -1,10 +1,5 @@
 # encoding: utf-8
 
-require 'honeybadger/notice'
-require 'honeybadger/config'
-require 'honeybadger/plugins/local_variables'
-require 'timecop'
-
 describe Honeybadger::Notice do
   let(:callbacks) { Honeybadger::Config::Callbacks.new }
   let(:config) { build_config }

--- a/spec/unit/honeybadger/plugin_spec.rb
+++ b/spec/unit/honeybadger/plugin_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/plugin'
-require 'honeybadger/config'
-
 describe Honeybadger::Plugin::CALLER_FILE do
   it { should_not match "/foo/bar" }
   it { should match "/foo/bar:32" }

--- a/spec/unit/honeybadger/plugins/delayed_job_spec.rb
+++ b/spec/unit/honeybadger/plugins/delayed_job_spec.rb
@@ -1,6 +1,3 @@
-require 'honeybadger/config'
-require 'honeybadger/agent'
-
 begin
   require 'delayed_job'
   require 'honeybadger/plugins/delayed_job/plugin'

--- a/spec/unit/honeybadger/plugins/local_variables_spec.rb
+++ b/spec/unit/honeybadger/plugins/local_variables_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/local_variables'
-require 'honeybadger/config'
 
 describe "Local variables integration", order: :defined do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/plugins/passenger_spec.rb
+++ b/spec/unit/honeybadger/plugins/passenger_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/passenger'
-require 'honeybadger/config'
 
 describe "Passenger integration" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -1,6 +1,4 @@
 require 'honeybadger/plugins/resque'
-require 'honeybadger/config'
-require 'honeybadger/agent'
 
 class TestWorker
   extend Honeybadger::Plugins::Resque::Extension

--- a/spec/unit/honeybadger/plugins/shoryuken_spec.rb
+++ b/spec/unit/honeybadger/plugins/shoryuken_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/shoryuken'
-require 'honeybadger/config'
 
 class TestShoryukenWorker < Honeybadger::Plugins::Shoryuken::Middleware
 end

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/sidekiq'
-require 'honeybadger/config'
 
 describe "Sidekiq Dependency" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/plugins/sucker_punch_spec.rb
+++ b/spec/unit/honeybadger/plugins/sucker_punch_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/sucker_punch'
-require 'honeybadger/config'
 
 describe "SuckerPunch Dependency" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/plugins/thor_spec.rb
+++ b/spec/unit/honeybadger/plugins/thor_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/thor'
-require 'honeybadger/config'
 
 describe "Thor Dependency" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/plugins/unicorn_spec.rb
+++ b/spec/unit/honeybadger/plugins/unicorn_spec.rb
@@ -1,5 +1,4 @@
 require 'honeybadger/plugins/unicorn'
-require 'honeybadger/config'
 
 describe "Unicorn integration" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }

--- a/spec/unit/honeybadger/rack/error_notifier_spec.rb
+++ b/spec/unit/honeybadger/rack/error_notifier_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/rack/error_notifier'
-
 class BacktracedException < Exception
   attr_accessor :backtrace
   def initialize(opts)

--- a/spec/unit/honeybadger/rack/metrics_reporter_spec.rb
+++ b/spec/unit/honeybadger/rack/metrics_reporter_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/rack/metrics_reporter'
-
 describe Honeybadger::Rack::MetricsReporter do
   let(:logger) { double(add: true) }
   let(:config) { Honeybadger::Config.new(logger: logger) }

--- a/spec/unit/honeybadger/rack/request_hash_spec.rb
+++ b/spec/unit/honeybadger/rack/request_hash_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/rack/request_hash'
-
 describe Honeybadger::Rack::RequestHash, if: defined?(Rack) do
   let(:request) { Rack::Request.new(Rack::MockRequest.env_for('/')) }
   subject { described_class.new(request) }

--- a/spec/unit/honeybadger/rack/user_feedback_spec.rb
+++ b/spec/unit/honeybadger/rack/user_feedback_spec.rb
@@ -1,6 +1,4 @@
 require 'sham_rack'
-require 'honeybadger/rack/user_feedback'
-require 'honeybadger/config'
 
 describe Honeybadger::Rack::UserFeedback do
   let(:config) { Honeybadger::Config.new }

--- a/spec/unit/honeybadger/rack/user_informer_spec.rb
+++ b/spec/unit/honeybadger/rack/user_informer_spec.rb
@@ -1,6 +1,4 @@
 require 'sham_rack'
-require 'honeybadger/rack/user_informer'
-require 'honeybadger/config'
 
 describe Honeybadger::Rack::UserInformer do
   let(:config) { Honeybadger::Config.new }

--- a/spec/unit/honeybadger/util/http_spec.rb
+++ b/spec/unit/honeybadger/util/http_spec.rb
@@ -1,8 +1,3 @@
-require 'net/http'
-require 'logger'
-require 'honeybadger/util/http'
-require 'honeybadger/config'
-
 describe Honeybadger::Util::HTTP do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, api_key: 'abc123') }
   let(:logger) { config.logger }

--- a/spec/unit/honeybadger/util/request_payload_spec.rb
+++ b/spec/unit/honeybadger/util/request_payload_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/util/request_payload'
-
 class TestSanitizer
   def sanitize(data)
     data

--- a/spec/unit/honeybadger/util/sanitizer_spec.rb
+++ b/spec/unit/honeybadger/util/sanitizer_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'honeybadger/util/sanitizer'
-
 describe Honeybadger::Util::Sanitizer do
   its(:max_depth) { should eq 20 }
   its(:filters) { should be_nil }

--- a/spec/unit/honeybadger/util/stats_spec.rb
+++ b/spec/unit/honeybadger/util/stats_spec.rb
@@ -1,5 +1,3 @@
-require 'honeybadger/util/stats'
-
 describe Honeybadger::Util::Stats do
   describe '.memory' do
     subject { Honeybadger::Util::Stats.memory }

--- a/spec/unit/spec_helper.rb
+++ b/spec/unit/spec_helper.rb
@@ -2,10 +2,16 @@ require 'logger'
 require 'pathname'
 require 'pry'
 require 'rspec/its'
+require 'timecop'
+require 'stringio'
+require 'net/http'
+require 'thread'
 
 # We don't want this bleeding through in tests. (i.e. from CircleCi)
 ENV['RACK_ENV'] = nil
 ENV['RAILS_ENV'] = nil
+
+require 'honeybadger'
 
 TMP_DIR = Pathname.new(File.expand_path('../../../tmp', __FILE__))
 FIXTURES_PATH = Pathname.new(File.expand_path('../fixtures/', __FILE__))


### PR DESCRIPTION
Originally I'd tried to make each file explicitly require all the
dependencies which it relied on. The benefit of that approach is that
you can require and test each file in isolation. This never happens in
practice, and is cumbersome.

Moving forward, the assumption would be that you must `require
'honeybadger'` (or similar) to use the gem, which allows all of the
supporting files to assume that their dependencies are already required.