### PR TITLE
CLI Rails-improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 branches:
   only:
     - master
-    - v3
+    - rails_cli
 language: ruby
 cache: bundler
 before_install: gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Exceptions encountered while loading/evaluating honeybadger.yml are now raised
+  instead of logged.
 
 ## [3.0.2] - 2017-02-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Exceptions encountered while loading/evaluating honeybadger.yml are now raised
   instead of logged.
 
+### Added
+- Friendlier backtraces for exceptions originating in honeybadger.yml.
+
 ## [3.0.2] - 2017-02-16
 ### Fixed
 - Fixed a bug caused by an interaction with the semantic\_logger gem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Friendlier backtraces for exceptions originating in honeybadger.yml.
 
+### Fixed
+- Rails environment is now loaded when running `honeybadger` cli from a Rails
+  root. This fixes an issue where programmatic configuration from Rails was not
+  loaded.
+
 ## [3.0.2] - 2017-02-16
 ### Fixed
 - Fixed a bug caused by an interaction with the semantic\_logger gem.

--- a/README.md
+++ b/README.md
@@ -486,9 +486,13 @@ en:
 
 See https://github.com/honeybadger-io/honeybadger-ruby/blob/master/CHANGELOG.md
 
-## Contributing
+## Development
 
-If you're adding a new feature, please [submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) as a preliminary step; that way you can be (moderately) sure that your pull request will be accepted.
+Pull requests are welcome. If you're adding a new feature, please [submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) as a preliminary step; that way you can be (moderately) sure that your pull request will be accepted.
+
+If you're integrating your gem/open source project with Honeybadger, please consider submitting an official plugin to our gem. [Submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) to discuss with us!
+
+We use [TomDoc](http://tomdoc.org/) to document our API. Classes and methods which are safe to depend on in your gems/projects are marked "Public". All other classes/methods are considered internal and may change without notice -- don't depend on them! If you need a new public API, we're happy to work with you. [Submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) to discuss.
 
 ### To contribute your code:
 

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -45,7 +45,12 @@ module Honeybadger
       end
 
       def error_message
-        FRIENDLY_ERRORS[code] || message
+        return message if code == :error
+        return FRIENDLY_ERRORS[code] if FRIENDLY_ERRORS[code]
+        return error if error =~ NOT_BLANK
+        msg = "The server responded with #{code}"
+        msg << ": #{message}" if message =~ NOT_BLANK
+        msg
       end
 
       private

--- a/lib/honeybadger/cli/deploy.rb
+++ b/lib/honeybadger/cli/deploy.rb
@@ -22,10 +22,8 @@ module Honeybadger
           local_username: options['user']
         }
 
-        http = Util::HTTP.new(config)
-        result = http.post('/v1/deploys', payload)
-
-        if result.code == '201'
+        result = config.backend.notify(:deploys, payload)
+        if result.success?
           say("Deploy notification complete.", :green)
         else
           say("Invalid response from server: #{result.code}", :red)

--- a/lib/honeybadger/cli/deploy.rb
+++ b/lib/honeybadger/cli/deploy.rb
@@ -1,11 +1,13 @@
 require 'forwardable'
 require 'honeybadger/cli/main'
+require 'honeybadger/cli/helpers'
 require 'honeybadger/util/http'
 
 module Honeybadger
   module CLI
     class Deploy
       extend Forwardable
+      include Helpers::BackendCmd
 
       def initialize(options, args, config)
         @options = options
@@ -26,7 +28,7 @@ module Honeybadger
         if response.success?
           say("Deploy notification complete.", :green)
         else
-          say("Invalid response from server: #{response.code}", :red)
+          say(error_message(response), :red)
           exit(1)
         end
       end

--- a/lib/honeybadger/cli/deploy.rb
+++ b/lib/honeybadger/cli/deploy.rb
@@ -22,11 +22,11 @@ module Honeybadger
           local_username: options['user']
         }
 
-        result = config.backend.notify(:deploys, payload)
-        if result.success?
+        response = config.backend.notify(:deploys, payload)
+        if response.success?
           say("Deploy notification complete.", :green)
         else
-          say("Invalid response from server: #{result.code}", :red)
+          say("Invalid response from server: #{response.code}", :red)
           exit(1)
         end
       end

