### PR TITLE
Require a Rails.application when loading Rails integrations

### DIFF
--- a/lib/honeybadger/cli/install.rb
+++ b/lib/honeybadger/cli/install.rb
@@ -18,8 +18,8 @@ module Honeybadger
         say("Installing Honeybadger #{VERSION}")
 
         begin
-          require 'rails'
           require File.join(Dir.pwd, 'config', 'application.rb')
+          raise LoadError unless defined?(::Rails.application)
           root = Rails.root
           config_root = root.join('config')
         rescue LoadError

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -37,8 +37,6 @@ module Honeybadger
       end
 
       def run
-        ENV['HONEYBADGER_LOGGING_PATH'] = '/dev/null'
-
         begin
           require File.join(Dir.pwd, 'config', 'environment.rb')
           raise LoadError unless defined?(::Rails.application)

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -37,9 +37,11 @@ module Honeybadger
       end
 
       def run
+        ENV['HONEYBADGER_LOGGING_PATH'] = '/dev/null'
+
         begin
-          require 'rails'
           require File.join(Dir.pwd, 'config', 'environment.rb')
+          raise LoadError unless defined?(::Rails.application)
           say("Detected Rails #{Rails::VERSION::STRING}")
         rescue LoadError
           require 'honeybadger/init/ruby'

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -35,7 +35,7 @@ module Honeybadger
       end
 
       Plugin.register :rails_exceptions_catcher do
-        requirement { defined?(::Rails) }
+        requirement { defined?(::Rails.application) && ::Rails.application }
 
         execution do
           require 'rack/request'

--- a/lib/honeybadger/version.rb
+++ b/lib/honeybadger/version.rb
@@ -1,4 +1,4 @@
 module Honeybadger
   # Public: The current String Honeybadger version.
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.1.0.beta1'.freeze
 end


### PR DESCRIPTION
This prevents Rails and/or Rails-related integrations from being loaded if the gem happens to exist but the `honeybadger` command is not being run inside an actual Rails application.