### PR TITLE
Include context in notices from failed Resque jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Include Context in Notices for failed Resque jobs
 
 ## [4.5.2] - 2019-10-09
 ### Changed

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -9,7 +9,9 @@ module Honeybadger
         # errors reported within jobs get sent before the worker dies.
         def around_perform_with_honeybadger(*args)
           Honeybadger.flush { yield }
-        ensure
+        end
+
+        def after_perform_with_honeybadger(*args)
           Honeybadger.clear!
         end
 
@@ -17,6 +19,8 @@ module Honeybadger
         # executed after +around_perform+.
         def on_failure_with_honeybadger(e, *args)
           Honeybadger.notify(e, parameters: { job_arguments: args }, sync: true) if send_exception_to_honeybadger?(e, args)
+        ensure
+          Honeybadger.clear!
         end
 
         def send_exception_to_honeybadger?(e, args)

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -30,6 +30,13 @@ describe TestWorker do
 
     it_behaves_like "reports exceptions"
 
+    it "clears the context" do
+      expect {
+        Honeybadger.context(badgers: true)
+        described_class.on_failure_with_honeybadger(error, 1, 2, 3)
+      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
+    end
+
     describe "with worker not extending Resque::Plugins::Retry" do
       context "when send exceptions on retry enabled" do
         before { ::Honeybadger.config[:'resque.resque_retry.send_exceptions_when_retrying'] = true }
@@ -93,12 +100,11 @@ describe TestWorker do
   end
 
   describe "::around_perform_with_honeybadger" do
-    it "clears the context" do
-      expect {
-        described_class.around_perform_with_honeybadger do
-          Honeybadger.context(badgers: true)
-        end
-      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
+    it "flushes pending errors before worker dies" do
+      expect(Honeybadger).to receive(:flush)
+
+      described_class.around_perform_with_honeybadger do
+      end
     end
 
     it "raises exceptions" do
@@ -106,7 +112,16 @@ describe TestWorker do
         described_class.around_perform_with_honeybadger do
           fail 'foo'
         end
-      }.to raise_error(RuntimeError)
+      }.to raise_error(RuntimeError, /foo/)
+    end
+  end
+
+  describe "::after_perform_with_honeybadger" do
+    it "clears the context" do
+      expect {
+        Honeybadger.context(badgers: true)
+        described_class.after_perform_with_honeybadger
+      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
     end
   end
 end

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -98,7 +98,7 @@ describe TestWorker do
         described_class.around_perform_with_honeybadger do
           Honeybadger.context(badgers: true)
         end
-      }.not_to change { Thread.current[:__honeybadger_context] }.from(nil)
+      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
     end
 
     it "raises exceptions" do


### PR DESCRIPTION
When a developer sets Honeybadger context within the execution of a Resque
job, they expect it to be included in any notices reported from the job,
including when the job fails.

The previous implementation cleared the context in the `around_perform` 
hook, which executes before the `on_failure` hook. This meant that the 
context was always empty for notices from failed jobs.

This moves clearing the context into the failure handler, and into an
`after_perform` hook. If the job succeeds, the context will be cleared by
`after_perform`. If the job fails, the `after_perform` hook will not run, 
so the context will be available when the notice is created in the
`on_failure` hook, which will then clear the context.