### PR TITLE
Add Honeybadger.local_variable_filter callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Context can now be added to any exception object by defining the
   `#honeybadger_context` method. The method should have no arguments and return
   a `Hash` of context data.
+- The values of local variables can now be filtered/transformed using a new
+  `Honeybadger.local_variable_filter` callback.
 
 ### Fixed
 - We no longer use "/dev/null" as the default log device as it doesn't exist on

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -312,6 +312,33 @@ module Honeybadger
     # Returns nothing.
     def_delegator :config, :backtrace_filter
 
+    # Public: Callback to filter/transform local variables. Keys are also
+    #         filtered using the `request.filter_keys` config option.
+    #
+    # block - A block which can be used to modify the value of each local
+    #         variable. Requires two block arguments: Symbol name and Object
+    #         value. Returns the Object value (which is passed to our default
+    #         request sanitizer).
+    #
+    # Examples
+    #
+    #   # Exclude the value if the variable name is "password":
+    #   Honeybadger.local_variable_filter do |name, value|
+    #     if name == :password
+    #       nil
+    #     else
+    #       value
+    #     end
+    #   end
+    #
+    #   # Use `#inspect` rather than the default `#to_s`:
+    #   Honeybadger.local_variable_filter do |_, value|
+    #     value.inspect
+    #   end
+    #
+    # Returns nothing.
+    def_delegator :config, :local_variable_filter
+
     # Public: Sets the Rack environment which is used to report request data
     # with errors.
     #

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -94,6 +94,11 @@ module Honeybadger
       self[:exception_fingerprint]
     end
 
+    def local_variable_filter
+      self[:local_variable_filter] = Proc.new if block_given?
+      self[:local_variable_filter]
+    end
+
     def get(key)
       IVARS.each do |var|
         source = instance_variable_get(var)

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -95,6 +95,11 @@ module Honeybadger
         hash[:exception_fingerprint] = Proc.new if block_given?
         get(:exception_fingerprint)
       end
+
+      def local_variable_filter
+        hash[:local_variable_filter] = Proc.new if block_given?
+        get(:local_variable_filter)
+      end
     end
   end
 end

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -387,10 +387,10 @@ module Honeybadger
 
       vars = binding.eval('local_variables')
       results =
-        vars.inject([]) { |acc, arg|
+        vars.inject([]) { |acc, var|
           begin
-            result = binding.eval(arg.to_s)
-            acc << [arg, result]
+            result = filter_local_variable(var, binding.eval(var.to_s))
+            acc << [var, result]
           rescue NameError
             # Do Nothing
           end
@@ -400,6 +400,11 @@ module Honeybadger
 
       result_hash = Hash[results]
       request_sanitizer.sanitize(result_hash)
+    end
+
+    def filter_local_variable(name, value)
+      return value unless config.local_variable_filter
+      config.local_variable_filter.call(name, value)
     end
 
     # Internal: Should local variables be sent?

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -10,7 +10,7 @@ module Honeybadger
 
   def_delegators :'Honeybadger::Agent.instance', :init!, :config, :configure,
     :context, :get_context, :flush, :stop, :with_rack_env, :exception_filter,
-    :exception_fingerprint, :backtrace_filter
+    :exception_fingerprint, :backtrace_filter, :local_variable_filter
 
   def notify(exception_or_opts, opts = {})
     Agent.instance.notify(exception_or_opts, opts)

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -100,5 +100,11 @@ describe Honeybadger::Agent do
         expect { instance.backtrace_filter(&NULL_BLOCK) }.to change(instance.config, :backtrace_filter).from(nil).to(NULL_BLOCK)
       end
     end
+
+    describe "#local_variable_filter" do
+      it "configures the local_variable_filter callback" do
+        expect { instance.local_variable_filter(&NULL_BLOCK) }.to change(instance.config, :local_variable_filter).from(nil).to(NULL_BLOCK)
+      end
+    end
   end
 end

--- a/spec/unit/honeybadger/config/ruby_spec.rb
+++ b/spec/unit/honeybadger/config/ruby_spec.rb
@@ -100,4 +100,14 @@ describe Honeybadger::Config::Ruby do
       })
     end
   end
+
+  describe "#local_variable_filter" do
+    it "assigns the local_variable_filter" do
+      block = ->{}
+      subject.local_variable_filter(&block)
+      expect(subject.to_hash).to eq({
+        local_variable_filter: block
+      })
+    end
+  end
 end

--- a/spec/unit/honeybadger_spec.rb
+++ b/spec/unit/honeybadger_spec.rb
@@ -34,6 +34,11 @@ describe Honeybadger do
     Honeybadger.exception_fingerprint {}
   end
 
+  it "delegates ::local_variable_filter to agent config" do
+    expect(Honeybadger.config).to receive(:local_variable_filter)
+    Honeybadger.local_variable_filter {}
+  end
+
   it "delegates ::flush to agent instance" do
     expect(Honeybadger::Agent.instance).to receive(:flush)
     Honeybadger.flush


### PR DESCRIPTION
This allows the values of local variables to be filtered/transformed via
a callback before being sent to Honeybadger. For example:

    # Exclude the value if the variable name is "password":
    Honeybadger.local_variable_filter do |name, value|
      if name == :password
        nil
      else
        value
      end
    end

    # Use `#inspect` rather than the default `#to_s`:
    Honeybadger.local_variable_filter do |_, value|
      value.inspect
    end