### PR TITLE
Faktory Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added Faktory plugin -@scottrobertson
 
 ## [4.5.6] - 2020-01-08
 ### Fixed

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -279,6 +279,11 @@ module Honeybadger
         default: 0,
         type: Integer
       },
+      :'faktory.attempt_threshold' => {
+        description: 'The number of attempts before notifications will be sent.',
+        default: 0,
+        type: Integer
+      },
       :'sidekiq.use_component' => {
         description: 'Automatically set the component to the class of the job. Helps with grouping.',
         default: true,

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -27,11 +27,15 @@ module Honeybadger
 
               if job = params[:job]
                 if (threshold = config[:'faktory.attempt_threshold'].to_i) > 0
-                  retry_opt = job['retry'].to_i
-                  current_retry = job.dig('failure', 'retry_count').to_i
-                  limit = [retry_opt - 1, threshold].min
+                  # If job.failure is nil, it is the first attempt. The first
+                  # retry has a job.failure.retry_count of 0, which would be
+                  # the second attempt in our case.
+                  retry_count = job.dig('failure', 'retry_count')
+                  attempt = retry_count ? retry_count + 1 : 0
 
-                  return if current_retry < limit
+                  limit = [job['retry'].to_i, threshold].min
+
+                  return if attempt < limit
                 end
 
                 opts[:component] = job['jobtype']

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -28,7 +28,7 @@ module Honeybadger
               if job = params[:job]
                 if (threshold = config[:'faktory.attempt_threshold'].to_i) > 0
                   retry_opt = job['retry'].to_i
-                  current_retry = job['failure']['retry_count'].to_i
+                  current_retry = job.dig('failure', 'retry_count').to_i
                   limit = [retry_opt - 1, threshold].min
 
                   return if current_retry < limit

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -1,0 +1,47 @@
+require 'honeybadger/plugin'
+require 'honeybadger/ruby'
+
+module Honeybadger
+  module Plugins
+    module Faktory
+      class Middleware
+        def call(worker, job)
+          Honeybadger.clear!
+          yield
+        end
+      end
+
+      Plugin.register do
+        requirement { defined?(::Faktory) }
+
+        execution do
+          ::Faktory.configure_worker do |faktory|
+            faktory.worker_middleware do |chain|
+              chain.prepend Middleware
+            end
+          end
+
+          ::Faktory.configure_worker do |faktory|
+            faktory.error_handlers << lambda do |ex, params|
+              opts = {parameters: params}
+
+              if job = params[:job]
+                if (threshold = config[:'faktory.attempt_threshold'].to_i) > 0
+                  retry_opt = job['retry'].to_i
+                  retry_count = job['failure']['retry_count'].to_i
+
+                  return if retry_count < [retry_opt - 1, threshold].min
+                end
+
+                opts[:component] = job['jobtype']
+                opts[:action] = 'perform'
+              end
+
+              Honeybadger.notify(ex, opts)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -28,9 +28,10 @@ module Honeybadger
               if job = params[:job]
                 if (threshold = config[:'faktory.attempt_threshold'].to_i) > 0
                   retry_opt = job['retry'].to_i
-                  retry_count = job['failure']['retry_count'].to_i
+                  current_retry = job['failure']['retry_count'].to_i
+                  limit = [retry_opt - 1, threshold].min
 
-                  return if retry_count < [retry_opt - 1, threshold].min
+                  return if current_retry < limit
                 end
 
                 opts[:component] = job['jobtype']

--- a/spec/unit/honeybadger/plugins/faktory_spec.rb
+++ b/spec/unit/honeybadger/plugins/faktory_spec.rb
@@ -56,10 +56,12 @@ describe "Faktory Dependency" do
 
       context "within job execution" do
         let(:handler_context) { {context: 'Job raised exception', job: job } }
-        let(:job) { {'retry' => retry_limit, 'failure' => failure, 'jobtype' => 'JobType'} }
-        let(:failure) { { 'retry_count' => retry_count } }
+        let(:job) { first_invocation }
+        let(:retried_invocation) { {'retry' => retry_limit, 'failure' => failure, 'jobtype' => 'JobType'} }
+        let(:first_invocation) { {'retry' => retry_limit, 'jobtype' => 'JobType'} }
+        let(:failure) { { 'retry_count' => attempt - 1 } }
         let(:retry_limit) { 5 }
-        let(:retry_count) { 0 }
+        let(:attempt) { 0 }
 
         let(:error_payload) {{
           parameters: handler_context,
@@ -73,15 +75,28 @@ describe "Faktory Dependency" do
         end
 
         context "when an attempt threshold is configured" do
-          let(:retry_count) { 2 }
-          let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'faktory.attempt_threshold' => 3) }
+          let(:job) { retried_invocation }
+          let(:retry_limit) { 1 }
+          let(:attempt) { 0 }
+          let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'faktory.attempt_threshold' => 5) }
 
           it "doesn't notify Honeybadger" do
             expect(Honeybadger).not_to receive(:notify)
             faktory_config.error_handlers[0].call(exception, handler_context)
           end
 
