### PR TITLE
Add block option to Honeybadger.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `Honeybadger.context` now accepts a block; the local context Hash will added
+- `Honeybadger.context` now accepts a block; the local context Hash will be added
   to exceptions which occur within the block's execution and cleared afterwards.
 
 ## [3.1.2] - 2017-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `Honeybadger.context` now accepts a block; the local context Hash will added
+  to exceptions which occur within the block's execution and cleared afterwards.
 
 ## [3.1.2] - 2017-04-20
 ### Fixed

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -152,10 +152,16 @@ module Honeybadger
     #        :user_email - The String user email address (optional).
     #        :tags       - The String comma-separated list of tags. When present,
     #                      tags will be applied to errors with this context (optional).
+    # block - An optional block that the context will be contained to.
     #
     # Examples
     #
     #   Honeybadger.context({my_data: 'my value'})
+    #
+    #   # Block-level context:
+    #   Honeybadger.context({local_data: 'my value'}) do
+    #     # Do something
+    #   end
     #
     #   # Inside a Rails controller:
     #   before_action do
@@ -166,8 +172,11 @@ module Honeybadger
     #   Honeybadger.context.clear!
     #
     # Returns self so that method calls can be chained.
-    def context(hash = nil)
-      context_manager.set_context(hash) unless hash.nil?
+    def context(hash = nil, &block)
+      raise ArgumentError, 'The context Hash must be provided with a block' if block_given? && hash.nil?
+
+      context_manager.set_context(hash, &block) unless hash.nil?
+
       self
     end
 


### PR DESCRIPTION
This PR adds a feature to set local context that is applied only to the execution of a block of code:

```
Honeybadger.context({local: true}) do
  # Do stuff
end
```