### PR TITLE
Add a conversion protocol for serializing unknown objects

### DIFF
--- a/lib/honeybadger/conversions.rb
+++ b/lib/honeybadger/conversions.rb
@@ -2,9 +2,9 @@ module Honeybadger
   module Conversions
     module_function
 
-    # Internal: Coerce context into a Hash.
+    # Internal: Convert context into a Hash.
     #
-    # context - The context object.
+    # object - The context object.
     #
     # Returns the Hash context.
     def Context(object)

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -660,8 +660,9 @@ describe Honeybadger::Notice do
   describe "#local_variables", order: :defined do
     let(:notice) { build_notice(exception: exception, config: config) }
     let(:mock_binding) { @mock_binding }
+    let(:value) { double() }
     let(:exception) do
-      foo = 'bar'
+      foo = value
       begin
         @mock_binding = binding
         fail 'oops'
@@ -711,7 +712,14 @@ describe Honeybadger::Notice do
         let(:config) { build_config(:'exceptions.local_variables' => true) }
 
         it "finds the local variables from first frame of trace" do
-          expect(notice.local_variables[:foo]).to eq 'bar'
+          expect(notice.local_variables[:foo]).to eq(String(value))
+        end
+
+        context "when value responds to #to_honeybadger" do
+          it "returns the #to_honeybadger value" do
+            allow(value).to receive(:to_honeybadger).and_return('baz')
+            expect(notice.local_variables[:foo]).to eq('baz')
+          end
         end
 
         context "with an application trace" do
@@ -721,7 +729,7 @@ describe Honeybadger::Notice do
           end
 
           it "finds the local variables from first frame of application trace" do
-            expect(notice.local_variables[:foo]).to eq 'bar'
+            expect(notice.local_variables[:foo]).to eq(String(value))
           end
 
           it "filters local variable keys" do


### PR DESCRIPTION
When preparing data to serialize as JSON for our API, we whitelist a few core types which are supported by JSON: `Hash`, `Array`, `Set`, `Numeric`, `TrueClass`, `FalseClass`, `NilClass`, and `String`. When an object is not one of those types, we convert it to its `String` representation using `#to_s` (and perform some additional sanitization on the result).

This PR adds a new conversion protocol that is used before the final `String` conversion. When the method `#to_honeybadger` is defined on an object, the return value of that method will be used in place of the object itself. The return value can be anything, since it's passed recursively back to the object sanitizer.

## An example of how this is useful

If you define `#to_s` on your Rails models, it's probably some human-readable string such as a name or email address--not suitable for debugging.

Instead, you could define `#to_honeybadger` and return a sanitized inspect string for the object, like `'#<User id: 1 email: "user@example.com">'`.

Now, if you pass the object directly to `Honeybadger.context`, i.e.: `Honeybadger.context({ user: current_user })`, you'll get an accurate representation of that object. If you're using the `local_variables` feature, any local variable which is a `User` instance will use the `#to_honeybadger` representation.

This also makes future extensions via our gem possible. If a majority of users want a specific type of representation for an ActiveRecord model, for instance, we could add a new plugin to define the conversion method on `ActiveRecord::Base` without fear of changing existing behavior.

## Other changes in this PR

There are a few other improvements in this PR:

- `BasicObject`, which previously could not be serialized, is now serialized as `"#<BasicObject>"`.
- Objects which explicitly alias `#to_s` to `#inspect` (such as `OpenStruct`) are now sanitized. `'#<OpenStruct attribute="value">'` becomes `'#<OpenStruct>'`. If you pass the value of `#inspect` (as a `String`) directly to Honeybadger (or return it from `#to_honeybadger`), the value will not be sanitized.
- We're now using `String(object)` instead of `object.to_s` as the last resort during sanitization.
- `'[RAISED]'` is returned when `object.to_honeybadger` or `String(object)` fails.