### PR TITLE
Fix memory leak in worker queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added missing Backend::Server#check_in specs
 - Added flag `--skip-rails-load` to cli commands for optionally skipping Rails initialization when running from a Rails root.
+- Fix a memory leak in the worker queue (jruby)
 
 ## [4.0.0] - 2018-08-21
 ### Added

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -24,7 +24,7 @@ module Honeybadger
       end
 
       def push(msg)
-        super unless size == max_size
+        super unless size >= max_size
       end
     end
 

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -19,12 +19,15 @@ module Honeybadger
       attr_reader :max_size
 
       def initialize(max_size)
+        @mutex = Mutex.new
         @max_size = max_size
         super()
       end
 
       def push(msg)
-        super unless size >= max_size
+        @mutex.synchronize do
+          super unless size >= max_size
+        end
       end
     end
 


### PR DESCRIPTION
The check for the max queue size is not synchronized, which means it can
return wrong results if multiple threads are pushing on to this queue at
the same time. If the wrong result is returned on the max_queue_size,
the check will be bypassed and the queue will grow unbounded until
memory is exhausted.

Example:

```
jruby-9.1.12.0 :021 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :022 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :023 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 99 
jruby-9.1.12.0 :024 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :025 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :026 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
```

With fix:

```
jruby-9.1.12.0 :013 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :014 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
jruby-9.1.12.0 :015 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 12 
jruby-9.1.12.0 :016 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 12 
jruby-9.1.12.0 :017 > q = Honeybadger::Worker::Queue.new(10); 100.times { Thread.new { q.push("hello") } }; q.size
 => 10 
```