### PR TITLE
Dup #notify opts before mutating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Dup notify opts before mutating (#345)
 ### Changed
 - Added Faktory plugin -@scottrobertson
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -115,6 +115,8 @@ module Honeybadger
     # @return [String] UUID reference to the notice within Honeybadger.
     # @return [false] when ignored.
     def notify(exception_or_opts, opts = {})
+      opts = opts.dup
+
       if exception_or_opts.is_a?(Exception)
         opts[:exception] = exception_or_opts
       elsif exception_or_opts.respond_to?(:to_hash)

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -70,6 +70,14 @@ describe Honeybadger::Agent do
       instance.notify(error_message: 'testing backtrace generation')
     end
 
+    it "does not mutate passed in opts" do
+      opts = {error_message: 'test'}
+      prev = opts.dup
+      instance = described_class.new(Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER))
+      instance.notify("test", opts)
+      expect(prev).to eq(opts)
+    end
+
     it "calls all of the before notify hooks before sending" do
       hooks = [spy("hook one", arity: 1), spy("hook two", arity: 1), spy("hook three", arity: 1)]
       instance = described_class.new(Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER))


### PR DESCRIPTION
closes #337 

Duping and reassigning `opt` before mutation.