### PR TITLE
Improve hash merge performance

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -108,7 +108,7 @@ module Honeybadger
       return false if config.disabled?
 
       if exception_or_opts.is_a?(Exception)
-        opts.merge!(exception: exception_or_opts)
+        opts[:exception] = exception_or_opts
       elsif exception_or_opts.respond_to?(:to_hash)
         opts.merge!(exception_or_opts.to_hash)
       else


### PR DESCRIPTION
This is a very small tweak to pick up a performance improvement on the
hash manipulation. I noticed this while running Rubocop.
[This is the documentation](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Performance/RedundantMerge) for the cop which picked this one up.

This is a fairly small change but it's incredibly low risk so I don't see any harm in pulling it in.