### PR TITLE
Deal with non-string breadcrumb log inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Allow non-strings to be passed to breadcrumbs logger
 
 ## [4.4.0] - 2019-07-24
 ### Added

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -5,7 +5,7 @@ module Honeybadger
     module LogWrapper
       def add(severity, message = nil, progname = nil)
         message, progname = [progname, nil] if message.nil?
-        message = message && message.strip
+        message = message && message.to_s.strip
         unless should_ignore_log?(message, progname)
           Honeybadger.add_breadcrumb(message, category: :log, metadata: {
             severity: format_severity(severity),

--- a/spec/fixtures/rails/config/application.rb
+++ b/spec/fixtures/rails/config/application.rb
@@ -12,6 +12,8 @@ if SKIP_ACTIVE_RECORD
 else
   require 'active_record/railtie'
   require 'activerecord-jdbcsqlite3-adapter' if defined?(JRUBY_VERSION)
+  require 'active_support'
+  require 'active_support/core_ext/enumerable'
   ENV['DATABASE_URL'] = 'sqlite3::memory:'
 end
 

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -1,0 +1,52 @@
+require 'honeybadger/breadcrumbs/logging'
+
+describe Honeybadger::Breadcrumbs::LogWrapper do
+  let(:logger) do
+    Class.new do
+      prepend Honeybadger::Breadcrumbs::LogWrapper
+
+      def add(_, *args)
+      end
+
+      def format_severity(str)
+        str
+      end
+    end
+  end
+
+  subject { logger.new }
+
+  it 'adds a breadcrumb' do
+    expect(subject).to receive(:format_severity).and_return("debug")
+    expect(Honeybadger).to receive(:add_breadcrumb).with("Message", hash_including(category: :log, metadata: hash_including(severity: "debug", progname: "none")))
+
+    subject.add("test", "Message", "none")
+  end
+
+  it 'handles non-string objects' do
+    expect(Honeybadger).to receive(:add_breadcrumb).with("{}", anything)
+    subject.add("DEBUG", {})
+  end
+
+  describe "ignores messages on" do
+    before { expect(Honeybadger).to_not receive(:add_breadcrumb) }
+
+    it 'nil message' do
+      subject.add("test", nil)
+    end
+
+    it 'empty string' do
+      subject.add("test", "")
+    end
+
+    it 'honeybadger progname' do
+      subject.add("test", "noop", "honeybadger")
+    end
+
+    it 'within log_subscriber call' do
+      Thread.current[:__hb_within_log_subscriber] = true
+      subject.add("test", "a message")
+      Thread.current[:__hb_within_log_subscriber] = false
+    end
+  end
+end


### PR DESCRIPTION
closes #315 

Calling `to_s` on the message passed to the logger before attempting to strip. I also added some unit specs around the `LogWrapper` class.