### PR TITLE
Encode sql in exclusion check

### DIFF
--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -26,7 +26,8 @@ module Honeybadger
             end,
             exclude_when: lambda do |data|
               # Ignore schema, begin, and commit transaction queries
-              data[:name] == "SCHEMA" || (data[:sql] && (data[:sql] =~ /^(begin|commit)( transaction)?$/i))
+              data[:name] == "SCHEMA" ||
+                (data[:sql] && (Util::SQL.force_utf_8(data[:sql].dup) =~ /^(begin|commit)( transaction)?$/i))
             end
           },
 

--- a/spec/fixtures/rails/config/breadcrumbs.rb
+++ b/spec/fixtures/rails/config/breadcrumbs.rb
@@ -8,6 +8,7 @@ end
 
 class BreadcrumbController < ApplicationController
   def active_record_event
+    ActiveRecord::Base.connection.execute("SELECT '\x83ݔj'")
     Thing.create(name: "a thing")
     notice
   end


### PR DESCRIPTION
Non-UTF-8 encoded strings can break in our exclusion check (as well as the obfuscator, which we fixed earlier). This PR forces encoding before we do our default regex check.