### PR TITLE
Fix at_exit callback being skipped in a rails app with sinatra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Use a unique route name in rails to avoid name conflicts.
 - Use prepend to add Sidekiq Middleware to fix context getting cleared.
+- Fix at_exit callback being skipped in rails apps with a sinatra dependency.
 
 ## [3.2.0] - 2017-11-27
 ### Changed

--- a/lib/honeybadger.rb
+++ b/lib/honeybadger.rb
@@ -9,10 +9,3 @@ end
 if defined?(Rake.application)
   require 'honeybadger/init/rake'
 end
-
-# Sinatra is a special case. Sinatra starts the web application in an at_exit
-# handler. And, since we require sinatra before requiring HB, the only way to
-# setup our at_exit callback is in the sinatra build callback honeybadger/init/sinatra.rb
-if !defined?(Sinatra::Base)
-  Honeybadger.install_at_exit_callback
-end

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -31,3 +31,5 @@ module Honeybadger
     end
   end
 end
+
+Honeybadger.install_at_exit_callback

--- a/lib/honeybadger/init/ruby.rb
+++ b/lib/honeybadger/init/ruby.rb
@@ -7,3 +7,5 @@ Honeybadger.init!({
 })
 
 Honeybadger.load_plugins!
+
+Honeybadger.install_at_exit_callback

--- a/lib/honeybadger/init/sinatra.rb
+++ b/lib/honeybadger/init/sinatra.rb
@@ -9,6 +9,9 @@ module Honeybadger
           def build_with_honeybadger(*args, &block)
             configure_honeybadger
             install_honeybadger
+            # Sinatra is a special case. Sinatra starts the web application in an at_exit
+            # handler. And, since we require sinatra before requiring HB, the only way to
+            # setup our at_exit callback is in the sinatra build callback honeybadger/init/sinatra.rb
             Honeybadger.install_at_exit_callback
             build_without_honeybadger(*args, &block)
           end


### PR DESCRIPTION
When a rails app had a dependency on sinatra (imported in gems like resque), the
at_exit callback wasn't being set up at all. This fixes it by explicitly
setting up the at_exit callbacks in rails and ruby init scripts