### PR TITLE
Handle Rails depreciation within defaults.rb 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Alias `Notice#controller=` as `Notice#component=`
 - Fix Rails 6.1 deprecation warning with `ActiveRecord::Base.connection_config`
 - Fix agent where breadcrumbs.enabled = true and local_context = true
+- Fix Rails deprecation of `ActionDispatch::ParamsParser::ParseError`
 
 ### Added
 - Add `honeybadger_skip_rails_load` Capistrano option to skip rails load on

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -17,7 +17,7 @@ module Honeybadger
                       # and may be removed here once support for Rails 5.2 is dropped.
                       # https://github.com/rails/rails/commit/e16c765ac6dcff068ff2e5554d69ff345c003de1
                       # https://github.com/honeybadger-io/honeybadger-ruby/pull/358
-                      'ActionDispatch::ParamsParser::ParseError'
+                      'ActionDispatch::ParamsParser::ParseError',
                       'ActionDispatch::Http::Parameters::ParseError',
                       'ActionController::BadRequest',
                       'ActionController::ParameterMissing',

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -13,7 +13,7 @@ module Honeybadger
                       'ActionController::UnknownFormat',
                       'ActionController::InvalidAuthenticityToken',
                       'ActionController::InvalidCrossOriginRequest',
-                      'ActionDispatch::ParamsParser::ParseError',
+                      'ActionDispatch::Http::Parameters::ParseError',
                       'ActionController::BadRequest',
                       'ActionController::ParameterMissing',
                       'ActiveRecord::RecordNotFound',

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -13,6 +13,11 @@ module Honeybadger
                       'ActionController::UnknownFormat',
                       'ActionController::InvalidAuthenticityToken',
                       'ActionController::InvalidCrossOriginRequest',
+                      # ActionDispatch::ParamsParser::ParseError was removed in Rails 6.0
+                      # and may be removed here once support for Rails 5.2 is dropped.
+                      # https://github.com/rails/rails/commit/e16c765ac6dcff068ff2e5554d69ff345c003de1
+                      # https://github.com/honeybadger-io/honeybadger-ruby/pull/358
+                      'ActionDispatch::ParamsParser::ParseError'
                       'ActionDispatch::Http::Parameters::ParseError',
                       'ActionController::BadRequest',
                       'ActionController::ParameterMissing',


### PR DESCRIPTION
We recently noticed an HTTP parameter parsing error coming through to our honeybadger errors, which we didn't think should be coming through. In the [defaults](https://docs.honeybadger.io/lib/ruby/getting-started/ignoring-errors.html#ignore-by-class), there is a reference to this now [deprecated class](https://github.com/rails/rails/commit/e16c765ac6dcff068ff2e5554d69ff345c003de1). 

To resolve this problem I have renamed the deprecated class with the new [class](https://api.rubyonrails.org/classes/ActionDispatch/Http/Parameters.html). 

I am unsure if this change should have any testing burden. I didn't see a `defaults_spec` to be updated, let me know if I missed anything else. 