--- a/lib/honeybadger/cli/deploy.rb
+++ b/lib/honeybadger/cli/deploy.rb
@@ -22,8 +22,10 @@ module Honeybadger
           local_username: options['user']
         }
 
-        result = config.backend.notify(:deploys, payload)
-        if result.success?
+        http = Util::HTTP.new(config)
+        result = http.post('/v1/deploys', payload)
+
+        if result.code == '201'
           say("Deploy notification complete.", :green)
         else
           say("Invalid response from server: #{result.code}", :red)

--- a/lib/honeybadger/cli/exec.rb
+++ b/lib/honeybadger/cli/exec.rb
@@ -78,16 +78,18 @@ MSG
           }
         }
 
+        http = Util::HTTP.new(config)
+
         begin
-          response = config.backend.notify(:notices, payload)
+          result = http.post('/v1/notices', payload)
         rescue
           say(result.msg)
           raise
         end
 
-        if !response.success?
+        if !result.success?
           say(result.msg)
-          say("\nFailed to notify Honeybadger: #{response.code}", :red)
+          say("\nFailed to notify Honeybadger: #{result.code}", :red)
           exit(1)
         end
 

--- a/lib/honeybadger/cli/exec.rb
+++ b/lib/honeybadger/cli/exec.rb
@@ -78,18 +78,16 @@ MSG
           }
         }
 
-        http = Util::HTTP.new(config)
-
         begin
-          result = http.post('/v1/notices', payload)
+          response = config.backend.notify(:notices, payload)
         rescue
           say(result.msg)
           raise
         end
 
-        if !result.success?
+        if !response.success?
           say(result.msg)
-          say("\nFailed to notify Honeybadger: #{result.code}", :red)
+          say("\nFailed to notify Honeybadger: #{response.code}", :red)
           exit(1)
         end
 

--- a/lib/honeybadger/cli/exec.rb
+++ b/lib/honeybadger/cli/exec.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'forwardable'
 require 'honeybadger/cli/main'
+require 'honeybadger/cli/helpers'
 require 'honeybadger/util/http'
 require 'honeybadger/util/stats'
 require 'open3'
@@ -11,6 +12,7 @@ module Honeybadger
   module CLI
     class Exec
       extend Forwardable
+      include Helpers::BackendCmd
 
       FAILED_TEMPLATE = <<-MSG
 Honeybadger detected failure or error output for the command:
@@ -87,7 +89,7 @@ MSG
 
         if !response.success?
           say(result.msg)
-          say("\nFailed to notify Honeybadger: #{response.code}", :red)
+          say(error_message(response), :red)
           exit(1)
         end
 

--- a/lib/honeybadger/cli/helpers.rb
+++ b/lib/honeybadger/cli/helpers.rb
@@ -1,0 +1,28 @@
+module Honeybadger
+  module CLI
+    module Helpers
+      module BackendCmd
+        def error_message(response)
+          host = config.get(:'connection.host')
+          <<-MSG
+!! --- Honeybadger request failed --------------------------------------------- !!
+
+We encountered an error when contacting the server:
+
+  #{response.error_message}
+
+To fix this issue, please try the following:
+
+  - Make sure the gem is configured properly.
+  - Retry executing this command a few times.
+  - Make sure you can connect to #{host} (`ping #{host}`).
+  - Email support@honeybadger.io for help. Include as much debug info as you
+    can for a faster resolution!
+
+!! --- End -------------------------------------------------------------------- !!
+MSG
+        end
+      end
+    end
+  end
+end

--- a/lib/honeybadger/cli/heroku.rb
+++ b/lib/honeybadger/cli/heroku.rb
@@ -53,7 +53,7 @@ module Honeybadger
 
       private
 
-      # Public: Detects the Heroku app name from GIT.
+      # Internal: Detects the Heroku app name from GIT.
       #
       # prompt_on_default - If a single remote is discoverd, should we prompt the
       #                     user before returning it?

--- a/lib/honeybadger/cli/install.rb
+++ b/lib/honeybadger/cli/install.rb
@@ -18,13 +18,14 @@ module Honeybadger
         say("Installing Honeybadger #{VERSION}")
 
         begin
+          require 'rails'
           require File.join(Dir.pwd, 'config', 'application.rb')
+          root = Rails.root
+          config_root = root.join('config')
         rescue LoadError
