### PR TITLE
Fix Rails 6.1 deprecation warning. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix Rails 6.1 deprecation warning with ActiveRecord::Base.connection_config
+
 ## [4.6.0] - 2020-03-12
 ### Fixed
 - Fixed issue where Sidekiq.attempt_threshold was triggering 2 attempts ahead

--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -18,7 +18,7 @@ module Honeybadger
             select_keys: [:sql, :name, :connection_id, :cached],
             transform: lambda do |data|
               if data[:sql]
-                adapter = ::ActiveRecord::Base.connection_db_config.configuration_hash[:adapter]
+                adapter = active_record_connection_db_config[:adapter]
                 data[:sql] = Util::SQL.obfuscate(data[:sql], adapter)
               end
               data
@@ -103,6 +103,15 @@ module Honeybadger
         }
       end
 
+      private_class_method def self.active_record_connection_db_config
+        if ::ActiveRecord::Base.respond_to?(:connection_db_config)
+          # >= Rails 6.1
+          ::ActiveRecord::Base.connection_db_config.configuration_hash
+        else
+          # < Rails 6.1
+          ::ActiveRecord::Base.connection_config
+        end
+      end
     end
   end
 end

--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -18,7 +18,7 @@ module Honeybadger
             select_keys: [:sql, :name, :connection_id, :cached],
             transform: lambda do |data|
               if data[:sql]
-                adapter = ::ActiveRecord::Base.connection_config[:adapter]
+                adapter = ::ActiveRecord::Base.connection_db_config.configuration_hash[:adapter]
                 data[:sql] = Util::SQL.obfuscate(data[:sql], adapter)
               end
               data


### PR DESCRIPTION
Rails master (6.1) causes a deprecation warning for `ActiveRecord::Base.connection_config`

> DEPRECATION WARNING: connection_config is deprecated and will be removed from Rails 6.2 (Use connection_db_config instead) (called from block in default_notifications a .../gems/honeybadger-4.6.0/lib/honeybadger/breadcrumbs/active_support.rb:21)

I haven't yet gone back to check when this method was added. 
