### PR TITLE
Notify When Sidekiq Job Defined Threshold or sidekiq.attempt_threshold is Reached 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Issue a Notification from a Sidekiq job when either the `sidekiq.attempt_threshold` is reached OR if the job defined retry threshold is reached, whichever comes first.
 
 ## [4.1.0] - 2018-10-16
 ### Added

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -141,6 +141,15 @@ describe "Sidekiq Dependency" do
                 sidekiq_config.error_handlers[0].call(exception, job_context)
               end
             end
+
+            context "and the retry count meets the job set threshold" do
+              let(:job) { { 'retry_count' => 2, 'retry' => 2 } }
+
+              it "notifies Honeybadger" do
+                expect(Honeybadger).to receive(:notify).with(exception, { parameters: job_context, component: nil }).once
+                sidekiq_config.error_handlers[0].call(exception, job_context)
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Recently we have been making some Sidekiq jobs that we don't want to retry but we still want to ensure they notify Honeybadger when they die. Our attempt_threshold is set at 5 so those jobs will never reach it. I updated the Sidekiq error handler hook to alert when either the `sidekiq.attempt_threshold` OR job defined retry count is reached. 

Since the [retry_count](https://github.com/mperham/sidekiq/blob/b53224955440cce657c282db9cfed4f3dafc5490/lib/sidekiq/job_retry.rb#L158) for sidekiq starts at 0 I had to subtract 1 from the options to ensure on the final retry the Honeybadger is triggered. 

Let me know what you think! Thanks! 