### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Honeybadger for Ruby
 
-[![Build Status](https://secure.travis-ci.org/honeybadger-io/honeybadger-ruby.png?branch=master)](http://travis-ci.org/honeybadger-io/honeybadger-ruby)
-[![Gem Version](https://badge.fury.io/rb/honeybadger.png)](http://badge.fury.io/rb/honeybadger)
+[![Build Status](https://secure.travis-ci.org/honeybadger-io/honeybadger-ruby.svg?branch=master)](http://travis-ci.org/honeybadger-io/honeybadger-ruby)
+[![Gem Version](https://badge.fury.io/rb/honeybadger.svg)](http://badge.fury.io/rb/honeybadger)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=honeybadger&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=honeybadger&package-manager=bundler&version-scheme=semver)
 
 This is the notifier gem for integrating apps with the :zap: [Honeybadger Exception Notifier for Ruby and Rails](http://honeybadger.io).
 


### PR DESCRIPTION
Adds a SemVer stability badge to the readme, calculated using all of the updates Dependabot has done of the honeybadger gem for your users (not a huge number because there haven't been many recent releases). Also switches other badges to svg, so they render better.

Post change, the badges will look like this:

[![Build Status](https://secure.travis-ci.org/honeybadger-io/honeybadger-ruby.svg?branch=master)](http://travis-ci.org/honeybadger-io/honeybadger-ruby) [![Gem Version](https://badge.fury.io/rb/honeybadger.svg)](http://badge.fury.io/rb/honeybadger) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=honeybadger&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=honeybadger&package-manager=bundler&version-scheme=semver)

What do you reckon? The badge is a new idea, but hopefully helpful for anyone trying to figure out what version requirement to set for honeybadger in their Gemfile.