-          nil
+          root = config_root = Pathname.new(Dir.pwd)
         end
 
-        root = defined?(Rails.root) ? Rails.root : Pathname.new(Dir.pwd)
-        config_root = defined?(Rails.root) ? root.join('config') : root
         config_path = config_root.join('honeybadger.yml')
 
         if config_path.exist?

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -141,6 +141,7 @@ WELCOME
         load_env
 
         config = Honeybadger.config
+        config.set(:report_data, true)
         config.set(:api_key, fetch_value(options, 'api_key')) if options.has_key?('api_key')
         config.set(:env, fetch_value(options, 'environment')) if options.has_key?('environment')
 

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -151,12 +151,20 @@ WELCOME
       def load_env
         # Initialize Rails when running from Rails root.
         environment_rb = File.join(Dir.pwd, 'config', 'environment.rb')
-        if File.exists?(environment_rb)
-          require environment_rb
-        end
+        load_rails_env(environment_rb) if File.exists?(environment_rb)
 
         # Ensure config is loaded (will be skipped if initialized by Rails).
         Honeybadger.config.load!
+      end
+
+      def load_rails_env(environment_rb)
+        begin
+          require 'rails'
+        rescue LoadError
+          # No Rails, so skip loading Rails environment.
+          return
+        end
+        require environment_rb
       end
 
       def log_error(e)

--- a/lib/honeybadger/cli/notify.rb
+++ b/lib/honeybadger/cli/notify.rb
@@ -44,6 +44,7 @@ module Honeybadger
 
         http = Util::HTTP.new(config)
         result = http.post('/v1/notices', payload)
+
         if result.code == '201'
           say("Error notification complete.", :green)
         else

--- a/lib/honeybadger/cli/notify.rb
+++ b/lib/honeybadger/cli/notify.rb
@@ -44,7 +44,6 @@ module Honeybadger
 
         http = Util::HTTP.new(config)
         result = http.post('/v1/notices', payload)
-
         if result.code == '201'
           say("Error notification complete.", :green)
         else

--- a/lib/honeybadger/cli/notify.rb
+++ b/lib/honeybadger/cli/notify.rb
@@ -1,6 +1,7 @@
 require 'digest'
 require 'forwardable'
 require 'honeybadger/cli/main'
+require 'honeybadger/cli/helpers'
 require 'honeybadger/util/http'
 require 'honeybadger/util/stats'
 
@@ -8,6 +9,7 @@ module Honeybadger
   module CLI
     class Notify
       extend Forwardable
+      include Helpers::BackendCmd
 
       def initialize(options, args, config)
         @options = options
@@ -46,7 +48,7 @@ module Honeybadger
         if response.success?
           say("Error notification complete.", :green)
         else
-          say("Invalid response from server: #{response.code}", :red)
+          say(error_message(response), :red)
           exit(1)
         end
       end

--- a/lib/honeybadger/cli/notify.rb
+++ b/lib/honeybadger/cli/notify.rb
@@ -42,12 +42,11 @@ module Honeybadger
 
         payload.delete(:request) if payload[:request].empty?
 
-        http = Util::HTTP.new(config)
-        result = http.post('/v1/notices', payload)
-        if result.code == '201'
+        response = config.backend.notify(:notices, payload)
+        if response.success?
           say("Error notification complete.", :green)
         else
-          say("Invalid response from server: #{result.code}", :red)
+          say("Invalid response from server: #{response.code}", :red)
           exit(1)
         end
       end

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -37,13 +37,9 @@ module Honeybadger
       end
 
       def run
-        require 'honeybadger/ruby'
-
         begin
-          require File.join(Dir.pwd, 'config', 'application.rb')
+          require File.join(Dir.pwd, 'config', 'environment.rb')
           raise LoadError unless defined?(::Rails)
-          require 'honeybadger/init/rails'
-          Rails.application.initialize!
           say("Detected Rails #{Rails::VERSION::STRING}")
         rescue LoadError
           require 'honeybadger/init/ruby'

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -67,7 +67,7 @@ module Honeybadger
 
 The error notifier is installed, but we encountered an error:
 
-  #{response.code.kind_of?(Integer) ? "(#{response.code}) " : nil}#{response.error_message}
+  #{response.error_message}
 
 To fix this issue, please try the following:
 

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -55,65 +55,8 @@ module Honeybadger
         Honeybadger.config.backend = test_backend
 
         at_exit do
