### PR TITLE
Allow overriding the cause.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- The exception cause may now be set using an optional `:cause` option when
+  calling `Honeybadger.notify`. If not present, the exception's cause will be
+  used, or the global `$!` exception if available.
 
 ## [3.1.2] - 2017-04-20
 ### Fixed

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -83,6 +83,7 @@ module Honeybadger
     #                     :parameters    - The Hash HTTP request paramaters (optional).
     #                     :session       - The Hash HTTP request session (optional).
     #                     :url           - The String HTTP request URL (optional).
+    #                     :cause         - The Exception cause for this error (optional).
     #
     # Examples
     #

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -444,24 +444,25 @@ module Honeybadger
       end
     end
 
-    # Internal: Unwrap causes from exception.
+    # Internal: Create a list of causes.
     #
-    # exception - Exception to unwrap.
+    # cause - The first cause to unwrap.
     #
-    # Returns Hash causes (in payload format).
-    def unwrap_causes(exception)
-      c, e, i = [], exception, 0
-      while (e) && i < MAX_EXCEPTION_CAUSES
-        c << {
-          class: e.class.name,
-          message: e.message,
-          backtrace: parse_backtrace(e.backtrace || caller).to_a
+    # Returns Array causes (in Hash payload format).
+    def unwrap_causes(cause)
+      causes, c, i = [], cause, 0
+
+      while (c) && i < MAX_EXCEPTION_CAUSES
+        causes << {
+          class: c.class.name,
+          message: c.message,
+          backtrace: parse_backtrace(c.backtrace || caller).to_a
         }
         i += 1
-        e = exception_cause(e)
+        c = exception_cause(c)
       end
 
-      c
+      causes
     end
 
     def params_filters

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -452,7 +452,7 @@ module Honeybadger
     def unwrap_causes(cause)
       causes, c, i = [], cause, 0
 
-      while (c) && i < MAX_EXCEPTION_CAUSES
+      while c && i < MAX_EXCEPTION_CAUSES
         causes << {
           class: c.class.name,
           message: c.message,


### PR DESCRIPTION
From the CHANGELOG:

> The exception cause may now be set using an optional `:cause` option when
> calling `Honeybadger.notify`. If not present, the exception's cause will be
> used, or the global `$!` exception if available.