### PR TITLE
Pass config to Breadcrumbs::Collector when local_context: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Alias Notice#controller= as Notice#component=
 
 - Fix Rails 6.1 deprecation warning with ActiveRecord::Base.connection_config
+- Fix agent where breadcrumbs.enabled = true and local_context = true
 
 ## [4.6.0] - 2020-03-12
 ### Fixed

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -63,12 +63,14 @@ module Honeybadger
       end
 
       @context = opts.delete(:context)
-      if opts.delete(:local_context)
+      local_context = opts.delete(:local_context)
+
+      @config ||= Config.new(opts)
+
+      if local_context
         @context ||= ContextManager.new
         @breadcrumbs = Breadcrumbs::Collector.new(config)
       end
-
-      @config ||= Config.new(opts)
 
       init_worker
     end


### PR DESCRIPTION
Previously, when using an agent with `local_context: true` and breadcrumbs enabled, errors result because when the `Breadcrumbs::Collector` was instantiated, the `@config` instance variable hadn't been initialized. This meant the collector was passed `nil` for its config, and when it attempted to access the breadcrumbs setting, a `NoMethodError` was raised.

This change ensures that we always set up our agent config before instantiating the `Breadcrumbs::Collector`.

## Feedback

I don't have any specific questions, but any and all feedback is very welcome. Hopefully this isn't controversial - there are some minor implementation notes in the commit message.

**Before submitting a pull request,** please make sure the following is done:

- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Run `rake spec` in the repository root.
- [x] Add an entry to the CHANGELOG.