-          Honeybadger.flush
-
-          if calling = TestBackend.callings[:notices].find {|c| c[0].exception.eql?(TEST_EXCEPTION) }
-            notice, response = *calling
-
-            if response.code != 201
-              host = Honeybadger.config.get(:'connection.host')
-              say(<<-MSG, :red)
-!! --- Honeybadger test failed ------------------------------------------------ !!
-
-The error notifier is installed, but we encountered an error:
-
-  #{response.error_message}
-
-To fix this issue, please try the following:
-
-  - Make sure the gem is configured properly.
-  - Retry executing this command a few times.
-  - Make sure you can connect to #{host} (`ping #{host}`).
-  - Email support@honeybadger.io for help. Include as much debug info as you
-    can for a faster resolution!
-
-!! --- End -------------------------------------------------------------------- !!
-MSG
-              exit(1)
-            end
-
-            say(generate_success_message(response), :green)
-
-            exit(0)
-          end
-
-          say(<<-MSG, :red)
-!! --- Honeybadger test failed ------------------------------------------------ !!
-
-Error: The test exception was not reported; the application may not be
-configured properly.
-
-This is usually caused by one of the following issues:
-
-  - There was a problem loading your application. Check your logs to see if a
-    different exception is being raised.
-  - The exception is being rescued before it reaches our Rack middleware. If
-    you're using `rescue` or `rescue_from` you may need to notify Honeybadger
-    manually: `Honeybadger.notify(exception)`.
-  - The honeybadger gem is misconfigured. Check the settings in your
-    honeybadger.yml file.
-MSG
-
-          notices = TestBackend.callings[:notices].map(&:first)
-          unless notices.empty?
-            say("\nThe following errors were reported:", :red)
-            notices.each {|n| say("\n  - #{n.error_class}: #{n.error_message}", :red) }
-          end
-
-          say("\nSee https://git.io/vXCYp for more troubleshooting help.\n\n", :red)
-          say("!! --- End -------------------------------------------------------------------- !!", :red)
-
-          exit(1)
+          # Exceptions will already be reported when exiting.
+          verify_test unless $!
         end
 
         run_test
@@ -211,6 +154,68 @@ MSG
         env = ::Rack::MockRequest.env_for("http#{ ssl ? 's' : nil }://www.example.com/verify", 'REMOTE_ADDR' => '127.0.0.1')
 
         ::Rails.application.call(env)
+      end
+
+      def verify_test
+        Honeybadger.flush
+
+        if calling = TestBackend.callings[:notices].find {|c| c[0].exception.eql?(TEST_EXCEPTION) }
+          notice, response = *calling
+
+          if response.code != 201
+            host = Honeybadger.config.get(:'connection.host')
+            say(<<-MSG, :red)
+!! --- Honeybadger test failed ------------------------------------------------ !!
+
+The error notifier is installed, but we encountered an error:
+
+  #{response.error_message}
+
+To fix this issue, please try the following:
+
+  - Make sure the gem is configured properly.
+  - Retry executing this command a few times.
+  - Make sure you can connect to #{host} (`ping #{host}`).
+  - Email support@honeybadger.io for help. Include as much debug info as you
+    can for a faster resolution!
+
+!! --- End -------------------------------------------------------------------- !!
+MSG
+            exit(1)
+          end
+
+          say(generate_success_message(response), :green)
+
+          exit(0)
+        end
+
+        say(<<-MSG, :red)
+!! --- Honeybadger test failed ------------------------------------------------ !!
+
+Error: The test exception was not reported; the application may not be
+configured properly.
+
+This is usually caused by one of the following issues:
+
+  - There was a problem loading your application. Check your logs to see if a
+    different exception is being raised.
+  - The exception is being rescued before it reaches our Rack middleware. If
+    you're using `rescue` or `rescue_from` you may need to notify Honeybadger
+    manually: `Honeybadger.notify(exception)`.
+  - The honeybadger gem is misconfigured. Check the settings in your
+    honeybadger.yml file.
+MSG
+
+        notices = TestBackend.callings[:notices].map(&:first)
+        unless notices.empty?
+          say("\nThe following errors were reported:", :red)
+          notices.each {|n| say("\n  - #{n.error_class}: #{n.error_message}", :red) }
+        end
+
+        say("\nSee https://git.io/vXCYp for more troubleshooting help.\n\n", :red)
+        say("!! --- End -------------------------------------------------------------------- !!", :red)
+
+        exit(1)
       end
 
       def generate_success_message(response)

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -38,8 +38,8 @@ module Honeybadger
 
       def run
         begin
