### PR TITLE
Make notice options assignable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ adheres to [Semantic Versioning](http://semver.org/).
   hooks which will be invoked with a `notice` before a `notice` is sent. Each
   `before_notify` hook MUST be a `callable` (lambda, Proc etc,) with an arity of 1.
 - Added the ability to halt notices in callbacks using `notice.halt!`
+- Make essential attributes on Notice writable:
+  ```ruby
+  Honeybadger.configure do |config|
+    config.before_notify do |notice|
+      notice.api_key = 'custom api key',
+      notice.error_message = "badgers!",
+      notice.error_class = 'MyError',
+      notice.backtrace = ["/path/to/file.rb:5 in `method'"],
+      notice.fingerprint = 'some unique string',
+      notice.tags = ['foo', 'bar'],
+      notice.context = { user: 33 },
+      notice.controller = 'MyController',
+      notice.action = 'index',
+      notice.parameters = { q: 'badgers?' },
+      notice.session = { uid: 42 },
+      notice.url = "/badgers",
+    end
+  end
+  ```
 
 ### Fixed
 - Ignore SIGTERM SignalExceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ adheres to [Semantic Versioning](http://semver.org/).
   ```ruby
   notice[:context] # => {}
   ```
+- The public method `Notice#fingerprint` now returns the original
+  String which was passed in from the `:fingerprint` option or the
+  `exception_fingerprint` callback, not a SHA1 hashed value. The value is
+  still hashed before sending through to the API.
 
 ## [3.3.0] - 2018-01-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ adheres to [Semantic Versioning](http://semver.org/).
   ```ruby
   notice.backtrace # => ["/path/to/file.rb:5 in `method'"]
   ```
+- `notice[:context]` now defaults to an empty Hash instead of nil.
+
+  Before:
+  ```ruby
+  notice[:context] # => nil
+  ```
+
+  After:
+  ```ruby
+  notice[:context] # => {}
+  ```
 
 ## [3.3.0] - 2018-01-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Ignore SIGTERM SignalExceptions.
 
+### Changed
+- The public method `Notice#backtrace` is now exposed as the raw Ruby
+  backtrace instead of an instance of `Honeybadger::Backtrace` (a private
+  class).
+
+  Before:
+  ```ruby
+  notice.backtrace # => #<Honeybadger::Backtrace>
+  ```
+
+  After:
+  ```ruby
+  notice.backtrace # => ["/path/to/file.rb:5 in `method'"]
+  ```
+
 ## [3.3.0] - 2018-01-29
 ### Changed
 - Use prepend to add Sidekiq Middleware to fix context getting cleared.

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -66,7 +66,7 @@ module Honeybadger
     attr_reader :cause
 
     # The backtrace from the given exception or hash.
-    attr_reader :backtrace
+    attr_accessor :backtrace
 
     # Custom fingerprint for error, used to group similar errors together.
     attr_reader :fingerprint
@@ -159,7 +159,8 @@ module Honeybadger
       @error_message = exception_attribute(:error_message, 'No message provided') do |exception|
         "#{exception.class.name}: #{exception.message}"
       end
-      @backtrace = parse_backtrace(exception_attribute(:backtrace, caller))
+
+      self.backtrace = exception_attribute(:backtrace, caller)
 
       @request = construct_request_hash(config, opts)
 
@@ -198,7 +199,7 @@ module Honeybadger
           token: id,
           class: s(error_class),
           message: s(error_message),
-          backtrace: s(backtrace.to_a),
+          backtrace: s(parse_backtrace(backtrace)),
           fingerprint: s(fingerprint),
           tags: s(tags),
           causes: s(causes)
@@ -457,7 +458,7 @@ module Honeybadger
         filters: construct_backtrace_filters(opts),
         config: config,
         source_radius: config[:'exceptions.source_radius']
-      )
+      ).to_a
     end
 
     # Unwrap the exception so that original exception is ignored or
@@ -499,7 +500,7 @@ module Honeybadger
         causes << {
           class: c.class.name,
           message: c.message,
-          backtrace: parse_backtrace(c.backtrace || caller).to_a
+          backtrace: parse_backtrace(c.backtrace || caller)
         }
         i += 1
         c = exception_cause(c)

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -73,6 +73,9 @@ module Honeybadger
 
     # Tags which will be applied to error.
     attr_reader :tags
+    def tags=(tags)
+      @tags = construct_tags(tags)
+    end
 
     # The name of the class of error (example: RuntimeError).
     attr_reader :error_class
@@ -169,8 +172,8 @@ module Honeybadger
       @cause = opts[:cause] || exception_cause(@exception) || $!
       @causes = unwrap_causes(@cause)
 
-      @tags = construct_tags(opts[:tags])
-      @tags = construct_tags(context[:tags]) | @tags if context
+      self.tags = opts[:tags]
+      self.tags = tags | construct_tags(context[:tags]) if context
 
       @stats = Util::Stats.all
 

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -78,10 +78,10 @@ module Honeybadger
     end
 
     # The name of the class of error (example: RuntimeError).
-    attr_reader :error_class
+    attr_accessor :error_class
 
     # The message from the exception, or a general description of the error.
-    attr_reader :error_message
+    attr_accessor :error_message
 
     # Deprecated: Excerpt from source file.
     attr_reader :source
@@ -158,8 +158,8 @@ module Honeybadger
       @request_sanitizer = Util::Sanitizer.new(filters: params_filters)
 
       @exception = unwrap_exception(opts[:exception])
-      @error_class = exception_attribute(:error_class, 'Notice') {|exception| exception.class.name }
-      @error_message = exception_attribute(:error_message, 'No message provided') do |exception|
+      self.error_class = exception_attribute(:error_class, 'Notice') {|exception| exception.class.name }
+      self.error_message = exception_attribute(:error_message, 'No message provided') do |exception|
         "#{exception.class.name}: #{exception.message}"
       end
 

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -83,9 +83,6 @@ module Honeybadger
     # The message from the exception, or a general description of the error.
     attr_accessor :error_message
 
-    # Deprecated: Excerpt from source file.
-    attr_reader :source
-
     # CGI variables such as HTTP_METHOD.
     def cgi_data; @request[:cgi_data]; end
 
@@ -110,8 +107,11 @@ module Honeybadger
     # Local variables are extracted from first frame of backtrace.
     attr_reader :local_variables
 
-    # Public: The API key used to deliver this notice.
+    # The API key used to deliver this notice.
     attr_accessor :api_key
+
+    # Deprecated: Excerpt from source file.
+    attr_reader :source
 
     # @api private
     # Cache project path substitutions for backtrace lines.

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -182,7 +182,7 @@ module Honeybadger
 
       self.local_variables = local_variables_from_exception(exception, config)
 
-      @api_key = opts[:api_key] || config[:api_key]
+      self.api_key = opts[:api_key] || config[:api_key]
 
       monkey_patch_action_dispatch_test_process!
 

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -83,6 +83,9 @@ module Honeybadger
     # The message from the exception, or a general description of the error.
     attr_accessor :error_message
 
+    # The context Hash.
+    attr_accessor :context
+
     # CGI variables such as HTTP_METHOD.
     def cgi_data; @request[:cgi_data]; end
 
@@ -167,7 +170,7 @@ module Honeybadger
 
       @request = construct_request_hash(config, opts)
 
-      @context = construct_context_hash(opts, exception)
+      self.context = construct_context_hash(opts, exception)
 
       @cause = opts[:cause] || exception_cause(@exception) || $!
       @causes = unwrap_causes(@cause)
@@ -265,7 +268,7 @@ module Honeybadger
 
     private
 
-    attr_reader :config, :opts, :context, :stats, :now, :pid, :causes,
+    attr_reader :config, :opts, :stats, :now, :pid, :causes,
       :request_sanitizer, :rack_env
 
     def ignore_by_origin?
@@ -372,7 +375,7 @@ module Honeybadger
       context.merge!(Context(opts[:global_context]))
       context.merge!(exception_context(exception))
       context.merge!(Context(opts[:context]))
-      context.empty? ? nil : context
+      context
     end
 
     def fingerprint_from_opts(opts)

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -87,25 +87,24 @@ module Honeybadger
     attr_accessor :context
 
     # CGI variables such as HTTP_METHOD.
-    def cgi_data; @request[:cgi_data]; end
+    attr_accessor :cgi_data
 
     # A hash of parameters from the query string or post body.
-    def params; @request[:params]; end
+    attr_accessor :params
     alias_method :parameters, :params
 
     # The component (if any) which was used in this request (usually the controller).
-    def component; @request[:component]; end
+    attr_accessor :component
     alias_method :controller, :component
 
     # The action (if any) that was called in this request.
-    def action; @request[:action]; end
+    attr_accessor :action
 
     # A hash of session data from the request.
-    def_delegator :@request, :session
-    def session; @request[:session]; end
+    attr_accessor :session
 
     # The URL at which the error occurred (if any).
-    def url; @request[:url]; end
+    attr_accessor :url
 
     # Local variables are extracted from first frame of backtrace.
     attr_accessor :local_variables
@@ -159,10 +158,10 @@ module Honeybadger
 
       @rack_env = opts.fetch(:rack_env, nil)
       @request_sanitizer = Util::Sanitizer.new(filters: params_filters)
-      @request = construct_request_hash(config, opts)
 
       @exception = unwrap_exception(opts[:exception])
       @cause = opts[:cause] || exception_cause(@exception) || $!
+
       @causes = unwrap_causes(@cause)
 
       self.error_class = exception_attribute(:error_class, 'Notice') {|exception| exception.class.name }
@@ -176,7 +175,14 @@ module Honeybadger
       self.api_key = opts[:api_key] || config[:api_key]
       self.tags = construct_tags(opts[:tags]) | construct_tags(context[:tags])
 
-      monkey_patch_action_dispatch_test_process!
+      self.url       = opts[:url]        || request_hash[:url]      || nil
+      self.action    = opts[:action]     || request_hash[:action]   || nil
+      self.component = opts[:controller] || opts[:component]        || request_hash[:component] || nil
+      self.params    = opts[:parameters] || opts[:params]           || request_hash[:params] || {}
+      self.session   = opts[:session]    || request_hash[:session]  || {}
+      self.cgi_data  = opts[:cgi_data]   || request_hash[:cgi_data] || {}
+
+      self.session = opts[:session][:data] if opts[:session] && opts[:session][:data]
 
       # Fingerprint must be calculated last since callback operates on `self`.
       self.fingerprint = fingerprint_from_opts(opts)
@@ -187,8 +193,9 @@ module Honeybadger
     #
     # @return [Hash] JSON representation of notice.
     def as_json(*args)
-      @request[:context] = s(context)
-      @request[:local_variables] = local_variables if local_variables
+      request = construct_request_hash
+      request[:context] = s(context)
+      request[:local_variables] = local_variables if local_variables
 
       {
         api_key: s(api_key),
@@ -202,7 +209,7 @@ module Honeybadger
           tags: s(tags),
           causes: s(causes)
         },
-        request: @request,
+        request: request,
         server: {
           project_root: s(config[:root]),
           revision: s(config[:revision]),
@@ -332,21 +339,23 @@ module Honeybadger
     end
 
     def request_hash
-      return {} unless rack_env
-      Util::RequestHash.from_env(rack_env)
+      @request_hash ||= Util::RequestHash.from_env(rack_env)
     end
 
-    # Construct the request object with data from various sources.
+    # Construct the request data.
     #
-    # Returns Request.
-    def construct_request_hash(config, opts)
-      request = {}
-      request.merge!(request_hash)
-      request.merge!(opts)
-      request[:component] = opts[:controller] if opts.has_key?(:controller)
-      request[:params] = opts[:parameters] if opts.has_key?(:parameters)
+    # Returns Hash request data.
+    def construct_request_hash
+      request = {
+        url: url,
+        component: component,
+        action: action,
+        params: params,
+        session: session,
+        cgi_data: cgi_data,
+        sanitizer: request_sanitizer
+      }
       request.delete_if {|k,v| config.excluded_request_keys.include?(k) }
-      request[:sanitizer] = request_sanitizer
       Util::RequestPayload.build(request)
     end
 
@@ -512,40 +521,5 @@ module Honeybadger
     def rails_params_filters
       rack_env && Array(rack_env['action_dispatch.parameter_filter']) or []
     end
-
-    # This is how much Honeybadger cares about Rails developers. :)
-    #
-    # Some Rails projects include ActionDispatch::TestProcess globally for the
-    # use of `fixture_file_upload` in tests. This is a bad practice because it
-    # includes other methods -- such as #session -- which override existing
-    # methods on *all objects*. This creates the following bug in Notice:
-    #
-    # When you call #session on any object which had previously defined it
-    # (such as OpenStruct), that newly defined method calls #session on
-    # +@request+ (defined in `ActionDispatch::TestProcess`), and if +@request+
-    # doesn't exist in that object, it calls #session *again* on `nil`, which
-    # also inherited it from Object, resulting in a SystemStackError.
-    #
-    # See https://stackoverflow.com/questions/18202261/include-actiondispatchtestprocess-prevents-guard-from-reloading-properly
-    # for more info.
-    #
-    # This method restores the correct #session method on @request and warns
-    # the user of the issue.
-    #
-    # Returns nothing.
-    def monkey_patch_action_dispatch_test_process!
-      return unless defined?(ActionDispatch::TestProcess) && defined?(self.fixture_file_upload)
-
-      STDOUT.puts('WARNING: It appears you may be including ActionDispatch::TestProcess globally. Check out https://www.honeybadger.io/s/adtp for more info.')
-
-      def @request.session
-        @table[:session]
-      end
-
-      def self.session
-        @request.session
-      end
-    end
-
   end
 end

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -69,7 +69,7 @@ module Honeybadger
     attr_accessor :backtrace
 
     # Custom fingerprint for error, used to group similar errors together.
-    attr_reader :fingerprint
+    attr_accessor :fingerprint
 
     # Tags which will be applied to error.
     attr_reader :tags
@@ -187,7 +187,7 @@ module Honeybadger
       monkey_patch_action_dispatch_test_process!
 
       # Fingerprint must be calculated last since callback operates on `self`.
-      @fingerprint = construct_fingerprint(opts)
+      self.fingerprint = fingerprint_from_opts(opts)
     end
 
     # @api private
@@ -206,7 +206,7 @@ module Honeybadger
           class: s(error_class),
           message: s(error_message),
           backtrace: s(parse_backtrace(backtrace)),
-          fingerprint: s(fingerprint),
+          fingerprint: fingerprint_hash,
           tags: s(tags),
           causes: s(causes)
         },
@@ -389,11 +389,9 @@ module Honeybadger
       end
     end
 
-    def construct_fingerprint(opts)
-      fingerprint = fingerprint_from_opts(opts)
-      if fingerprint && fingerprint.respond_to?(:to_s)
-        Digest::SHA1.hexdigest(fingerprint.to_s)
-      end
+    def fingerprint_hash
+      return unless fingerprint
+      Digest::SHA1.hexdigest(fingerprint.to_s)
     end
 
     def construct_tags(tags)

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -108,7 +108,7 @@ module Honeybadger
     def url; @request[:url]; end
 
     # Local variables are extracted from first frame of backtrace.
-    attr_reader :local_variables
+    attr_accessor :local_variables
 
     # The API key used to deliver this notice.
     attr_accessor :api_key
@@ -180,7 +180,7 @@ module Honeybadger
 
       @stats = Util::Stats.all
 
-      @local_variables = local_variables_from_exception(exception, config)
+      self.local_variables = local_variables_from_exception(exception, config)
 
       @api_key = opts[:api_key] || config[:api_key]
 

--- a/lib/honeybadger/util/request_hash.rb
+++ b/lib/honeybadger/util/request_hash.rb
@@ -26,6 +26,7 @@ module Honeybadger
 
       def self.from_env(env)
         return {} unless defined?(::Rack::Request)
+        return {} unless env
 
         hash, request = {}, ::Rack::Request.new(env)
 

--- a/lib/honeybadger/util/request_payload.rb
+++ b/lib/honeybadger/util/request_payload.rb
@@ -29,7 +29,6 @@ module Honeybadger
           payload[key] = sanitizer.sanitize(opts[key])
         end
 
-        payload[:session] = opts[:session][:data] if opts[:session] && opts[:session][:data]
         payload[:url] = sanitizer.filter_url(payload[:url]) if payload[:url]
         if payload[:cgi_data][HTTP_COOKIE_KEY]
           payload[:cgi_data][HTTP_COOKIE_KEY] = sanitizer.filter_cookies(payload[:cgi_data][HTTP_COOKIE_KEY])

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -51,7 +51,7 @@ describe Honeybadger::Agent do
       instance = described_class.new(config)
 
       expect(instance.worker).to receive(:push) do |notice|
-        expect(notice.backtrace.to_a[0][:file]).to eq('[PROJECT_ROOT]/spec/unit/honeybadger/agent_spec.rb')
+        expect(notice.backtrace.to_a[0]).to match('lib/honeybadger/agent.rb')
       end
 
       instance.notify(error_message: 'testing backtrace generation')

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -301,7 +301,7 @@ describe Honeybadger::Notice do
 
     it "skips exception context when method isn't defined" do
       notice = build_notice(exception: RuntimeError.new)
-      expect(notice[:request][:context]).to be_nil
+      expect(notice[:request][:context]).to eq({})
     end
 
     it "merges context in order of precedence: local, exception, global" do
@@ -334,9 +334,9 @@ describe Honeybadger::Notice do
       expect { build_notice(global_context: global_context, context: hash) }.not_to change { hash }
     end
 
-    it "returns nil context when context is not set" do
+    it "returns empty Hash when context is not set" do
       notice = build_notice
-      expect(notice[:request][:context]).to be_nil
+      expect(notice[:request][:context]).to eq({})
     end
 
     it "allows falsey values in context" do

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -791,8 +791,12 @@ describe Honeybadger::Notice do
 
     context "from both" do
       it "merges tags" do
-        expect(build_notice(tags: 'baz', context: { tags: ' foo  , bar ' }).tags).to eq(%w(foo bar baz))
+        expect(build_notice(tags: 'foo , bar', context: { tags: ' foo , baz ' }).tags).to eq(%w(foo bar baz))
       end
+    end
+
+    it "converts nil to empty Array" do
+      expect(build_notice(tags: nil).tags).to eq([])
     end
   end
 

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -547,23 +547,28 @@ describe Honeybadger::Notice do
 
     it "accepts fingerprint as string" do
       notice = build_notice({fingerprint: 'foo' })
-      expect(notice.fingerprint).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
+      expect(notice.fingerprint).to eq 'foo'
+      expect(notice.as_json[:error][:fingerprint]).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
     end
 
     it "accepts fingerprint responding to #call" do
       notice = build_notice({fingerprint: double(call: 'foo')})
-      expect(notice.fingerprint).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
+      expect(notice.fingerprint).to eq 'foo'
+      expect(notice.as_json[:error][:fingerprint]).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
     end
 
     it "accepts fingerprint using #to_s" do
-      notice = build_notice({fingerprint: double(to_s: 'foo')})
-      expect(notice.fingerprint).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
+      object = double(to_s: 'foo')
+      notice = build_notice({fingerprint: object})
+      expect(notice.fingerprint).to eq object
+      expect(notice.as_json[:error][:fingerprint]).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
     end
 
     context "fingerprint is a callback which accesses notice" do
       it "can access request information" do
         notice = build_notice({params: { key: 'foo' }, fingerprint: lambda {|n| n[:params][:key] }})
-        expect(notice.fingerprint).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
+        expect(notice.fingerprint).to eq 'foo'
+        expect(notice.as_json[:error][:fingerprint]).to eq '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'
       end
     end
   end

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -529,13 +529,31 @@ describe Honeybadger::Notice do
     end
   end
 
-  describe "#api_key=" do
-    it "can override the API key for the notice" do
-      notice = build_notice
+  describe 'public attributes' do
+    it 'assigns the same values from each opt and setter method' do
+      opts = {
+        api_key: 'custom api key',
+        error_message: 'badgers!',
+        error_class: 'MyError',
+        backtrace: ["/path/to/file.rb:5 in `method'"],
+        fingerprint: 'some unique string',
+        tags: ['foo', 'bar'],
+        context: { user: 33 },
+        # TODO
+        # controller: 'AuthController',
+        # action: 'become_admin',
+        # parameters: { q: 'Marcus Aurelius' },
+        # session: { uid: 42 },
+        # url: "/surfs-up",
+      }
 
