### PR TITLE
Avoid calling AR::Base.connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Remove usage of `ActiveRecord::Base.connection` (thanks @jcoyne for testing)
 
 ## [4.7.1] - 2020-08-11
 ### Fixed


### PR DESCRIPTION
We had a submitted issue where DB connections were timing out after upgrading. I _think_ this is the result of accessing the `::ActiveRecord::Base.connection` to collect the adapter name. This **should** only affect Rails < 6 users as the active connection is passed in with the instrumentation event for Rails 6.

This brings back the method to pull the adapter from AR connection config, instead of the `adapter_name` from a connection.
