### PR TITLE
Support adding context to exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - The exception cause may now be set using an optional `:cause` option when
   calling `Honeybadger.notify`. If not present, the exception's cause will be
   used, or the global `$!` exception if available.
+- Context can now be added to any exception object by defining the
+  `#honeybadger_context` method. The method should have no arguments and return
+  a `Hash` of context data.
 
 ## [3.1.2] - 2017-04-20
 ### Fixed

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -147,7 +147,7 @@ module Honeybadger
 
       @request = construct_request_hash(config, opts)
 
-      @context = construct_context_hash(opts)
+      @context = construct_context_hash(opts, exception)
 
       @cause = opts[:cause] || exception_cause(@exception) || $!
       @causes = unwrap_causes(@cause)
@@ -321,9 +321,15 @@ module Honeybadger
       Util::RequestPayload.build(request)
     end
 
-    def construct_context_hash(opts)
+    def exception_context(exception)
+      return {}.freeze unless exception && exception.respond_to?(:honeybadger_context)
+      exception.honeybadger_context
+    end
+
+    def construct_context_hash(opts, exception)
       context = {}
       context.merge!(opts[:global_context]) if opts[:global_context]
+      context.merge!(exception_context(exception))
       context.merge!(opts[:context]) if opts[:context]
       context.empty? ? nil : context
     end


### PR DESCRIPTION
This adds support for adding context to exceptions when raising them:

```ruby
class CustomError < StandardError
  attr_reader :honeybadger_context

  def initialize(message, context = {})
    @honeybadger_context = context
    super(message)
  end
end

raise CustomError.new("an error occurred", {
  context_key: "context_value"
})
```

This could also be used to wrap 3rd-party errors with Honeybadger context in a `rescue` statement:

```ruby
begin
  # Code which may raise `3rdPartyError`, responding to `#some_attribute`
rescue 3rdPartyError => e
  raise CustomError.new(e.message, {
    context_key: e.some_attribute
  })
end
```