### PR TITLE
Add latest jruby version to the travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       gemfile: gemfiles/rails.gemfile
     - rvm: 2.5.0
       gemfile: gemfiles/rails.gemfile
-    - rvm: jruby-9.1.4.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails.gemfile
   exclude:
     - rvm: 2.1.10
@@ -65,11 +65,11 @@ matrix:
       gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.5.0
       gemfile: gemfiles/rails4.2.gemfile
-    - rvm: jruby-9.1.4.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/binding_of_caller.gemfile
     # activesupport 4.0 depends on minitest ~> 4.2, Ruby 2.3 bundles minitest
     # 5. This isn't a problem locally, but it blows up Travis for some reason.
-    - rvm: jruby-9.1.4.0
+    - rvm: jruby-9.1.7.0
       gemfile: gemfiles/rails4.0.gemfile
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ rvm:
   - 2.4.0
   - 2.5.0
   - jruby-9.1.4.0
+  - jruby-9.1.7.0
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ rvm:
   - 2.3.3
   - 2.4.0
   - 2.5.0
-  - jruby-9.1.4.0
   - jruby-9.1.7.0
 matrix:
   fast_finish: true


### PR DESCRIPTION
This was a small fix, so I added it before asking. Should we just update the version of jruby instead of adding a new patch version? Maybe this isn't even necessary. This would increase the build times of our already slow travis jobs.