+          context "and the retry_limit is zero on first invocation" do
+            let(:job) { first_invocation }
+            let(:retry_limit) { 0 }
+
+            it "notifies Honeybadger" do
+              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              faktory_config.error_handlers[0].call(exception, handler_context)
+            end
+          end
+
           context "and the retry_limit is exhausted" do
+            let(:attempt) { 3 }
             let(:retry_limit) { 3 }
 
             it "notifies Honeybadger" do
@@ -90,8 +105,9 @@ describe "Faktory Dependency" do
             end
           end
 
-          context "and the retry count meets the threshold" do
-            let(:retry_count) { 3 }
+          context "and the attempts meets the threshold" do
+            let(:attempt) { 5 }
+            let(:retry_limit) { 10 }
 
             it "notifies Honeybadger" do
               expect(Honeybadger).to receive(:notify).with(exception, error_payload).once

--- a/spec/unit/honeybadger/plugins/faktory_spec.rb
+++ b/spec/unit/honeybadger/plugins/faktory_spec.rb
@@ -1,0 +1,105 @@
+require 'honeybadger/plugins/faktory'
+require 'honeybadger/config'
+
+describe "Faktory Dependency" do
+  let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }
+
+  before do
+    Honeybadger::Plugin.instances[:faktory].reset!
+  end
+
+  context "when faktory is not installed" do
+    it "fails quietly" do
+      expect { Honeybadger::Plugin.instances[:faktory].load!(config) }.not_to raise_error
+    end
+  end
+
+  context "when faktory is installed" do
+    let(:shim) do
+      Class.new do
+        def self.configure_worker
+        end
+      end
+    end
+
+    let(:faktory_config) { double('config', :error_handlers => []) }
+    let(:chain) { double('chain', :prepend => true) }
+
+    before do
+      Object.const_set(:Faktory, shim)
+      allow(::Faktory).to receive(:configure_worker).and_yield(faktory_config)
+      allow(faktory_config).to receive(:worker_middleware).and_yield(chain)
+    end
+
+    after { Object.send(:remove_const, :Faktory) }
+
+    it "adds the error handler" do
+      Honeybadger::Plugin.instances[:faktory].load!(config)
+      expect(faktory_config.error_handlers).not_to be_empty
+    end
+
+    describe "error handler" do
+      let(:exception) { RuntimeError.new('boom') }
+
+      before do
+        Honeybadger::Plugin.instances[:faktory].load!(config)
+      end
+
+      context "not within job execution" do
+        let(:handler_context) { {context: 'Failed Hard', event: {} } }
+
+        it "notifies Honeybadger" do
+          expect(Honeybadger).to receive(:notify).with(exception, { parameters: handler_context }).once
+          faktory_config.error_handlers[0].call(exception, handler_context)
+        end
+      end
+
+      context "within job execution" do
+        let(:handler_context) { {context: 'Job raised exception', job: job } }
+        let(:job) { {'retry' => retry_limit, 'failure' => failure, 'jobtype' => 'JobType'} }
+        let(:failure) { { 'retry_count' => retry_count } }
+        let(:retry_limit) { 5 }
+        let(:retry_count) { 0 }
+
+        let(:error_payload) {{
+          parameters: handler_context,
+          component: 'JobType',
+          action: 'perform'
+        }}
+
+        it "notifies Honeybadger" do
+          expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+          faktory_config.error_handlers[0].call(exception, handler_context)
+        end
+
+        context "when an attempt threshold is configured" do
+          let(:retry_count) { 2 }
+          let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'faktory.attempt_threshold' => 3) }
+
+          it "doesn't notify Honeybadger" do
+            expect(Honeybadger).not_to receive(:notify)
+            faktory_config.error_handlers[0].call(exception, handler_context)
+          end
+
+          context "and the retry_limit is exhausted" do
+            let(:retry_limit) { 3 }
+
+            it "notifies Honeybadger" do
+              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              faktory_config.error_handlers[0].call(exception, handler_context)
+            end
+          end
+
+          context "and the retry count meets the threshold" do
+            let(:retry_count) { 3 }
+
+            it "notifies Honeybadger" do
+              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              faktory_config.error_handlers[0].call(exception, handler_context)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added Faktory Plugin, with most of the internals contributed from @scottrobertson (thanks!).

I implemented the logic a little different from the sidekiq version. If there is no job passed along, then the error happened somewhere where retries are not applicable (lifecycle or internals) and we always report. The retry logic is similar to sidekiq, but refactored a little for readability.

I found the job params from the structs in the go project (https://github.com/contribsys/faktory/blob/master/client/job.go#L27)

@joshuap I am defaulting to using the `jobtype` as the component (and 'perform' as action, like sidekiq). Is there a reason to make this an option, like in the sidekiq plugin? I was unsure why you would want component to be nil.