### PR TITLE
Logger isn't being overridden properly when configuring with Honeybadger.configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ You can use any of the options below in your config file, or in the environment.
 
 Sometimes, default exception data just isn't enough. If you have extra data that will help you in debugging, send it as part of an error's context. [View full method documentation](http://www.rubydoc.info/gems/honeybadger/Honeybadger%3Acontext)
 
-Global context is stored in a thread local variable and automatically reported with any exception which occurrs within the current thread's execution.
+Global context is stored in a thread local variable and automatically reported with any exception which occurs within the current thread's execution.
 
 #### Use this method if:
 

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -75,7 +75,7 @@ module Honeybadger
       ruby_config = Ruby.new(self)
       yield(ruby_config)
       self.ruby = ruby.merge(ruby_config).freeze
-      @logging = @backend = nil
+      @logger = @backend = nil
       self
     end
 
@@ -108,7 +108,7 @@ module Honeybadger
 
     def set(key, value)
       self.ruby = ruby.merge(key => value).freeze
-      @logging = @backend = nil
+      @logger = @backend = nil
     end
     alias []= :set
 

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -72,7 +72,7 @@ describe Honeybadger::Config do
         instance.init!
       end
 
-      context "when a config error occurrs while loading file" do
+      context "when a config error occurs while loading file" do
         before do
           allow(instance.logger).to receive(:add)
           allow(Honeybadger::Config::Yaml).to receive(:new).and_raise(Honeybadger::Config::ConfigError.new('ouch'))
@@ -83,7 +83,7 @@ describe Honeybadger::Config do
         end
       end
 
-      context "when a generic error occurrs while loading file" do
+      context "when a generic error occurs while loading file" do
         before do
           allow(instance.logger).to receive(:add)
           allow(Honeybadger::Config::Yaml).to receive(:new).and_raise(RuntimeError.new('ouch'))

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -251,4 +251,23 @@ describe Honeybadger::Config do
       it { should be_nil }
     end
   end
+
+  describe "#configure" do
+    context "when the app has already been initialized" do
+      it "overrides the logger with the configured logger" do
+        INIT_LOGGER = Logger.new('/dev/null')
+        CONFIGURE_LOGGER = Logger.new('/dev/null')
+
+        honeybadger = Honeybadger::Config.new.init!(logger: INIT_LOGGER)
+
+        honeybadger.configure do |config|
+          config.logger = CONFIGURE_LOGGER
+        end
+
+        expect(CONFIGURE_LOGGER).to receive(:add).with(Logger::Severity::ERROR, /foo/)
+
+        honeybadger.logger.error('foo')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Noticed this in a pure Ruby app I was working on:
```
Bundler.require(:default) # this requires Honeybadger which inits the logger to STDOUT 
                                          # (because of https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/init/ruby.rb#L6)

Honeybadger.configure do |config|
  config.logger = Logger.new('/some/file')
end
```

The file specified would never actually get logged to; instead, logging would still show up in STDOUT.

I think [this](https://github.com/honeybadger-io/honeybadger-ruby/commit/ddbc18945842cc6a09b3b0ba58099641ace251b3#diff-af93e356bc211e1ecfdf85c19369f215R62) change meant to use `@logger` instead of `@logging`.

(I also fixed a typo in some other tests that I saw. LMK if you'd prefer I tear that commit out.)