+          require 'rails'
           require File.join(Dir.pwd, 'config', 'environment.rb')
-          raise LoadError unless defined?(::Rails)
           say("Detected Rails #{Rails::VERSION::STRING}")
         rescue LoadError
           require 'honeybadger/init/ruby'
@@ -126,7 +126,7 @@ MSG
       def_delegator :@shell, :say
 
       def run_test
-        if defined?(::Rails.application)
+        if defined?(::Rails.application) && ::Rails.application
           run_rails_test
         else
           run_standalone_test

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -48,14 +48,24 @@ module Honeybadger
     # initialization. This is not required for the notifier to work (i.e. with
     # `require 'honeybadger/ruby'`).
     def init!(opts = {}, env = ENV)
-      self.framework = opts.freeze
+      load!(framework: opts, env: env)
+
+      init_logging!
+      init_backend!
+
+      logger.info(sprintf('Initializing Honeybadger Error Tracker for Ruby. Ship it! version=%s framework=%s', Honeybadger::VERSION, detected_framework))
+      logger.warn('Entering development mode: data will not be reported.') if dev? && backend.kind_of?(Backend::Null)
+
+      self
+    end
+
+    def load!(framework: {}, env: ENV)
+      return self if @loaded
+      self.framework = framework.freeze
       self.env = Env.new(env).freeze
       load_config_from_disk {|yaml| self.yaml = yaml.freeze }
       detect_revision!
-      init_logging!
-      init_backend!
-      logger.info(sprintf('Initializing Honeybadger Error Tracker for Ruby. Ship it! version=%s framework=%s', Honeybadger::VERSION, detected_framework))
-      logger.warn('Entering development mode: data will not be reported.') if dev? && backend.kind_of?(Backend::Null)
+      @loaded = true
       self
     end
 

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -380,15 +380,6 @@ module Honeybadger
           yield(yml) if block_given?
         end
       end
-    rescue ConfigError => e
-      error("Error loading config from disk: #{e}")
-      nil
-    rescue StandardError => e
-      error {
-        msg = "Error loading config from disk. class=%s message=%s\n\t%s"
-        sprintf(msg, e.class, e.message.dump, Array(e.backtrace).join("\n\t"))
-      }
-      nil
     end
 
     def undotify_keys(hash)

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -13,7 +13,9 @@ require 'honeybadger/util/revision'
 require 'honeybadger/logging'
 
 module Honeybadger
-  # Internal
+  # Internal: The Config class is used to manage Honeybadger's initialization
+  # and configuration. Please don't depend on any internal classes or methods
+  # outside of Honeybadger as they may change without notice.
   class Config
     extend Forwardable
 
@@ -235,7 +237,7 @@ module Honeybadger
       includes_token?(self[:plugins], name)
     end
 
-    # Internal: Match the project root.
+    # Match the project root.
     #
     # Returns Regexp matching the project root in a file string.
     def root_regexp
@@ -279,7 +281,7 @@ module Honeybadger
       set(:revision, Util::Revision.detect(self[:root]))
     end
 
-    # Internal: Optional path to honeybadger.log log file.
+    # Optional path to honeybadger.log log file.
     #
     # Returns the Pathname log path if a log path was specified.
     def log_path
@@ -288,7 +290,7 @@ module Honeybadger
       locate_absolute_path(self[:'logging.path'], self[:root])
     end
 
-    # Internal: Path to honeybadger.yml configuration file; this should be the
+    # Path to honeybadger.yml configuration file; this should be the
     # root directory if no path was specified.
     #
     # Returns the Pathname configuration path.
@@ -364,7 +366,7 @@ module Honeybadger
       @logger = Logging::ConfigLogger.new(self, build_logger)
     end
 
-    # Internal: Does collection include the String value or Symbol value?
+    # Does collection include the String value or Symbol value?
     #
     # obj - The Array object, if present.
     # value - The value which may exist within Array obj.

