### PR TITLE
Ensure we call super with the original args in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- When `breadcrumbs` are enabled ensure we call the original `Logger#add` with the original arguments
 
 ## [4.5.0] - 2019-08-05
 ### Changed

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -4,6 +4,7 @@ module Honeybadger
     #
     module LogWrapper
       def add(severity, message = nil, progname = nil)
+        org_severity, org_message, org_progname = severity, message, progname
         message, progname = [progname, nil] if message.nil?
         message = message && message.to_s.strip
         unless should_ignore_log?(message, progname)
@@ -13,7 +14,7 @@ module Honeybadger
           })
         end
 
-        super
+        super(org_severity, org_message, org_progname)
       end
 
       private

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -5,7 +5,12 @@ describe Honeybadger::Breadcrumbs::LogWrapper do
     Class.new do
       prepend Honeybadger::Breadcrumbs::LogWrapper
 
-      def add(_, *args)
+      attr_reader :severity, :message, :progname
+
+      def add(severity, message, progname)
+        @severity = severity
+        @message = message
+        @progname = progname
       end
 
       def format_severity(str)
@@ -26,6 +31,13 @@ describe Honeybadger::Breadcrumbs::LogWrapper do
   it 'handles non-string objects' do
     expect(Honeybadger).to receive(:add_breadcrumb).with("{}", anything)
     subject.add("DEBUG", {})
+  end
+
+  it 'does not mutate the message' do
+    subject.add("DEBUG", {}, 'Honeybadger')
+    expect(subject.severity).to eq('DEBUG')
+    expect(subject.message).to eq({})
+    expect(subject.progname).to eq('Honeybadger')
   end
 
   describe "ignores messages on" do


### PR DESCRIPTION
This fixes #318 where the original message is converted to a string and stored in `message`. When calling super this string version is used.

The logger class itself doesn't care if the message is an object, from the docs it's supported with the note that when the log is written to an output, the message is converted to a string

> +message+ can be any object, but it has to be converted to a String in order to log it.  
Generally, +inspect+ is used if the given object is not a String. A special case is an +Exception+ object, which will be printed in detail, including message, class, and backtrace.  See #msg2str for the implementation if required.

All arguments passed to add are stored in a variable and then when calling super the original arguments are used explicitly.
