### PR TITLE
fix before_notify hooks bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix #301 - before_notify hooks are overridden on subsequent
+  `Honeybadger.configure` calls.
 
 ## [4.2.0] - 2019-01-31
 ### Changed

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -72,9 +72,9 @@ module Honeybadger
     end
 
     def configure
-      ruby_config = Ruby.new(self)
-      yield(ruby_config)
-      self.ruby = ruby.merge(ruby_config).freeze
+      new_ruby = Ruby.new(self)
+      yield(new_ruby)
+      self.ruby = ruby.merge(new_ruby).freeze
       @logger = @backend = nil
       self
     end

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -82,13 +82,15 @@ module Honeybadger
       end
 
       def before_notify(action = nil, &block)
-        (hash[:before_notify] ||= []).tap do |before_notify_hooks|
-          if action && validate_before_action(action)
-            before_notify_hooks << action
-          elsif block_given? && validate_before_action(block)
-            before_notify_hooks << block
-          end
+        hooks = Array(get(:before_notify)).dup
+
+        if action && validate_before_action(action)
+          hooks << action
+        elsif block_given? && validate_before_action(block)
+          hooks << block
         end
+
+        hash[:before_notify] = hooks
       end
 
       def backtrace_filter

--- a/spec/unit/honeybadger/config/ruby_spec.rb
+++ b/spec/unit/honeybadger/config/ruby_spec.rb
@@ -106,6 +106,13 @@ describe Honeybadger::Config::Ruby do
 
       expect(subject.before_notify).to eq([callable])
     end
+
+    it "configures multiple hooks" do
+      subject.before_notify {|n| n }
+      subject.before_notify {|n| n }
+
+      expect(subject.before_notify.size).to eq(2)
+    end
   end
 
   describe "#exception_filter" do

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -268,5 +268,17 @@ describe Honeybadger::Config do
         honeybadger.logger.error('foo')
       end
     end
+
+    it "configures multiple before_notify hooks" do
+      subject.configure do |config|
+        config.before_notify {|n| n }
+      end
+
+      subject.configure do |config|
+        config.before_notify {|n| n }
+      end
+
+      expect(subject.before_notify_hooks.size).to eq(2)
+    end
   end
 end


### PR DESCRIPTION
before_notify hooks are overridden on subsequent Honeybadger.configure calls

Fixes #301