### PR TITLE
Capture NameError exceptions when evaluating local_variables

### DIFF
--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -366,8 +366,20 @@ module Honeybadger
       binding ||= exception.__honeybadger_bindings_stack[0]
 
       vars = binding.eval('local_variables')
-      result = Hash[vars.map {|arg| [arg, binding.eval(arg.to_s)]}]
-      request_sanitizer.sanitize(result)
+      results =
+        vars.inject([]) { |acc, arg|
+          begin
+            result = binding.eval(arg.to_s)
+            acc << [arg, result]
+          rescue NameError
+            # Do Nothing
+          end
+
+          acc
+        }
+
+      result_hash = Hash[results]
+      request_sanitizer.sanitize(result_hash)
     end
 
     # Internal: Should local variables be sent?


### PR DESCRIPTION
This PR only concerns the exceptoins.local_variables feature. When enabled:

Sometimes the local_variables returned by
`binding.eval('local_variables')` cannot be evaluated. In that case,
capture the NameError exception and move on.

To be a bit more specific, when I debug the code I see that, in one scenario in my Rails 4 app, `binding.eval('local_variables')` returns: `[:m, :args, :block, :r, :target]`. I'm not sure where the `m` variable comes from but trying to evaluate it blows up with a NameError exception.

> binding.eval('m')
> NameError (undefined local variable or method `m' for #<...>

So I've added exception handling to the local variable evals.
