### PR TITLE
Expose cause data to callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Added `Notice#causes`, which allows cause data to be mutated in
   `before_notify` callbacks (useful for filtering purposes).
 - Added `Notice#cause=`, which allows the cause to be changed or disabled
-  in`before_notify` callbacks.
+  in `before_notify` callbacks.
 
 ### Fixed
 - `Honeybadger.notify(exception, cause: nil)` will now prevent the cause from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added `Notice#causes`, which allows cause data to be mutated in
+  `before_notify` callbacks (useful for filtering purposes).
+- Added `Notice#cause=`, which allows the cause to be changed or disabled
+  in`before_notify` callbacks.
+
+### Fixed
+- `Honeybadger.notify(exception, cause: nil)` will now prevent the cause from
+  being reported.
 
 ## [4.4.1] - 2019-07-30
 ### Fixed


### PR DESCRIPTION
1. Adds `Notice#causes`, which allows cause data to be mutated in `before_notify` callbacks (for filtering purposes)
2. Adds `Notice#cause=`, which allows the cause to be changed/disabled in `before_notify` callbacks
3. Changes the `:cause` option to `Honeybadger.notify`; passing `cause: nil` will now disable the cause for the current notice.

This also adds a new `Cause` class, which is intended to be used as a duck type (the class itself is private). It contains three attributes that correspond to similar attributes on `Notice`: `error_class`, `error_message`, and `backtrace`. With this API, filtering cause data inside `before_notify` callbacks looks like this:

```ruby
# Assumes a method `filter_error_message(message)` exists
Honeybadger.configure do |config|
  config.before_notify do |notice|
    notice.error_message = filter_error_message(notice.error_message)
    notice.causes.each do |cause|
      cause.error_message = filter_error_message(cause.error_message)
    end
  end
end
```