### PR TITLE
Notify HB about deploy on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added missing Backend::Server#check_in specs
 - Added flag `--skip-rails-load` to cli commands for optionally skipping Rails initialization when running from a Rails root.
+- Notify HB on demand
 
 ## [4.0.0] - 2018-08-21
 ### Added

--- a/vendor/capistrano-honeybadger/README.md
+++ b/vendor/capistrano-honeybadger/README.md
@@ -30,6 +30,9 @@ gem 'honeybadger', '~> 2.0'
 ```ruby
 # Capfile
 require 'capistrano/honeybadger'
+
+# production.rb / staging.rb / etc.
+after 'deploy:finishing', 'honeybadger:deploy' 
 ```
 
 Please note that any `require` should be placed in `Capfile`, not `config/deploy.rb`.

--- a/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
+++ b/vendor/capistrano-honeybadger/lib/capistrano/tasks/deploy.cap
@@ -84,5 +84,3 @@ namespace :load do
     set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
   end
 end
-
-after 'deploy:finishing', 'honeybadger:deploy'


### PR DESCRIPTION
We have a lot of different environments in our projects, for example: production, staging.
We want to notice HB only after deploy to production, but we can't do it. And now we can