### PR TITLE
Deal with invalid UTF-8 byte sequences during SQL obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 - ActiveRecord SQL Breadcrumb event pulls adapter from supplied connection,
   allowing for multiple databases.
 - Fix Rails deprecation of `ActionDispatch::ParamsParser::ParseError`
+- Deal with invalid UTF-8 byte sequences during SQL obfuscation
 
 ## [4.7.0] - 2020-06-02
 ### Fixed

--- a/lib/honeybadger/util/sql.rb
+++ b/lib/honeybadger/util/sql.rb
@@ -11,7 +11,7 @@ module Honeybadger
       DoubleQuoters = /(postgres|sqlite|postgis)/.freeze
 
       def self.obfuscate(sql, adapter)
-        sql.dup.tap do |s|
+        force_utf_8(sql.dup).tap do |s|
           s.gsub!(EscapedQuotes, EmptyReplacement)
           s.gsub!(SQuotedData, Replacement)
           s.gsub!(DQuotedData, Replacement) if adapter =~ DoubleQuoters
@@ -19,6 +19,13 @@ module Honeybadger
           s.gsub!(Newline, EmptyReplacement)
           s.squeeze!(' ')
         end
+      end
+
+      def self.force_utf_8(string)
+        string.encode(
+          Encoding.find('UTF-8'),
+          {invalid: :replace, undef: :replace, replace: ''}
+        )
       end
     end
   end

--- a/spec/unit/honeybadger/util/sql_spec.rb
+++ b/spec/unit/honeybadger/util/sql_spec.rb
@@ -1,0 +1,15 @@
+require "honeybadger/util/sql"
+
+describe Honeybadger::Util::SQL do
+  describe "#obfuscate" do
+    it "works with non UTF-8 strings" do
+      expect {
+        described_class.obfuscate(
+          "SELECT AES_DECRYPT('\x83ݔj\\\xE3Lb\u0001\\\xEC\u0010&\u000F[\\\xE6`q', 'key')",
+          "sqlite3"
+        )
+      }.to_not raise_error
+    end
+  end
+end
+


### PR DESCRIPTION
resolves #364 

Replace any invalid characters before we attempt to do any `gsub!`ing.