### PR TITLE
Fix logging bug in before_notify feature

### DIFF
--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -70,7 +70,7 @@ module Honeybadger
       end
 
       def logger
-        get(:logger)
+        get(:logger) || config.logger
       end
 
       def backend=(backend)
@@ -78,7 +78,7 @@ module Honeybadger
       end
 
       def backend
-        get(:backend)
+        get(:backend) || config.backend
       end
 
       def backtrace_filter


### PR DESCRIPTION
This fixes a bug where the logger isn't initialized when logging in `Config::Ruby`. The #logger and #backend methods both do some lazy initialization which wasn't being performed.