### PR TITLE
Throttling improvements (WIP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,20 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Default `max_queue_size` has been reduced from 1000 to 100.
+
 ### Added
 - Added `Notice#causes`, which allows cause data to be mutated in
   `before_notify` callbacks (useful for filtering purposes).
 - Added `Notice#cause=`, which allows the cause to be changed or disabled
   in `before_notify` callbacks.
+- Added extra shutdown logging.
 
 ### Fixed
 - `Honeybadger.notify(exception, cause: nil)` will now prevent the cause from
   being reported.
+- When throttled, queued notices will be discarded during shutdown.
 
 ## [4.4.2] - 2019-08-01
 ### Fixed

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -323,7 +323,7 @@ module Honeybadger
     # @example
     #   Honeybadger.stop # => nil
     def stop(force = false)
-      worker.send(force ? :shutdown! : :shutdown)
+      worker.shutdown(force)
       true
     end
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -81,7 +81,7 @@ module Honeybadger
       },
       max_queue_size: {
         description: 'Maximum number of items for each worker queue.',
-        default: 1000,
+        default: 100,
         type: Integer
       },
       plugins: {

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -190,7 +190,7 @@ module Honeybadger
     end
 
     def notify_backend(payload)
-      debug { sprintf('worker notifying backend id=%s', payload.id) }
+      d { sprintf('worker notifying backend id=%s', payload.id) }
       backend.notify(:notices, payload)
     end
 
@@ -216,7 +216,7 @@ module Honeybadger
     end
 
     def handle_response(msg, response)
-      debug { sprintf('worker response code=%s message=%s', response.code, response.message.to_s.dump) }
+      d { sprintf('worker response code=%s message=%s', response.code, response.message.to_s.dump) }
 
       case response.code
       when 429, 503

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -225,7 +225,7 @@ module Honeybadger
         suspend(3600)
       when 201
         if throttle = dec_throttle
-          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle_interval, response.code) }
+          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
         else
           info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
         end

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -53,6 +53,7 @@ module Honeybadger
 
       mutex.synchronize do
         @shutdown = true
+        @start_at = nil
         @pid = nil
       end
 

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -38,7 +38,7 @@ module Honeybadger
       return false unless start
 
       if queue.size >= config.max_queue_size
-        warn(sprintf('Unable to report error; reached max queue size of %s. id=%s', queue.size, msg.id))
+        warn { sprintf('Unable to report error; reached max queue size of %s. id=%s', queue.size, msg.id) }
         return false
       end
 

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -216,7 +216,7 @@ module Honeybadger
       case response.code
       when 429, 503
         throttle = inc_throttle
-        warn { sprintf('Error report failed: project is sending too many errors. id=%s code=%s throttle=%s interval=%s', msg.id, throttle, response.code, throttle_interval) }
+        warn { sprintf('Error report failed: project is sending too many errors. id=%s code=%s throttle=%s interval=%s', msg.id, response.code, throttle, throttle_interval) }
       when 402
         warn { sprintf('Error report failed: payment is required. id=%s code=%s', msg.id, response.code) }
         suspend(3600)

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -17,10 +17,10 @@ module Honeybadger
     # Used to signal the worker to shutdown.
     SHUTDOWN = :__hb_worker_shutdown!
 
-    # The number to multiply the current throttle interval by, resulting in an
-    # exponential backoff. 1.05 will reach an interval of 2 minutes after
-    # around 100 429 responses from the server.
-    THROTTLE_MULTIPLIER = 1.05
+    # The base number for the exponential backoff formula when calculating the
+    # throttle interval. `1.05 ** throttle` will reach an interval of 2 minutes
+    # after around 100 429 responses from the server.
+    BASE_THROTTLE = 1.05
 
     def initialize(config)
       @config = config
@@ -195,7 +195,7 @@ module Honeybadger
     end
 
     def calc_throttle_interval