--- a/lib/honeybadger/config/yaml.rb
+++ b/lib/honeybadger/config/yaml.rb
@@ -25,7 +25,22 @@ module Honeybadger
       end
 
       def self.load_yaml(path)
-        yaml = YAML.load(ERB.new(path.read).result)
+        begin
+          yaml = YAML.load(ERB.new(path.read).result)
+        rescue => e
+          config_error = ConfigError.new(e.to_s)
+
+          if e.backtrace
+            backtrace = e.backtrace.dup
+            if backtrace[0] && backtrace[0].start_with?('(erb)'.freeze)
+              backtrace[0] = backtrace[0].gsub('(erb)'.freeze, path.to_s)
+            end
+            config_error.set_backtrace(backtrace)
+          end
+
+          raise config_error
+        end
+
         case yaml
         when Hash
           yaml

--- a/lib/honeybadger/config/yaml.rb
+++ b/lib/honeybadger/config/yaml.rb
@@ -31,7 +31,7 @@ module Honeybadger
           config_error = ConfigError.new(e.to_s)
 
           if e.backtrace
-            backtrace = e.backtrace.dup.map do |line|
+            backtrace = e.backtrace.map do |line|
               if line.start_with?('(erb)'.freeze)
                 line.gsub('(erb)'.freeze, path.to_s)
               else

--- a/lib/honeybadger/config/yaml.rb
+++ b/lib/honeybadger/config/yaml.rb
@@ -31,9 +31,12 @@ module Honeybadger
           config_error = ConfigError.new(e.to_s)
 
           if e.backtrace
-            backtrace = e.backtrace.dup
-            if backtrace[0] && backtrace[0].start_with?('(erb)'.freeze)
-              backtrace[0] = backtrace[0].gsub('(erb)'.freeze, path.to_s)
+            backtrace = e.backtrace.dup.map do |line|
+              if line.start_with?('(erb)'.freeze)
+                line.gsub('(erb)'.freeze, path.to_s)
+              else
+                line
+              end
             end
             config_error.set_backtrace(backtrace)
           end

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -16,6 +16,8 @@ end
 
 module Honeybadger
   module Rack
+    # Public: Middleware for Rack applications. Adds a feedback form to the
+    # Rack response when an error has occurred.
     class UserFeedback
       extend Forwardable
 

--- a/lib/honeybadger/rack/user_informer.rb
+++ b/lib/honeybadger/rack/user_informer.rb
@@ -2,6 +2,8 @@ require 'forwardable'
 
 module Honeybadger
   module Rack
+    # Public: Middleware for Rack applications. Adds an error ID to the Rack
+    # response when an error has occurred.
     class UserInformer
       extend Forwardable
 

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -19,7 +19,7 @@ feature "Running the deploy cli command" do
 
     it "notifies the user" do
       expect(run('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user')).not_to be_successfully_executed
-      expect(all_output).to match(/invalid response/i)
+      expect(all_output).to match(/request failed/i)
     end
   end
 end

--- a/spec/features/notify_spec.rb
+++ b/spec/features/notify_spec.rb
@@ -1,0 +1,34 @@
+feature "Running the notify CLI command" do
+  before do
+    set_environment_variable('HONEYBADGER_API_KEY', 'asdf')
+    set_environment_variable('HONEYBADGER_LOGGING_LEVEL', 'DEBUG')
+  end
+
+  it "requires the --message flag" do
+    expect(run('honeybadger notify')).to be_successfully_executed
+    expect(all_output).to match('--message')
+    assert_no_notification
+  end
+
+  context "with a message" do
+    it "reports an exception with a default class" do
+      expect(run('honeybadger notify --message "Test error message"')).to be_successfully_executed
+      assert_notification('error' => {'class' => 'CLI Notification', 'message' => 'Test error message'})
+    end
+
+    it "overrides the class via --class flag" do
+      expect(run('honeybadger notify --class "MyClass" --message "Test error message"')).to be_successfully_executed
+      assert_notification('error' => {'class' => 'MyClass'})
+    end
+
+    it "uses configured API key" do
+      expect(run('honeybadger notify --message "Test error message"')).to be_successfully_executed
+      assert_notification('api_key' => 'asdf')
+    end
+
+    it "overrides the API key via --api-key flag" do
+      expect(run('honeybadger notify --message "Test error message" --api-key my-key')).to be_successfully_executed
+      assert_notification('api_key' => 'my-key')
+    end
+  end
+end

