### PR TITLE
Use prepend to add Sidekiq Middleware

### DIFF
--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -17,7 +17,7 @@ module Honeybadger
         execution do
           ::Sidekiq.configure_server do |sidekiq|
             sidekiq.server_middleware do |chain|
-              chain.add Middleware
+              chain.prepend Middleware
             end
           end
 

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -23,7 +23,7 @@ describe "Sidekiq Dependency" do
     end
 
     let(:sidekiq_config) { double('config', :error_handlers => []) }
-    let(:chain) { double('chain', :add => true) }
+    let(:chain) { double('chain', :prepend => true) }
 
     before do
       Object.const_set(:Sidekiq, shim)
@@ -39,7 +39,7 @@ describe "Sidekiq Dependency" do
       end
 
       it "adds the server middleware" do
-        expect(chain).to receive(:add).with(Honeybadger::Plugins::Sidekiq::Middleware)
+        expect(chain).to receive(:prepend).with(Honeybadger::Plugins::Sidekiq::Middleware)
         Honeybadger::Plugin.instances[:sidekiq].load!(config)
       end
 


### PR DESCRIPTION
Mike estimates that 90% of Sidekiq users are past 3.3.0, which is 3 years old and is the version which introduced the Sidekiq::Middleware::Chain#prepend method.

This PR switches our Sidekiq plugin to use `Chain#prepend` rather than `Chain#add`. The benefit of this is that Honeybadger context can be used inside of additional Sidekiq middleware.

I considered adding a deprecation warning for Sidekiq < 3.3.0, but ideally I'd like to move faster than that, and since this isn't breaking our API (only removing support for an unsupported version of Sidekiq), my plan is to release this in (coincidentally) version 3.3.0 of the honeybadger gem.

/cc @minhajuddin @aselder

Fixes #248 