### PR TITLE
Add new Rack exceptions to default ignore list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Use a unique route name in rails to avoid name conflicts.
 - Use prepend to add Sidekiq Middleware to fix context getting cleared.
 - Fix at_exit callback being skipped in rails apps with a sinatra dependency.
-- Add Rack::QueryParser::ParameterTypeError and Rack::QueryParser::InvalidParameterError to default ignore list
+- Add `Rack::QueryParser::ParameterTypeError` and
+  `Rack::QueryParser::InvalidParameterError` to default ignore list.
 
 ## [3.2.0] - 2017-11-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Use a unique route name in rails to avoid name conflicts.
 - Use prepend to add Sidekiq Middleware to fix context getting cleared.
 - Fix at_exit callback being skipped in rails apps with a sinatra dependency.
+- Add Rack::QueryParser::ParameterTypeError and Rack::QueryParser::InvalidParameterError to default ignore list
 
 ## [3.2.0] - 2017-11-27
 ### Changed

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -17,6 +17,8 @@ module Honeybadger
                       'ActionController::ParameterMissing',
                       'ActiveRecord::RecordNotFound',
                       'ActionController::UnknownAction',
+                      'Rack::QueryParser::ParameterTypeError',
+                      'Rack::QueryParser::InvalidParameterError',
                       'CGI::Session::CookieStore::TamperedWithCookie',
                       'Mongoid::Errors::DocumentNotFound',
                       'Sinatra::NotFound'].map(&:freeze).freeze


### PR DESCRIPTION
Rails 5 uses Rack 2 which introduces two new exception classes to indicate poorly formatted parameters.

- Rack::QueryParser::InvalidParameterError
- Rack::QueryParser::ParameterTypeError

Both of these are turned in to 400 Bad Requests automatically by ActionDispatch, yet still get reported to Honeybadger by default. These should be treated like ActionDispatch::ParamsParser::ParseError and ActionController::BadRequest
