### PR TITLE
Deprecate Honeybadger.exception_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,15 @@ adheres to [Semantic Versioning](http://semver.org/).
   String which was passed in from the `:fingerprint` option or the
   `exception_fingerprint` callback, not a SHA1 hashed value. The value is
   still hashed before sending through to the API.
-
 - The public method `Honeybadger.exception_filter` has been deprecated in favor
-  of `Honeybadger.before_notify`.
+  of `before_notify`:
+  ```ruby
+  Honeybadger.configure do |config|
+    config.before_notify do |notice|
+      notice.halt!
+    end
+  end
+  ```
 
 ### Removed
 - The `disabled` option is now removed, Use the `report_data` option instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ adheres to [Semantic Versioning](http://semver.org/).
   `exception_fingerprint` callback, not a SHA1 hashed value. The value is
   still hashed before sending through to the API.
 
+- The public method `Honeybadger.exception_filter` has been deprecated in favor
+  of `Honeybadger.before_notify`.
+
 ### Removed
 - The `disabled` option is now removed, Use the `report_data` option instead.
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -308,9 +308,7 @@ module Honeybadger
     #
     # @!method exception_filter
     # @yieldreturn [Boolean] true (to ignore) or false (to send).
-    def exception_filter(&block)
-      config.exception_filter(&block)
-    end
+    def_delegator :config, :exception_filter
 
     # Callback to add a custom grouping strategy for exceptions. The return
     # value is hashed and sent to Honeybadger. Errors with the same fingerprint

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -291,7 +291,7 @@ module Honeybadger
     # @yield [Config::Ruby] configuration object.
     def_delegator :config, :configure
 
-    # Callback to ignore exceptions.
+    # DEPRECATED: Callback to ignore exceptions.
     #
     # See public API documentation for {Honeybadger::Notice} for available attributes.
     #
@@ -308,7 +308,10 @@ module Honeybadger
     #
     # @!method exception_filter
     # @yieldreturn [Boolean] true (to ignore) or false (to send).
-    def_delegator :config, :exception_filter
+    def exception_filter
+      warn 'DEPRECATED: Honeybadger.exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
+      config.exception_filter
+    end
 
     # Callback to add a custom grouping strategy for exceptions. The return
     # value is hashed and sent to Honeybadger. Errors with the same fingerprint

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -309,7 +309,6 @@ module Honeybadger
     # @!method exception_filter
     # @yieldreturn [Boolean] true (to ignore) or false (to send).
     def exception_filter(&block)
-      warn 'DEPRECATED: Honeybadger.exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
       config.exception_filter(&block)
     end
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -308,9 +308,9 @@ module Honeybadger
     #
     # @!method exception_filter
     # @yieldreturn [Boolean] true (to ignore) or false (to send).
-    def exception_filter
+    def exception_filter(&block)
       warn 'DEPRECATED: Honeybadger.exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
-      config.exception_filter
+      config.exception_filter(&block)
     end
 
     # Callback to add a custom grouping strategy for exceptions. The return

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -89,8 +89,11 @@ module Honeybadger
     end
 
     def exception_filter
-      warn 'DEPRECATED: exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
-      self[:exception_filter] = Proc.new if block_given?
+      if block_given?
+        warn('DEPRECATED: exception_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_filter')
+        self[:exception_filter] = Proc.new
+      end
+
       self[:exception_filter]
     end
 

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -89,6 +89,7 @@ module Honeybadger
     end
 
     def exception_filter
+      warn 'DEPRECATED: exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
       self[:exception_filter] = Proc.new if block_given?
       self[:exception_filter]
     end

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -97,6 +97,7 @@ module Honeybadger
       end
 
       def exception_filter
+        warn 'DEPRECATED: exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
         hash[:exception_filter] = Proc.new if block_given?
         get(:exception_filter)
       end

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -97,8 +97,11 @@ module Honeybadger
       end
 
       def exception_filter
-        warn 'DEPRECATED: exception_filter is deprecated. Please use Honeybadger.before_notify instead.'
-        hash[:exception_filter] = Proc.new if block_given?
+        if block_given?
+          logger.warn('DEPRECATED: exception_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_filter')
+          hash[:exception_filter] = Proc.new
+        end
+
         get(:exception_filter)
       end
 


### PR DESCRIPTION
Fixes #272 

I don't seem to find documentation for `Honeybadger.before_notify`, we should update our docs to add this. The PR for this is still open: https://github.com/honeybadger-io/docs/pull/29