-      ((THROTTLE_MULTIPLIER ** throttle) - 1).round(3)
+      ((BASE_THROTTLE ** throttle) - 1).round(3)
     end
 
     def inc_throttle

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -195,7 +195,7 @@ module Honeybadger
     end
 
     def calc_throttle_interval
-      (throttle.times.reduce(1) {|a,_| a *= THROTTLE_MULTIPLIER } - 1).round(3)
+      ((THROTTLE_MULTIPLIER ** throttle) - 1).round(3)
     end
 
     def inc_throttle

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -57,7 +57,6 @@ module Honeybadger
       end
 
       return true if force
-
       return true unless thread&.alive?
 
       if throttled?
@@ -68,7 +67,6 @@ module Honeybadger
       info { sprintf('Waiting to report %s error(s) to Honeybadger', queue.size) } unless queue.empty?
 
       queue.push(SHUTDOWN)
-
       !!thread.join
     ensure
       queue.clear

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -211,7 +211,7 @@ module Honeybadger
     end
 
     def handle_response(msg, response)
-      d { sprintf('worker response code=%s message=%s', response.code, response.message.to_s.dump) }
+      d { sprintf('worker response id=%s code=%s message=%s', msg.id, response.code, response.message.to_s.dump) }
 
       case response.code
       when 429, 503

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -237,7 +237,7 @@ describe Honeybadger::Worker do
       end
 
       context "and a throttle is set" do
-        before { instance.send(:add_throttle, 1.25) }
+        before { instance.send(:inc_throttle) }
 
         it "removes throttle" do
           expect { handle_response }.to change(instance, :throttle_interval).by(-1.25)

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -195,7 +195,7 @@ describe Honeybadger::Worker do
       let(:response) { Honeybadger::Backend::Response.new(429) }
 
       it "adds throttle" do
-        expect { handle_response }.to change(instance, :throttle_interval).by(1.25)
+        expect { handle_response }.to change(instance, :throttle_interval).by(0.05)
       end
     end
 
@@ -240,7 +240,7 @@ describe Honeybadger::Worker do
         before { instance.send(:inc_throttle) }
 
         it "removes throttle" do
-          expect { handle_response }.to change(instance, :throttle_interval).by(-1.25)
+          expect { handle_response }.to change(instance, :throttle_interval).by(-0.05)
         end
       end
 

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -140,8 +140,8 @@ describe Honeybadger::Worker do
     end
 
     it "changes the pid to the current pid" do
-      allow(Process).to receive(:pid).and_return(101)
-      expect { subject.start }.to change(subject, :pid).to(101)
+      allow(Process).to receive(:pid).and_return(101, 102)
+      expect { subject.start }.to change(subject, :pid).from(101).to(102)
     end
 
     context "when shutdown" do
@@ -187,10 +187,6 @@ describe Honeybadger::Worker do
     it "stops the thread" do
       subject.shutdown
       expect(subject.send(:thread)).not_to be_alive
-    end
-
-    it "clears the pid" do
-      expect { subject.shutdown }.to change(subject, :pid).to(nil)
     end
 
     context "when previously throttled" do
@@ -247,34 +243,6 @@ describe Honeybadger::Worker do
         subject.push(obj)
         subject.shutdown
       end
-    end
-
-    context "when suspended during shutdown" do
-      before do
-        allow(subject.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(403) )
-      end
-
-      it "won't start again in the future" do
-        expect {
-          subject.push(obj)
-          subject.shutdown
-        }.not_to change(subject, :start_at)
-      end
-    end
-  end
-
-  describe "#shutdown!" do
-    before { subject.start }
-
-    it "kills the thread" do
-      subject.shutdown!
-      expect(subject.send(:thread)).not_to be_alive
-    end
-
-    it "logs debug info" do
-      allow(config.logger).to receive(:debug)
-      expect(config.logger).to receive(:debug).with(/kill/i)
-      subject.shutdown!
     end
   end
 

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -222,11 +222,11 @@ describe Honeybadger::Worker do
 
     context "when throttled during shutdown" do
       before do
