### PR TITLE
Don't enable Lambda plugin in non-Lambda execution environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Don't enable Lambda plugin in non-Lambda execution environments
+
 ## [4.7.2] - 2020-08-17
 ### Fixed
 - Remove usage of `ActiveRecord::Base.connection` (thanks @jcoyne for testing)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+### Fixed
 - Don't enable Lambda plugin in non-Lambda execution environments
 
 ## [4.7.2] - 2020-08-17

--- a/lib/honeybadger/util/lambda.rb
+++ b/lib/honeybadger/util/lambda.rb
@@ -14,7 +14,7 @@ module Honeybadger
 
       class << self
         def lambda_execution?
-          !!ENV["AWS_EXECUTION_ENV"]
+          !!ENV["AWS_LAMBDA_FUNCTION_NAME"]
         end
 
         def normalized_data

--- a/spec/unit/honeybadger/util/lambda_spec.rb
+++ b/spec/unit/honeybadger/util/lambda_spec.rb
@@ -3,11 +3,32 @@ require 'honeybadger/util/lambda'
 describe Honeybadger::Util::Lambda do
   subject { described_class }
 
-  before do
-    allow(ENV).to receive(:[])
+  describe ".lambda_execution?" do
+    def with_env_variable(variable, value)
+      original_value = ENV[variable]
+      ENV[variable] = value
+      yield
+      ENV[variable] = original_value
+    end
+
+    it "is false if AWS_LAMBDA_FUNCTION_NAME is unset" do
+      with_env_variable("AWS_LAMBDA_FUNCTION_NAME", nil) do
+        expect(subject.lambda_execution?).to be_falsey
+      end
+    end
+
+    it "is true if AWS_LAMBDA_FUNCTION_NAME is set" do
+      with_env_variable("AWS_LAMBDA_FUNCTION_NAME", "MyLovelyFunction") do
+        expect(subject.lambda_execution?).to be_truthy
+      end
+    end
   end
 
   describe ".normalized_data" do
+    before do
+      allow(ENV).to receive(:[])
+    end
+
     it "includes all HTTP headers" do
       expect(ENV).to receive(:[]).twice.with("AWS_REGION").and_return("westeros")
       expect(ENV).to receive(:[]).twice.with("AWS_EXECUTION_ENV").and_return("Ruby")


### PR DESCRIPTION
The Lambda plugin currently enables itself in all environments where the `AWS_EXECUTION_ENV` environment variable is set, regardless of value.

However, this variable is also set in other contexts, e.g. ECS. In those contexts this results in the plugin overwriting the component and action values set in any notice with nil (since no lambda function or handler data is present in the environment).

This commit updates the requirement test to check the `AWS_EXECUTION_ENV` value for the prefix specified in the [AWS Lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html).

  > AWS_EXECUTION_ENV – The runtime identifier, prefixed by `AWS_Lambda_`—for example, `AWS_Lambda_java8`.

Since it's not completely clear what the capitalisation is (edit: or rather, I don't trust the eccentric capitalisation in the example the docs give) I've opted to make the regex comparison case insensitive; I think the risk of this causing false positives is low.