### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/lib/honeybadger/backtrace.rb
+++ b/lib/honeybadger/backtrace.rb
@@ -92,7 +92,7 @@ module Honeybadger
       #
       # Returns an array of line(s) from source file.
       def get_source(file, number, radius = 2)
-        if file && File.exists?(file)
+        if file && File.exist?(file)
           before = after = radius
           start = (number.to_i - 1) - before
           start = 0 and before = 1 if start <= 0

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -151,7 +151,7 @@ WELCOME
       def load_env
         # Initialize Rails when running from Rails root.
         environment_rb = File.join(Dir.pwd, 'config', 'environment.rb')
-        load_rails_env(environment_rb) if File.exists?(environment_rb)
+        load_rails_env(environment_rb) if File.exist?(environment_rb)
 
         # Ensure config is loaded (will be skipped if initialized by Rails).
         Honeybadger.config.load!

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -57,7 +57,7 @@ module Honeybadger
       end
 
       def custom_template_file?
-        custom_template_file && File.exists?(custom_template_file)
+        custom_template_file && File.exist?(custom_template_file)
       end
 
       def template_file

--- a/lib/honeybadger/util/stats.rb
+++ b/lib/honeybadger/util/stats.rb
@@ -1,8 +1,8 @@
 module Honeybadger
   module Util
     class Stats
-      HAS_MEM = File.exists?("/proc/meminfo")
-      HAS_LOAD = File.exists?("/proc/loadavg")
+      HAS_MEM = File.exist?("/proc/meminfo")
+      HAS_LOAD = File.exist?("/proc/loadavg")
 
       class << self
         def all

--- a/spec/unit/honeybadger/backtrace_spec.rb
+++ b/spec/unit/honeybadger/backtrace_spec.rb
@@ -80,7 +80,7 @@ describe Honeybadger::Backtrace do
       ]
 
       ['app/models/user.rb', 'app/concerns/authenticated_controller.rb', 'app/controllers/users_controller.rb'].each do |file|
-        expect(File).to receive(:exists?).with(file).and_return(true)
+        expect(File).to receive(:exist?).with(file).and_return(true)
         expect(File).to receive(:open).with(file).and_yield(StringIO.new(source))
       end
 


### PR DESCRIPTION
Replaces deprecated method `exists?` with `exists`

- Ruby [prefers this](https://ruby-doc.org/core-2.2.0/File.html#method-c-exists-3F) as of 2.2.0
- Will get rid of lots of `File.exists? is a deprecated name` logspam warnings