### PR TITLE
[WIP] [breadcrumb] Handle notifications with no finished timestamp

### DIFF
--- a/lib/honeybadger/plugins/breadcrumbs.rb
+++ b/lib/honeybadger/plugins/breadcrumbs.rb
@@ -101,7 +101,9 @@ module Honeybadger
       # @api private
       def self.subscribe_to_notification(name, notification_config)
         ActiveSupport::Notifications.subscribe(name) do |_, started, finished, _, data|
-          send_breadcrumb_notification(name, finished - started, notification_config, data)
+          duration = finished && started ? finished - started : nil
+          
+          send_breadcrumb_notification(name, duration, notification_config, data)
         end
       end
     end


### PR DESCRIPTION
:wave: We ran into issues with custom active support notifications that don't have a `finished` timestamp.

Based on [the documentation](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-subscribe) `finished` and `started` can be `nil`.

In this PR, I'm setting the duration to `nil` if `finished` or `started` are `nil`.

I'll add a test and update the changelog later this week unless you want to get at it. :)