### PR TITLE
Move to YARD doc format

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
---plugin tomdoc
+--no-private

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pull requests are welcome. If you're adding a new feature, please [submit an iss
 
 If you're integrating your gem/open source project with Honeybadger, please consider submitting an official plugin to our gem. [Submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) to discuss with us!
 
-We use [TomDoc](http://tomdoc.org/) to document our API. Classes and methods which are safe to depend on in your gems/projects are marked "Public". All other classes/methods are considered internal and may change without notice -- don't depend on them! If you need a new public API, we're happy to work with you. [Submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) to discuss.
+We use [YARD](https://yardoc.org/) to document our API. Classes and methods which are safe to depend on in your gems/projects are marked "Public". All other classes/methods are considered internal and may change without notice -- don't depend on them! If you need a new public API, we're happy to work with you. [Submit an issue](https://github.com/honeybadger-io/honeybadger-ruby/issues/new) to discuss.
 
 ### To contribute your code:
 

--- a/lib/honeybadger/backend.rb
+++ b/lib/honeybadger/backend.rb
@@ -7,6 +7,7 @@ require 'honeybadger/backend/null'
 require 'honeybadger/backend/debug'
 
 module Honeybadger
+  # @api private
   module Backend
     class BackendError < StandardError; end
 

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -18,17 +18,20 @@ module Honeybadger
         403 => "The API key is invalid. Please check your API key and try again.".freeze
       }.freeze
 
-      # Public: Initializes the Response instance.
+      # Initializes the Response instance.
       #
-      # response - With 1 argument Net::HTTPResponse, the code, body, and
-      #            message will be determined automatically (optional).
-      # code      - The Integer status code. May also be :error for requests which
-      #             failed to reach the server.
-      # body      - The String body of the response.
-      # message   - The String message returned by the server (or set by the
-      #             backend in the case of an :error code).
+      # @overload initialize(response)
+      #   Creates an instance from a +Net::HTTPResponse+.
+      #   @param [Net::HTTPResponse] response With 1 argument, the code, body,
+      #     and message will be determined automatically.
       #
-      # Returns nothing
+      # @overload initialize(code, body, message)
+      #   Creates an instance from parameters.
+      #   @param [Integer] code The status code. May also be :error for requests
+      #     which failed to reach the server.
+      #   @param [String] body The String body of the response.
+      #   @param [String] message The String message returned by the server (or
+      #     set by the backend in the case of an :error code).
       def initialize(*args)
         if (response = args.first).kind_of?(Net::HTTPResponse)
           @code, @body, @message = response.code.to_i, response.body.to_s, response.message
@@ -73,26 +76,25 @@ module Honeybadger
         @config = config
       end
 
-      # Internal: Process payload for feature.
+      # Process payload for feature.
       #
-      # feature - A Symbol feature name (corresponds to HTTP endpoint). Current
-      #           options are: `:notices`, `:deploys`, `:ping`.
-      # payload - Any Object responding to `#to_json`.
-      #
-      # Examples
-      #
+      # @example
       #   backend.notify(:notices, Notice.new(...))
       #
-      # Raises NotImplementedError
+      # @param [Symbol] feature The feature name (corresponds to HTTP
+      #   endpoint). Current options are: `:notices`, `:deploys`, `:ping`.
+      # @param [#to_json] payload The JSON payload to send.
+      #
+      # @raise NotImplementedError
       def notify(feature, payload)
         raise NotImplementedError, 'must define #notify on subclass.'
       end
 
-      # Internal: Does a check in using the input id.
+      # Does a check in using the input id.
       #
-      # id - The unique check_in id.
+      # @param [String] id The unique check_in id.
       #
-      # Raises NotImplementedError.
+      # @raise NotImplementedError
       def check_in(id)
         raise NotImplementedError, 'must define #check_in on subclass.'
       end

--- a/lib/honeybadger/backend/debug.rb
+++ b/lib/honeybadger/backend/debug.rb
@@ -2,9 +2,9 @@ require 'honeybadger/backend/null'
 
 module Honeybadger
   module Backend
-    # Internal: Logs the notice payload rather than sending it. The purpose of
-    # this backend is primarily for programmatically inspecting JSON payloads
-    # in integration tests.
+    # Logs the notice payload rather than sending it. The purpose of this
+    # backend is primarily for programmatically inspecting JSON payloads in
+    # integration tests.
     class Debug < Null
       def notify(feature, payload)
         logger.unknown("notifying debug backend of feature=#{feature}\n\t#{payload.to_json}")

--- a/lib/honeybadger/backend/server.rb
+++ b/lib/honeybadger/backend/server.rb
@@ -24,12 +24,12 @@ module Honeybadger
         super
       end
 
-      # Internal: Post payload to endpoint for feature.
+      # Post payload to endpoint for feature.
       #
-      # feature - The feature which is being notified.
-      # payload - The payload to send, responding to `#to_json`.
+      # @param [Symbol] feature The feature which is being notified.
+      # @param [#to_json] payload The JSON payload to send.
       #
-      # Returns Response.
+      # @return [Response]
       def notify(feature, payload)
         ENDPOINTS[feature] or raise(BackendError, "Unknown feature: #{feature}")
         Response.new(@http.post(ENDPOINTS[feature], payload, payload_headers(payload)))
@@ -37,11 +37,11 @@ module Honeybadger
         Response.new(:error, nil, "HTTP Error: #{e.class}")
       end
 
-      # Internal: Does a check in using the input id.
+      # Does a check in using the input id.
       #
-      # id - The unique check_in id.
+      # @param [String] id The unique check_in id.
       #
-      # Returns Response.
+      # @return [Response]
       def check_in(id)
         Response.new(@http.get("#{CHECK_IN_ENDPOINT}/#{id}"))
       rescue *HTTP_ERRORS => e
@@ -50,11 +50,6 @@ module Honeybadger
 
       private
 
-      # Internal: Construct headers for supported payloads.
-      #
-      # payload - The payload object.
-      #
-      # Returns Hash headers if supported, otherwise nil.
       def payload_headers(payload)
         if payload.respond_to?(:api_key) && payload.api_key
           {

--- a/lib/honeybadger/backend/test.rb
+++ b/lib/honeybadger/backend/test.rb
@@ -3,34 +3,31 @@ require 'honeybadger/backend/null'
 module Honeybadger
   module Backend
     class Test < Null
-      # Public: The notification list.
+      # The notification list.
       #
-      # Examples
-      #
+      # @example
       #   Test.notifications[:notices] # => [Notice, Notice, ...]
       #
-      # Returns the Hash notifications.
+      # @return [Hash] Notifications hash.
       def self.notifications
         @notifications ||= Hash.new {|h,k| h[k] = [] }
       end
 
-      # Public: The check in list.
+      # @api public
+      # The check in list.
       #
-      # Examples
-      #
+      # @example
       #   Test.check_ins # => ["foobar", "danny", ...]
       #
-      # Returns the Array of check ins.
+      # @return [Array<Object>] List of check ins.
       def self.check_ins
         @check_ins ||= []
       end
 
-      # Internal: Local helper.
       def notifications
         self.class.notifications
       end
 
-      # Internal: Local helper.
       def check_ins
         self.class.check_ins
       end

--- a/lib/honeybadger/backtrace.rb
+++ b/lib/honeybadger/backtrace.rb
@@ -1,20 +1,21 @@
 require 'json'
 
 module Honeybadger
-  # Internal: Front end to parsing the backtrace for each notice
+  # @api private
+  # Front end to parsing the backtrace for each notice.
   class Backtrace
-    # Internal: Handles backtrace parsing line by line
+    # Handles backtrace parsing line by line.
     class Line
-      # Backtrace line regexp (optionally allowing leading X: for windows support)
+      # Backtrace line regexp (optionally allowing leading X: for windows support).
       INPUT_FORMAT = %r{^((?:[a-zA-Z]:)?[^:]+):(\d+)(?::in `([^']+)')?$}.freeze
 
-      # The file portion of the line (such as app/models/user.rb)
+      # The file portion of the line (such as app/models/user.rb).
       attr_reader :file
 
-      # The line number portion of the line
+      # The line number portion of the line.
       attr_reader :number
 
-      # The method of the line (such as index)
+      # The method of the line (such as index).
       attr_reader :method
 
       # Filtered representations
@@ -22,9 +23,9 @@ module Honeybadger
 
       # Parses a single line of a given backtrace
       #
-      # unparsed_line - The raw line from +caller+ or some backtrace
+      # @param [String] unparsed_line The raw line from +caller+ or some backtrace.
       #
-      # Returns the parsed backtrace line
+      # @return The parsed backtrace line.
       def self.parse(unparsed_line, opts = {})
         filters = opts[:filters] || []
         filtered_line = filters.reduce(unparsed_line) do |line, proc|

--- a/lib/honeybadger/cli.rb
+++ b/lib/honeybadger/cli.rb
@@ -5,6 +5,7 @@ require 'thor'
 require 'honeybadger/cli/main'
 
 module Honeybadger
+  # @api private
   module CLI
     def self.start(*args)
       Main.start(*args)

--- a/lib/honeybadger/cli/heroku.rb
+++ b/lib/honeybadger/cli/heroku.rb
@@ -53,10 +53,10 @@ module Honeybadger
 
       private
 
-      # Internal: Detects the Heroku app name from GIT.
+      # Detects the Heroku app name from GIT.
       #
-      # prompt_on_default - If a single remote is discoverd, should we prompt the
-      #                     user before returning it?
+      # @param [Boolean] prompt_on_default If a single remote is discoverd,
+      #   should we prompt the user before returning it?
       #
       # Returns the String app name if detected, otherwise nil.
       def detect_heroku_app(prompt_on_default = true)

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -13,9 +13,9 @@ require 'honeybadger/util/revision'
 require 'honeybadger/logging'
 
 module Honeybadger
-  # Internal: The Config class is used to manage Honeybadger's initialization
-  # and configuration. Please don't depend on any internal classes or methods
-  # outside of Honeybadger as they may change without notice.
+  # @api private
+  # The Config class is used to manage Honeybadger's initialization and
+  # configuration.
   class Config
     extend Forwardable
 
@@ -124,6 +124,7 @@ module Honeybadger
     alias to_h to_hash
 
     # Internal Helpers
+
 
     def logger
       init_logging! unless @logger
@@ -241,9 +242,6 @@ module Honeybadger
       includes_token?(self[:plugins], name)
     end
 
-    # Match the project root.
-    #
-    # Returns Regexp matching the project root in a file string.
     def root_regexp
       return @root_regexp if @root_regexp
       return nil if @no_root
@@ -285,19 +283,12 @@ module Honeybadger
       set(:revision, Util::Revision.detect(self[:root]))
     end
 
-    # Optional path to honeybadger.log log file.
-    #
-    # Returns the Pathname log path if a log path was specified.
     def log_path
       return if log_stdout?
       return if !self[:'logging.path']
       locate_absolute_path(self[:'logging.path'], self[:root])
     end
 
-    # Path to honeybadger.yml configuration file; this should be the
-    # root directory if no path was specified.
-    #
-    # Returns the Pathname configuration path.
     def config_path
       config_paths.first
     end
@@ -370,12 +361,8 @@ module Honeybadger
       @logger = Logging::ConfigLogger.new(self, build_logger)
     end
 
-    # Does collection include the String value or Symbol value?
-    #
-    # obj - The Array object, if present.
-    # value - The value which may exist within Array obj.
-    #
-    # Returns true or false.
+    # Takes an Array and a value and returns true if the value exists in the
+    # array in String or Symbol form, otherwise false.
     def includes_token?(obj, value)
       return false unless obj.kind_of?(Array)
       obj.map(&:to_sym).include?(value.to_sym)

--- a/lib/honeybadger/const.rb
+++ b/lib/honeybadger/const.rb
@@ -1,12 +1,20 @@
 require 'honeybadger/version'
 
 module Honeybadger
-  # Autoloading allows middleware classes to be referenced in applications
-  # which include the optional Rack dependency without explicitly requiring
-  # these files.
   module Rack
+    # Autoloading allows middleware classes to be referenced in applications
+    # which include the optional Rack dependency without explicitly requiring
+    # these files.
     autoload :ErrorNotifier, 'honeybadger/rack/error_notifier'
     autoload :UserFeedback, 'honeybadger/rack/user_feedback'
     autoload :UserInformer, 'honeybadger/rack/user_informer'
+  end
+
+  # @api private
+  module Plugins
+  end
+
+  # @api private
+  module Util
   end
 end

--- a/lib/honeybadger/context_manager.rb
+++ b/lib/honeybadger/context_manager.rb
@@ -1,6 +1,7 @@
 require 'honeybadger/conversions'
 
 module Honeybadger
+  # @api private
   class ContextManager
     include Conversions
 
@@ -17,7 +18,8 @@ module Honeybadger
       _initialize
     end
 
-    # Internal accessors
+    # Internal helpers
+
 
     def set_context(hash)
       @mutex.synchronize do

--- a/lib/honeybadger/conversions.rb
+++ b/lib/honeybadger/conversions.rb
@@ -1,12 +1,13 @@
 module Honeybadger
+  # @api private
   module Conversions
     module_function
 
-    # Internal: Convert context into a Hash.
+    # Convert context into a Hash.
     #
-    # object - The context object.
+    # @param [Object] object The context object.
     #
-    # Returns the Hash context.
+    # @return [Hash] The hash context.
     def Context(object)
       object = object.to_honeybadger_context if object.respond_to?(:to_honeybadger_context)
       Hash(object)

--- a/lib/honeybadger/init/rake.rb
+++ b/lib/honeybadger/init/rake.rb
@@ -1,7 +1,8 @@
 require 'honeybadger/ruby'
 
-# Patch Rake::Application to handle errors with Honeybadger
 module Honeybadger
+  # @api private
+  # Patch Rake::Application to handle errors with Honeybadger
   module RakeHandler
     def self.included(klass)
       klass.class_eval do

--- a/lib/honeybadger/logging.rb
+++ b/lib/honeybadger/logging.rb
@@ -4,13 +4,14 @@ require 'delegate'
 require 'forwardable'
 
 module Honeybadger
+  # @api private
   module Logging
     PREFIX = '** [Honeybadger] '.freeze
 
-    # Internal: Logging helper methods. Requires a Honeybadger::Config @config
-    # instance variable to exist and/or #logger to be defined. Each
-    # method is defined/block captured in this module rather than delegating to
-    # the logger directly to avoid extra object allocation.
+    # Logging helper methods. Requires a Honeybadger::Config @config instance
+    # variable to exist and/or #logger to be defined. Each method is
+    # defined/block captured in this module rather than delegating to the
+    # logger directly to avoid extra object allocation.
     module Helper
       private
       def debug(msg = nil)

--- a/lib/honeybadger/plugin.rb
+++ b/lib/honeybadger/plugin.rb
@@ -1,6 +1,7 @@
 require 'forwardable'
 
 module Honeybadger
+  # @api private
   class Plugin
     CALLER_FILE = Regexp.new('\A(?:\w:)?([^:]+)(?=(:\d+))').freeze
 
@@ -94,9 +95,8 @@ module Honeybadger
       false
     end
 
-    # Private: Used for testing only; don't normally call this. :)
-    #
-    # Returns nothing
+    # @private
+    # Used for testing only; don't normally call this. :)
     def reset!
       @loaded = false
     end

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -4,15 +4,15 @@ module Honeybadger
   module Plugins
     module Rails
       module ExceptionsCatcher
-        # Internal: Adds additional Honeybadger info to Request env when an
+        # Adds additional Honeybadger info to Request env when an
         # exception is rendered in Rails' middleware.
         #
-        # arg       - The Rack env Hash in Rails 3.0-4.2. After Rails 5 arg is
-        #             an ActionDispatch::Request.
-        # exception - The Exception which was rescued.
+        # @param [Hash, ActionDispatch::Request] arg The Rack env +Hash+ in
+        #   Rails 3.0-4.2. After Rails 5 +arg+ is an +ActionDispatch::Request+.
+        # @param [Exception] exception The error which was rescued.
         #
-        # Returns the super value of the middleware's #render_exception()
-        # method.
+        # @return The super value of the middleware's +#render_exception()+
+        #   method.
         def render_exception(arg, exception)
           if arg.kind_of?(::ActionDispatch::Request)
             request = arg

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -5,7 +5,7 @@ module Honeybadger
   module Plugins
     module Resque
       module Extension
-        # Executed before `on_failure` hook; the flush is necessary so that
+        # Executed before +on_failure+ hook; the flush is necessary so that
         # errors reported within jobs get sent before the worker dies.
         def around_perform_with_honeybadger(*args)
           Honeybadger.flush { yield }
@@ -13,8 +13,8 @@ module Honeybadger
           Honeybadger.context.clear!
         end
 
-        # Error notifications must be synchronous as the `on_failure` hook is
-        # executed after `around_perform`.
+        # Error notifications must be synchronous as the +on_failure+ hook is
+        # executed after +around_perform+.
         def on_failure_with_honeybadger(e, *args)
           Honeybadger.notify(e, parameters: { job_arguments: args }, sync: true) if send_exception_to_honeybadger?(e, args)
         end

--- a/lib/honeybadger/rack/error_notifier.rb
+++ b/lib/honeybadger/rack/error_notifier.rb
@@ -5,11 +5,10 @@ require 'honeybadger/ruby'
 
 module Honeybadger
   module Rack
-    # Public: Middleware for Rack applications. Any errors raised by the upstream
+    # Middleware for Rack applications. Any errors raised by the upstream
     # application will be delivered to Honeybadger and re-raised.
     #
-    # Examples
-    #
+    # @example
     #   require 'honeybadger/rack/error_notifier'
     #
     #   app = Rack::Builder.app do

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -16,8 +16,8 @@ end
 
 module Honeybadger
   module Rack
-    # Public: Middleware for Rack applications. Adds a feedback form to the
-    # Rack response when an error has occurred.
+    # Middleware for Rack applications. Adds a feedback form to the Rack
+    # response when an error has occurred.
     class UserFeedback
       extend Forwardable
 
@@ -41,25 +41,31 @@ module Honeybadger
         [status, headers, body]
       end
 
+      # @private
+      # @todo Make this method and others actually private.
       def action
         URI.parse("#{config.connection_protocol}://#{config[:'connection.host']}:#{config.connection_port}/v1/feedback/").to_s
       rescue URI::InvalidURIError
         nil
       end
 
+      # @private
       def render_form(error_id, action = action())
         return unless action
         ERB.new(@template ||= File.read(template_file)).result(binding)
       end
 
+      # @private
       def custom_template_file
         @custom_template_file ||= File.join(config[:root], 'lib', 'honeybadger', 'templates', 'feedback_form.erb')
       end
 
+      # @private
       def custom_template_file?
         custom_template_file && File.exist?(custom_template_file)
       end
 
+      # @private
       def template_file
         if custom_template_file?
           custom_template_file

--- a/lib/honeybadger/rack/user_informer.rb
+++ b/lib/honeybadger/rack/user_informer.rb
@@ -2,8 +2,8 @@ require 'forwardable'
 
 module Honeybadger
   module Rack
-    # Public: Middleware for Rack applications. Adds an error ID to the Rack
-    # response when an error has occurred.
+    # Middleware for Rack applications. Adds an error ID to the Rack response
+    # when an error has occurred.
     class UserInformer
       extend Forwardable
 

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -25,7 +25,6 @@ module Honeybadger
   #   @!method $2(...)
   #     Forwards to {$1}.
   #     @see Agent#$2
-  def_delegator :'Honeybadger::Agent.instance', :notify
   def_delegator :'Honeybadger::Agent.instance', :check_in
   def_delegator :'Honeybadger::Agent.instance', :context
   def_delegator :'Honeybadger::Agent.instance', :configure
@@ -44,6 +43,15 @@ module Honeybadger
   def_delegator :'Honeybadger::Agent.instance', :config
   def_delegator :'Honeybadger::Agent.instance', :init!
   def_delegator :'Honeybadger::Agent.instance', :with_rack_env
+
+  # @!method notify(...)
+  # Forwards to {Agent.instance}.
+  # @see Agent#notify
+  def notify(exception_or_opts, opts = {})
+    # Note this is defined directly (instead of via forwardable) so that
+    # generated stack traces work as expected.
+    Agent.instance.notify(exception_or_opts, opts)
+  end
 
   # @api private
   def load_plugins!

--- a/lib/honeybadger/util/request_hash.rb
+++ b/lib/honeybadger/util/request_hash.rb
@@ -2,8 +2,8 @@ require 'set'
 
 module Honeybadger
   module Util
-    # Internal: Constructs a request hash from a Rack::Request matching the
-    # /v1/notices API specification.
+    # Constructs a request hash from a Rack::Request matching the /v1/notices
+    # API specification.
     module RequestHash
       HTTP_HEADER_PREFIX = 'HTTP_'.freeze
 

--- a/lib/honeybadger/util/request_payload.rb
+++ b/lib/honeybadger/util/request_payload.rb
@@ -2,9 +2,9 @@ require 'honeybadger/util/sanitizer'
 
 module Honeybadger
   module Util
-    # Internal: Constructs/sanitizes request data for notices
+    # Constructs/sanitizes request data for notices
     module RequestPayload
-      # Internal: Default values to use for request data.
+      # Default values to use for request data.
       DEFAULTS = {
         url: nil,
         component: nil,
@@ -14,10 +14,10 @@ module Honeybadger
         cgi_data: {}.freeze
       }.freeze
 
-      # Internal: Allowed keys.
+      # Allowed keys.
       KEYS = DEFAULTS.keys.freeze
 
-      # Internal: The cgi_data key where the raw Cookie header is stored.
+      # The cgi_data key where the raw Cookie header is stored.
       HTTP_COOKIE_KEY = 'HTTP_COOKIE'.freeze
 
       def self.build(opts = {})

--- a/lib/honeybadger/util/revision.rb
+++ b/lib/honeybadger/util/revision.rb
@@ -10,8 +10,8 @@ module Honeybadger
 
         private
 
-        # Requires (currently) alpha platform feature
-        # `heroku labs:enable runtime-dyno-metadata`
+        # Requires (currently) alpha platform feature `heroku labs:enable
+        # runtime-dyno-metadata`
         #
         # See https://devcenter.heroku.com/articles/dyno-metadata
         def from_heroku

--- a/lib/honeybadger/util/sanitizer.rb
+++ b/lib/honeybadger/util/sanitizer.rb
@@ -5,8 +5,8 @@ require 'honeybadger/conversions'
 
 module Honeybadger
   module Util
-    # Internal: Sanitizer sanitizes data for sending to Honeybadger's API. The
-    # filters are based on Rails' HTTP parameter filter.
+    # Sanitizer sanitizes data for sending to Honeybadger's API. The filters
+    # are based on Rails' HTTP parameter filter.
     class Sanitizer
       COOKIE_PAIRS = /[;,]\s?/
       COOKIE_SEP = '='.freeze

--- a/lib/honeybadger/version.rb
+++ b/lib/honeybadger/version.rb
@@ -1,4 +1,4 @@
 module Honeybadger
-  # Public: The current String Honeybadger version.
+  # The current String Honeybadger version.
   VERSION = '3.2.0'.freeze
 end

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -4,16 +4,17 @@ require 'net/http'
 require 'honeybadger/logging'
 
 module Honeybadger
-  # Internal: A concurrent queue to notify the backend.
+  # A concurrent queue to notify the backend.
+  # @api private
   class Worker
     extend Forwardable
 
     include Honeybadger::Logging::Helper
 
-    # Internal: Sub-class thread so we have a named thread (useful for debugging in Thread.list).
+    # Sub-class thread so we have a named thread (useful for debugging in Thread.list).
     class Thread < ::Thread; end
 
-    # Internal: A queue which enforces a maximum size.
+    # A queue which enforces a maximum size.
     class Queue < ::Queue
       attr_reader :max_size
 
@@ -48,9 +49,6 @@ module Honeybadger
       handle_response(msg, notify_backend(msg))
     end
 
-    # Internal: Shutdown the worker after sending remaining data.
-    #
-    # Returns true.
     def shutdown
       d { 'shutting down worker' }
 
@@ -91,9 +89,7 @@ module Honeybadger
       true
     end
 
-    # Internal: Blocks until queue is processed up to this point in time.
-    #
-    # Returns nothing.
+    # Blocks until queue is processed up to this point in time.
     def flush
       mutex.synchronize do
         if thread && thread.alive?
@@ -226,19 +222,12 @@ module Honeybadger
       end
     end
 
-    # Internal: Release the marker. Important to perform during cleanup when
-    # shutting down, otherwise it could end up waiting indefinitely.
-    #
-    # Returns nothing.
+    # Release the marker. Important to perform during cleanup when shutting
+    # down, otherwise it could end up waiting indefinitely.
     def release_marker
       signal_marker(marker)
     end
 
-    # Internal: Signal a marker.
-    #
-    # marker - The ConditionVariable marker to signal.
-    #
-    # Returns nothing.
     def signal_marker(marker)
       mutex.synchronize do
         marker.signal


### PR DESCRIPTION
This will allow us to use rubydoc.info as a resource for folks who want to deep-dive into the gem's API.

All internal classes and methods have been marked with the `# @api private` tag, which means they are not part of the public api and should not be used outside of the honeybadger gem. Anything not marked `@api private` (or explicitly marked `@api pubic`) should be free to use. YARD includes a helpful note when something is `@api private`, warning the user not to depend on it.

There is also one usage of the `@private` tag, which is different. From the docs:

> This tag [`@private`] should only be used to mark objects private when Ruby visibility rules cannot do so.

I'm using it to hide a method that is public for the purpose of testing.