-      notice.api_key = "Hello, world"
-
-      expect(notice.api_key).to eq("Hello, world")
+      opts_notice = build_notice(opts)
+      opts.each do |attr, val|
+        setter_notice = build_notice
+        setter_notice.send(:"#{attr}=", val)
+        expect(setter_notice.send(attr)).to eq(val)
+        expect(opts_notice.send(attr)).to eq(val)
+      end
     end
   end
 

--- a/spec/unit/honeybadger_spec.rb
+++ b/spec/unit/honeybadger_spec.rb
@@ -132,7 +132,7 @@ describe Honeybadger do
 
     it "generates a backtrace excluding the singleton" do
       expect(instance.worker).to receive(:push) do |notice|
-        expect(notice.backtrace.to_a[0][:file]).to eq('[PROJECT_ROOT]/spec/unit/honeybadger_spec.rb')
+        expect(notice.backtrace.to_a[0]).to match('lib/honeybadger/agent.rb')
       end
 
       Honeybadger.notify(error_message: 'testing backtrace generation')


### PR DESCRIPTION
This is an alternative implementation of #277 for #271 

The main difference is that it ensures that the the new setters work the same way as the options to `Honeybadger.notify({})`, and it moves the construction and sanitization that was happening to `#as_json`.

The biggest breaking change is that `Honeybadger::Backtrace` (a private class) is no longer exposed directly to the user via `Notice#backtrace`. Now `Notice#backtrace` returns the raw backtrace, which was already what the `:backtrace` option supported and what the new `#backtrace=` setter supports, and the backtrace is parsed in `Notice#as_json`. See CHANGELOG.md for other breaking changes.

Merging this should update master to target a v4.0.0 release of the gem.