-        allow(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(429) )
+        allow(subject.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(429) )
       end
 
       it "shuts down immediately" do
-        expect(instance.send(:backend)).to receive(:notify).exactly(1).times
+        expect(subject.send(:backend)).to receive(:notify).exactly(1).times
         5.times { subject.push(obj) }
         subject.shutdown
       end
@@ -251,12 +251,14 @@ describe Honeybadger::Worker do
 
     context "when suspended during shutdown" do
       before do
-        allow(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(403) )
+        allow(subject.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(403) )
       end
 
       it "won't start again in the future" do
-        subject.push(obj)
-        expect { instance.shutdown }.not_to change(subject, :start_at).from(nil)
+        expect {
+          subject.push(obj)
+          subject.shutdown
+        }.not_to change(subject, :start_at)
       end
     end
   end

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -118,7 +118,7 @@ describe Honeybadger::Worker do
     context "when queue is full" do
       before do
         allow(config).to receive(:max_queue_size).and_return(5)
-        5.times { instance.push(obj) }
+        allow(instance).to receive(:queue).and_return(double(size: 5))
       end
 
       it "rejects the push" do


### PR DESCRIPTION
[Feedback wanted!]

This attempts to improve throttling. Here's the approach so far:

1. The max queue size has been reduced from 1000 to 100.
2. The exponential backoff multiple has been reduced from 1.25 to 1.05. See an example and the results at the end of this comment. Suggestions/better formulas are welcome.
3. `sleep` is still used to throttle the worker. When shutting down the worker (when `send_data_at_exit` is enabled), check to see if there is a throttle. If there is, log a warning and skip sending data; there's no point in sending data when it will most likely be rejected by the server anyway.
4. If a request is throttled *during* the shutdown, log the same warning and skip the rest of the queue.
5. Don't sleep anywhere else. Outside of throttling, the worker should always run in realtime to avoid delays when shutting down. It could also crash if necessary (because it has a mechanism to restart itself).

With the new defaults, shutting down with a maxed out queue (100 notices) could still take a while, but this solves the problem of blocking for long periods of time due to throttling in the worker; `at_exit` will never block longer than it takes to report the backlog as fast as the server allows. Also, the added logging will make it clear what's happening, in case people want to change the defaults/turn it off.

If we want to enforce a time limit when shutting down/sending data at exit, we might also be able to use `thread.join(5)` to stop processing and log a warning after (i.e.) 5 seconds. I haven't investigated if that's totally safe yet.

### Throttle formula:
Below is the time to wait in seconds for each 429 response from the server. A throttle is removed for each 201 response until it's back to 0 (realtime).

```
[1] pry(main)> 101.times {|t| puts (1.05 ** t - 1).round(3) }
0.0
0.05
0.103
0.158
0.216
0.276
0.34
0.407
0.477
0.551
0.629
0.71
0.796
0.886
0.98
1.079
1.183
1.292
1.407
1.527
1.653
1.786
1.925
2.072
2.225
2.386
2.556
2.733
2.92
3.116
3.322
3.538
3.765
4.003
4.253
4.516
4.792
5.081
5.385
5.705
6.04
6.392
6.762
7.15
7.557
7.985
8.434
8.906
9.401
9.921
10.467
11.041
11.643
12.275
12.939
13.636
14.367
15.136
15.943
16.79
17.679
18.613
19.594
20.623
21.705
22.84
24.032
25.283
26.598
27.978
29.426
30.948
32.545
34.222
35.984
37.833
39.774
41.813
43.954
46.201
48.561
51.04
53.641
56.374
59.242
62.254
65.417
68.738
72.225
75.886
79.73
83.767
88.005
92.455
97.128
102.035
107.186
112.596
118.276
124.239
130.501
```