### PR TITLE
Fix CHANGELOG Fingerprint Example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ adheres to [Semantic Versioning](http://semver.org/).
   ```ruby
   Honeybadger.configure do |config|
     config.before_notify do |notice|
-      notice.exception_fingerprint = 'new fingerprint'
+      notice.fingerprint = 'new fingerprint'
     end
   end
   ```


### PR DESCRIPTION
When adding the new 4.0 syntax I was receiving a NoMethod error when trying to set `exception_fingerprint` for notice. When I switched to setting `fingerprint` everything seemed to work as intended. I believe this CHANGELOG example needs to be updated with `fingerprint`. The [docs](https://docs.honeybadger.io/ruby/getting-started/customizing-error-grouping.html#customizing-the-grouping-for-all-exceptions) also likely need to be updated. 