### PR TITLE
Fix Sidekiq retry count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- Fixed issue where Sidekiq.attempt_threshold was triggering 2 attempts ahead
+  of the setting
 - Dup notify opts before mutating (#345)
 ### Changed
 - Added Faktory plugin -@scottrobertson


### PR DESCRIPTION
Our Sidekiq plugin relies on `retry_count` in the job parameters to determine if a job should skip. It was taking the `to_i` of the value and essentially using it as an attempts count. This was causing the job to wait 2 extra executions, as the `retry_count` equals 1 on the third execution (see comment in source for explanation).

This refactor calculates the attempts and uses that to determine if we should skip reporting. Now if `sidekiq.attempt_threshold` is set to the value of 2, then on the second execution, it will report (as opposed to the 4th)

This also updates the specs so they describe the `attempts` instead of `retry_count` so you don't have to the math in your head while working through the specs.