### PR TITLE
Replace empty Proc.new with explicit block param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Replace empty `Proc.new` with explicit block param to suppress warnings
+  in Ruby 2.7
+
 ## [4.5.2] - 2019-10-09
 ### Changed
 - Added parameter filtering to breadcrumb metadata (#329)

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -79,10 +79,10 @@ module Honeybadger
       self
     end
 
-    def backtrace_filter
+    def backtrace_filter(&block)
       if block_given?
         warn('DEPRECATED: backtrace_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#backtrace_filter')
-        self[:backtrace_filter] = Proc.new
+        self[:backtrace_filter] = block
       end
 
       self[:backtrace_filter]
@@ -92,19 +92,19 @@ module Honeybadger
       (ruby[:before_notify] || []).clone
     end
 
-    def exception_filter
+    def exception_filter(&block)
       if block_given?
         warn('DEPRECATED: exception_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_filter')
-        self[:exception_filter] = Proc.new
+        self[:exception_filter] = block
       end
 
       self[:exception_filter]
     end
 
-    def exception_fingerprint
+    def exception_fingerprint(&block)
       if block_given?
         warn('DEPRECATED: exception_fingerprint is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_fingerprint')
-        self[:exception_fingerprint] = Proc.new
+        self[:exception_fingerprint] = block
       end
 
       self[:exception_fingerprint]

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -93,28 +93,28 @@ module Honeybadger
         hash[:before_notify] = hooks
       end
 
-      def backtrace_filter
+      def backtrace_filter(&block)
         if block_given?
           logger.warn('DEPRECATED: backtrace_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#backtrace_filter')
-          hash[:backtrace_filter] = Proc.new if block_given?
+          hash[:backtrace_filter] = block if block_given?
         end
 
         get(:backtrace_filter)
       end
 
-      def exception_filter
+      def exception_filter(&block)
         if block_given?
           logger.warn('DEPRECATED: exception_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_filter')
-          hash[:exception_filter] = Proc.new
+          hash[:exception_filter] = block
         end
 
         get(:exception_filter)
       end
 
-      def exception_fingerprint
+      def exception_fingerprint(&block)
         if block_given?
           logger.warn('DEPRECATED: exception_fingerprint is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_fingerprint')
-          hash[:exception_fingerprint] = Proc.new
+          hash[:exception_fingerprint] = block
         end
 
         get(:exception_fingerprint)

--- a/lib/honeybadger/plugin.rb
+++ b/lib/honeybadger/plugin.rb
@@ -66,11 +66,11 @@ module Honeybadger
       #   +snake_case+. The name is inferred from the current file name if omitted.
       #
       # @return nil
-      def register(name = nil)
+      def register(name = nil, &block)
         name ||= name_from_caller(caller) or
           raise(ArgumentError, 'Plugin name is required, but was nil.')
         instances[key = name.to_sym] and fail("Already registered: #{name}")
-        instances[key] = new(name).tap { |d| d.instance_eval(&Proc.new) }
+        instances[key] = new(name).tap { |d| d.instance_eval(&block) }
       end
 
       # @api private
@@ -136,8 +136,8 @@ module Honeybadger
     #   end
     #
     # @return nil
-    def requirement
-      @requirements << Proc.new
+    def requirement(&block)
+      @requirements << block
     end
 
     # Define an execution block. Execution blocks will be executed if all
@@ -161,8 +161,8 @@ module Honeybadger
     #   end
     #
     # @return nil
-    def execution
-      @executions << Proc.new
+    def execution(&block)
+      @executions << block
     end
 
     # @api private


### PR DESCRIPTION
Empty Proc.new, proc and lambda fall back to the block parameter passed to the parent method. This behavior will be deprecated in Ruby 2.7.

We can replace these with explicit block parameters.