### PR TITLE
Add "before notify" hooks via Ruby configuration

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -127,6 +127,10 @@ module Honeybadger
 
       notice = Notice.new(config, opts)
 
+      config.before_notify_hooks.each do |hook|
+        with_error_handling { hook.call(notice) }
+      end
+
       unless notice.api_key =~ NOT_BLANK
         error { sprintf('Unable to send error report: API key is missing. id=%s', notice.id) }
         return false
@@ -379,6 +383,12 @@ module Honeybadger
 
     def init_worker
       @worker = Worker.new(config)
+    end
+
+    def with_error_handling
+      yield
+    rescue => ex
+      error { "Rescued an error in a before notify hook: #{ex.message}" }
     end
 
     @instance = new(Config.new)

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -84,6 +84,10 @@ module Honeybadger
       self[:backtrace_filter]
     end
 
+    def before_notify_hooks
+      (ruby[:before_notify] || []).clone
+    end
+
     def exception_filter
       self[:exception_filter] = Proc.new if block_given?
       self[:exception_filter]

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -107,8 +107,8 @@ module Honeybadger
     # Local variables are extracted from first frame of backtrace.
     attr_reader :local_variables
 
-    # The API key used to deliver this notice.
-    attr_reader :api_key
+    # Public: The API key used to deliver this notice.
+    attr_accessor :api_key
 
     # @api private
     # Cache project path substitutions for backtrace lines.

--- a/spec/unit/honeybadger/config/ruby_spec.rb
+++ b/spec/unit/honeybadger/config/ruby_spec.rb
@@ -81,6 +81,33 @@ describe Honeybadger::Config::Ruby do
     end
   end
 
+  describe "#before_notify" do
+    it "adds a block as a before hook" do
+      block = ->(_notice) {}
+
+      subject.before_notify(&block)
+
+      expect(subject.to_hash).to eq(before_notify: [block])
+    end
+
+    it "adds a callable as a before hook" do
+      callable = ->(_notice) {}
+
+      subject.before_notify(callable)
+
+      expect(subject.to_hash).to eq(before_notify: [callable])
+    end
+
+    it "gives access to the before hooks when passed nothing" do
+      expect(subject.before_notify).to eq([])
+
+      callable = ->(_notice) {}
+      subject.before_notify(callable)
+
+      expect(subject.before_notify).to eq([callable])
+    end
+  end
+
   describe "#exception_filter" do
     it "assigns the exception_filter" do
       block = ->{}

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -532,6 +532,16 @@ describe Honeybadger::Notice do
     end
   end
 
+  describe "#api_key=" do
+    it "can override the API key for the notice" do
+      notice = build_notice
+
+      notice.api_key = "Hello, world"
+
+      expect(notice.api_key).to eq("Hello, world")
+    end
+  end
+
   context "custom fingerprint" do
     it "includes nil fingerprint when no fingerprint is specified" do
       notice = build_notice


### PR DESCRIPTION
This is a first pass at solving #246.

Based on my discussion with @joshuap, I created a sample implementation of the DSL. The DSL can be used in three ways:

```ruby
# Pass a callable to the method
thing_that_responds_to_call = ->(notice) { notice.context(from_hook: true) }
Honeybadger.configure do |config|
  config.before_notify(thing_that_responds_to_call)
end

# Pass a block to the method
Honeybadger.configure do |config|
  config.before_notify do |notice|
    notice.context(from_hook: true)
  end
end

# Grab the list of hooks (if necessary)
Honeybadger.configure do |config|
  hooks = config.before_notify

  # do something with hooks variable?
end
```

I also added a setter for `Notice#api_key` because that will be useful in the "before notify" hooks for routing errors to different projects without having to remember to do that throughout your code base.

Having not written the implementation that I intend to write yet (that's a problem for tomorrow), I think this will give me all of the handles that I need.

## Outstanding Questions

1. Is the addition of `Notice#api_key=` acceptable? I think I outlined the use case well in my commit message. Also, notices shouldn't really be accessed outside of the Honeybadger stack (or plugins to it), so I don't think this is an issue.
2. Do we like the DSL grammar as-is? I'm usually not a fan of overloading methods for multiple purposes (in this case, both setting and accessing hooks), but I think it makes sense in the scope of this configuration DSL.
3. How should we handle errors that might occur within the hook? Since it's within the Honeybadger gem, we should probably be extra careful about rescuing any exceptions ... and likely reporting them, since it's a bug in the "before notify" hook. That gets into a weird meta bug report that I'm not sure how we would want to handle.

I have a few other questions that I will pose in inline comments since it will be easier to follow the question and answer it there.

Closes #246