### PR TITLE
Notify synchronously in Resque hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed a bug in the Resque plugin which prevented error reports from being
+  sent. The issue was that the Resque's callbacks were executed in an unexpected
+  order which caused the queue to be flushed before error notification instead
+  of after.
 
 ## [3.1.1] - 2017-04-13
 ### Fixed

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -12,7 +12,7 @@ describe TestWorker do
 
     shared_examples_for "reports exceptions" do
       specify do
-        expect(Honeybadger).to receive(:notify).with(error, hash_including(parameters: {job_arguments: [1, 2, 3]}))
+        expect(Honeybadger).to receive(:notify).with(error, hash_including(parameters: {job_arguments: [1, 2, 3]}, sync: true))
         described_class.on_failure_with_honeybadger(error, 1, 2, 3)
       end
     end
@@ -83,7 +83,7 @@ describe TestWorker do
           it "should report raised error to honeybadger" do
             other_error = StandardError.new('stubbed Honeybadger error in retry_criteria_valid?')
             allow(described_class).to receive(:retry_criteria_valid?).and_raise(other_error)
-            expect(Honeybadger).to receive(:notify).with(other_error, hash_including(parameters: {job_arguments: [1, 2, 3]}))
+            expect(Honeybadger).to receive(:notify).with(other_error, hash_including(parameters: {job_arguments: [1, 2, 3]}, sync: true))
             described_class.on_failure_with_honeybadger(error, 1, 2, 3)
           end
         end


### PR DESCRIPTION
This fixes a bug in the Resque plugin which prevented notifications from
being sent. The issue was that the Resque's callbacks were executed in
an unexpected order which caused the queue to be flushed before error
notification instead of after.