### PR TITLE
Change order of throttle and response code

### DIFF
--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -202,7 +202,7 @@ module Honeybadger
 
       case response.code
       when 429, 503
-        warn { sprintf('Error report failed: project is sending too many errors. id=%s code=%s throttle=1.25 interval=%s', msg.id, throttle_interval, response.code) }
+        warn { sprintf('Error report failed: project is sending too many errors. id=%s code=%s throttle=1.25 interval=%s', msg.id, response.code, throttle_interval) }
         add_throttle(1.25)
       when 402
         warn { sprintf('Error report failed: payment is required. id=%s code=%s', msg.id, response.code) }


### PR DESCRIPTION
Looking through my sidekiq logs, I found this line:
```
WARN: ** [Honeybadger] Error report failed: project is sending too many errors. id=ID code=18.189894035458565 throttle=1.25 interval=429 level=2 pid=6789
```

The order of interval and response code is wrong.

PS: Once I have more time, I can add a test for that.