### PR TITLE
Fix reporting to Honeybadger after N retries

### DIFF
--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -24,10 +24,10 @@ module Honeybadger
           if defined?(::Sidekiq::VERSION) && ::Sidekiq::VERSION > '3'
             ::Sidekiq.configure_server do |sidekiq|
               sidekiq.error_handlers << lambda {|ex, params|
-                job = params[:job]
+                job = params[:job] || params
                 return if job['retry'.freeze] && job['retry_count'.freeze].to_i < config[:'sidekiq.attempt_threshold'].to_i
                 opts = {parameters: params}
-                opts[:component] = params['wrapped'.freeze] || job['class'.freeze] if config[:'sidekiq.use_component']
+                opts[:component] = job['wrapped'.freeze] || job['class'.freeze] if config[:'sidekiq.use_component']
                 Honeybadger.notify(ex, opts)
               }
             end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -24,9 +24,10 @@ module Honeybadger
           if defined?(::Sidekiq::VERSION) && ::Sidekiq::VERSION > '3'
             ::Sidekiq.configure_server do |sidekiq|
               sidekiq.error_handlers << lambda {|ex, params|
-                return if params['retry'.freeze] && params['retry_count'.freeze].to_i < config[:'sidekiq.attempt_threshold'].to_i
+                job = params[:job]
+                return if job['retry'.freeze] && job['retry_count'.freeze].to_i < config[:'sidekiq.attempt_threshold'].to_i
                 opts = {parameters: params}
-                opts[:component] = params['wrapped'.freeze] || params['class'.freeze] if config[:'sidekiq.use_component']
+                opts[:component] = params['wrapped'.freeze] || job['class'.freeze] if config[:'sidekiq.use_component']
                 Honeybadger.notify(ex, opts)
               }
             end

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -61,7 +61,8 @@ describe "Sidekiq Dependency" do
 
       describe "error handler" do
         let(:exception) { RuntimeError.new('boom') }
-        let(:job_context) { {} }
+        let(:job_context) { {context: 'Job raised exception', job: job } }
+        let(:job) { {} }
 
         before do
           Honeybadger::Plugin.instances[:sidekiq].load!(config)
@@ -73,7 +74,7 @@ describe "Sidekiq Dependency" do
         end
 
         context "when an attempt threshold is configured" do
-          let(:job_context) { { 'retry_count' => 2, 'retry' => true } }
+          let(:job) { { 'retry_count' => 2, 'retry' => true } }
           let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'sidekiq.attempt_threshold' => 3) }
 
           it "doesn't notify Honeybadger" do
@@ -82,7 +83,7 @@ describe "Sidekiq Dependency" do
           end
 
           context "and the retries are exhausted" do
-            let(:job_context) { { 'retry_count' => 2, 'retry' => false } }
+            let(:job) { { 'retry_count' => 2, 'retry' => false } }
 
             it "notifies Honeybadger" do
               expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
@@ -91,7 +92,7 @@ describe "Sidekiq Dependency" do
           end
 
           context "and the retry count meets the threshold" do
-            let(:job_context) { { 'retry_count' => 3, 'retry' => true } }
+            let(:job) { { 'retry_count' => 3, 'retry' => true } }
 
             it "notifies Honeybadger" do
               expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
@@ -103,4 +104,3 @@ describe "Sidekiq Dependency" do
     end
   end
 end
-

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -61,42 +61,85 @@ describe "Sidekiq Dependency" do
 
       describe "error handler" do
         let(:exception) { RuntimeError.new('boom') }
-        let(:job_context) { {context: 'Job raised exception', job: job } }
-        let(:job) { {} }
 
         before do
           Honeybadger::Plugin.instances[:sidekiq].load!(config)
         end
 
-        it "notifies Honeybadger" do
-          expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
-          sidekiq_config.error_handlers[0].call(exception, job_context)
-        end
+        context 'Sidekiq 4.2.3 and later' do
+          # The data we're interested in is inside the job subhash
+          let(:job_context) { {context: 'Job raised exception', job: job } }
+          let(:job) { {} }
 
-        context "when an attempt threshold is configured" do
-          let(:job) { { 'retry_count' => 2, 'retry' => true } }
-          let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'sidekiq.attempt_threshold' => 3) }
-
-          it "doesn't notify Honeybadger" do
-            expect(Honeybadger).not_to receive(:notify)
+          it "notifies Honeybadger" do
+            expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
             sidekiq_config.error_handlers[0].call(exception, job_context)
           end
 
-          context "and the retries are exhausted" do
-            let(:job) { { 'retry_count' => 2, 'retry' => false } }
+          context "when an attempt threshold is configured" do
+            let(:job) { { 'retry_count' => 2, 'retry' => true } }
+            let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'sidekiq.attempt_threshold' => 3) }
 
-            it "notifies Honeybadger" do
-              expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+            it "doesn't notify Honeybadger" do
+              expect(Honeybadger).not_to receive(:notify)
               sidekiq_config.error_handlers[0].call(exception, job_context)
             end
+
+            context "and the retries are exhausted" do
+              let(:job) { { 'retry_count' => 2, 'retry' => false } }
+
+              it "notifies Honeybadger" do
+                expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+                sidekiq_config.error_handlers[0].call(exception, job_context)
+              end
+            end
+
+            context "and the retry count meets the threshold" do
+              let(:job) { { 'retry_count' => 3, 'retry' => true } }
+
+              it "notifies Honeybadger" do
+                expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+                sidekiq_config.error_handlers[0].call(exception, job_context)
+              end
+            end
+          end
+        end
+
+        context 'Sidekiq earlier than 4.2.3' do
+          # The data we're interested in is at the top level of the params
+          let(:job_context) { job }
+          let(:job) { {} }
+
+          it "notifies Honeybadger" do
+            expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+            sidekiq_config.error_handlers[0].call(exception, job_context)
           end
 
-          context "and the retry count meets the threshold" do
-            let(:job) { { 'retry_count' => 3, 'retry' => true } }
+          context "when an attempt threshold is configured" do
+            let(:job) { { 'retry_count' => 2, 'retry' => true } }
+            let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'sidekiq.attempt_threshold' => 3) }
 
-            it "notifies Honeybadger" do
-              expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+            it "doesn't notify Honeybadger" do
+              expect(Honeybadger).not_to receive(:notify)
               sidekiq_config.error_handlers[0].call(exception, job_context)
+            end
+
+            context "and the retries are exhausted" do
+              let(:job) { { 'retry_count' => 2, 'retry' => false } }
+
+              it "notifies Honeybadger" do
+                expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+                sidekiq_config.error_handlers[0].call(exception, job_context)
+              end
+            end
+
+            context "and the retry count meets the threshold" do
+              let(:job) { { 'retry_count' => 3, 'retry' => true } }
+
+              it "notifies Honeybadger" do
+                expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+                sidekiq_config.error_handlers[0].call(exception, job_context)
+              end
             end
           end
         end


### PR DESCRIPTION
It turns out that the retry and retry_count hash entries are not at the top level of the params handed to the error handler but inside the `:job`. As `nil.to_i` always returns 0 the check here never fired.

I've only tried this with the latest Sidekiq Pro but I assume that the standard Sidekiq behaves in the same way. You (as in the company behind Honeybadger) should have an easy time finding out if that is true as all the data is sent to you.