### PR TITLE
Added parameter filter to Breadcrumb sanitizer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - <<: *test
   "jruby":
     docker:
-      - image: circleci/jruby:9-jdk
+      - image: circleci/jruby:9.2.7-jdk
         environment:
           BUNDLER_VERSION: 1.17.3
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added parameter filtering to breadcrumb metadata (#329)
 
 ## [4.5.1] - 2019-08-13
 ### Fixed

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -379,7 +379,7 @@ module Honeybadger
     # Sanitize at the depth of 4 since we are sanitizing the breadcrumb root
     # hash data structure.
     def sanitized_breadcrumbs
-      Util::Sanitizer.new(max_depth: 4).sanitize(breadcrumbs.to_h)
+      Util::Sanitizer.new(max_depth: 4, filters: params_filters).sanitize(breadcrumbs.to_h)
     end
 
     def construct_context_hash(opts, exception)

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -376,10 +376,15 @@ module Honeybadger
       Context(object)
     end
 
-    # Sanitize at the depth of 4 since we are sanitizing the breadcrumb root
-    # hash data structure.
+    # Sanitize metadata to keep it at a single level and remove any filtered
+    # parameters
     def sanitized_breadcrumbs
-      Util::Sanitizer.new(max_depth: 4, filters: params_filters).sanitize(breadcrumbs.to_h)
+      sanitizer = Util::Sanitizer.new(max_depth: 1, filters: params_filters)
+      breadcrumbs.each do |breadcrumb|
+        breadcrumb.metadata = sanitizer.sanitize(breadcrumb.metadata)
+      end
+
+      breadcrumbs.to_h
     end
 
     def construct_context_hash(opts, exception)

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -508,6 +508,15 @@ describe Honeybadger::Notice do
       expect(message.bytesize).to be > 65536
       expect(65536...65556).to cover notice.as_json[:error][:message].bytesize
     end
+
+    it 'filters breadcrumbs' do
+      config[:'request.filter_keys'] = ['password']
+      notice = build_notice(breadcrumbs: {
+        trail: [{ metadata: { password: "my-password" } }]
+      })
+
+      expect(notice.as_json[:breadcrumbs][:trail][0][:metadata][:password]).to eq "[FILTERED]"
+    end
   end
 
   describe 'public attributes' do


### PR DESCRIPTION
Added parameter filtering and refactored so we are only sanitizing metadata.

I was concerned that if we started filtering from the root and the user filtered the word 'active' or any keys we use on the root, it would be removed and would cause problems.