--- a/spec/fixtures/rails/config/environment.rb
+++ b/spec/fixtures/rails/config/environment.rb
@@ -1,0 +1,8 @@
+# Load the rails application
+require File.expand_path('../application', __FILE__)
+
+# Load honeybadger hooks before initialization.
+require 'honeybadger'
+
+# Initialize the rails application
+RailsApp.initialize!

--- a/spec/unit/honeybadger/config/yaml_spec.rb
+++ b/spec/unit/honeybadger/config/yaml_spec.rb
@@ -110,4 +110,28 @@ logging:
       expect { subject }.to raise_error(Honeybadger::Config::ConfigError)
     end
   end
+
+  context "when an error occurs in ERB" do
+    let(:config_path) { FIXTURES_PATH.join('honeybadger.yml') }
+    let(:yaml) { <<-YAML }
+---
+api_key: "<%= MyApp.config.nonexistant_var %>"
+YAML
+
+    before do
+      allow(config_path).to receive(:read).and_return(yaml)
+    end
+
+    it "raises a config error" do
+      expect { described_class.new(config_path) }.to raise_error(Honeybadger::Config::ConfigError)
+    end
+
+    it "raises an exception with a helpful backtrace" do
+      begin
+        described_class.new(config_path)
+      rescue => e
+        expect(e.backtrace[0]).to start_with(config_path.to_s)
+      end
+    end
+  end
 end

--- a/spec/unit/honeybadger/config/yaml_spec.rb
+++ b/spec/unit/honeybadger/config/yaml_spec.rb
@@ -107,7 +107,7 @@ logging:
     end
 
     it "re-raises the exception" do
-      expect { subject }.to raise_error(RuntimeError)
+      expect { subject }.to raise_error(Honeybadger::Config::ConfigError)
     end
   end
 end

--- a/spec/unit/honeybadger/config/yaml_spec.rb
+++ b/spec/unit/honeybadger/config/yaml_spec.rb
@@ -126,7 +126,7 @@ YAML
       expect { described_class.new(config_path) }.to raise_error(Honeybadger::Config::ConfigError)
     end
 
-    it "raises an exception with a helpful backtrace" do
+    it "raises an exception with a helpful backtrace", if: RUBY_PLATFORM !~ /java/ do
       begin
         described_class.new(config_path)
       rescue => e

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -78,13 +78,8 @@ describe Honeybadger::Config do
           allow(Honeybadger::Config::Yaml).to receive(:new).and_raise(Honeybadger::Config::ConfigError.new('ouch'))
         end
 
-        it "does not raise an exception" do
-          expect { init_instance }.not_to raise_error
-        end
-
-        it "logs the error message to the default logger" do
-          expect(instance.logger).to receive(:add).with(Logger::Severity::ERROR, /ouch/)
-          init_instance
+        it "raises the exception" do
+          expect { init_instance }.to raise_error(Honeybadger::Config::ConfigError)
         end
       end
 
@@ -94,18 +89,8 @@ describe Honeybadger::Config do
           allow(Honeybadger::Config::Yaml).to receive(:new).and_raise(RuntimeError.new('ouch'))
         end
 
-        it "does not raise an exception" do
-          expect { init_instance }.not_to raise_error
-        end
-
-        it "logs the error message to the default logger" do
-          expect(instance.logger).to receive(:add).with(Logger::Severity::ERROR, /ouch/)
-          init_instance
-        end
-
-        it "logs the backtrace to the boot logger" do
-          expect(instance.logger).to receive(:add).with(Logger::Severity::ERROR, /config_spec\.rb/)
-          init_instance
+        it "raises the exception" do
+          expect { init_instance }.to raise_error(RuntimeError)
         end
       end
     end


### PR DESCRIPTION
This in part addresses #217, and introduces some other semi-related changes/improvements. From the changelog:

- Exceptions encountered while loading/evaluating honeybadger.yml are now raised instead of logged.
- Friendlier backtraces for exceptions originating in honeybadger.yml.
- Rails environment is now loaded when running `honeybadger` cli from a Rails root. This fixes an issue where programmatic configuration from Rails was not loaded.

Also:

- Added test coverage for `honeybadger notify` CLI command.
- Updated development documentation.
- Better error messages for server/response-related issues.