### PR TITLE
Fix Ruby 2.7 deprecation warning in sql.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](http://semver.org/).
   allowing for multiple databases.
 - Fix Rails deprecation of `ActionDispatch::ParamsParser::ParseError`
 - Deal with invalid UTF-8 byte sequences during SQL obfuscation
+- Fix Ruby 2.7 deprication notice in sql.rb
 
 ## [4.7.0] - 2020-06-02
 ### Fixed

--- a/lib/honeybadger/util/sql.rb
+++ b/lib/honeybadger/util/sql.rb
@@ -24,7 +24,9 @@ module Honeybadger
       def self.force_utf_8(string)
         string.encode(
           Encoding.find('UTF-8'),
-          {invalid: :replace, undef: :replace, replace: ''}
+          invalid: :replace, 
+          undef: :replace, 
+          replace: ''
         )
       end
     end


### PR DESCRIPTION
I noticed that a new Ruby 2.7 deprecation warning popped up after merging a recent PR (#366) - this is my attempt to fix that.

Let me know what else I can do to help!