### PR TITLE
Don’t insert middleware into the Rails stack

### DIFF
--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -13,8 +13,8 @@ module Honeybadger
 
         initializer 'honeybadger.install_middleware' do |app|
           app.config.middleware.insert(0, Honeybadger::Rack::ErrorNotifier)
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer)
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback)
+          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer) if Honeybadger.config[:'user_informer.enabled']
+          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback) if Honeybadger.config[:'feedback.enabled']
         end
 
         config.after_initialize do

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -27,7 +27,6 @@ module Honeybadger
       end
 
       def call(env)
-        return @app.call(env) unless config[:'feedback.enabled']
         status, headers, body = @app.call(env)
         if env['honeybadger.error_id'] && form = render_form(env['honeybadger.error_id'])
           new_body = []

--- a/lib/honeybadger/rack/user_informer.rb
+++ b/lib/honeybadger/rack/user_informer.rb
@@ -17,7 +17,6 @@ module Honeybadger
       end
 
       def call(env)
-        return @app.call(env) unless config[:'user_informer.enabled']
         status, headers, body = @app.call(env)
         if env['honeybadger.error_id']
           new_body = []


### PR DESCRIPTION
Don’t insert middleware into the Rails stack if they’ve been disabled in the config

Reimplements https://github.com/honeybadger-io/honeybadger-ruby/pull/142/files