### PR TITLE
Feat: Decrease time spent bundle installing in GH Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,6 +43,7 @@ jobs:
       BUNDLE_GEMFILE: "gemfiles/${{ matrix.gemfile }}"
       BUNDLE_JOBS: 4
       BUNDLE_PATH: "vendor/bundle"
+      BUNDLE_WITHOUT: "development"
     steps:
     - uses: actions/checkout@v2
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,7 @@
+# minimal rails gems required to run rails
+# https://github.com/rails/rails/blob/main/rails.gemspec
+RAILS_GEMS = %w[activesupport activemodel activerecord railties]
+
 appraise 'standalone' do
 end
 
@@ -27,7 +31,7 @@ appraise 'resque' do
 end
 
 appraise 'rails5.2' do
-  gem 'rails', '~> 5.2.0'
+  RAILS_GEMS.each { |rails_gem| gem rails_gem, "~> 5.2" }
   gem 'sqlite3', '~> 1.4', platform: :mri
   gem 'activerecord-jdbcsqlite3-adapter', '~> 52', platform: :jruby
   gem 'better_errors', require: false, platforms: [:ruby_20, :ruby_21]
@@ -38,7 +42,7 @@ end
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
   # The latest officially supported Rails/Rack release
   appraise 'rails6.0' do
-    gem 'rails', '~> 6.0.0'
+    RAILS_GEMS.each { |rails_gem| gem rails_gem, "~> 6.0" }
     gem 'sqlite3', '~> 1.4', platform: :mri
     gem 'activerecord-jdbcsqlite3-adapter', '~> 60', platform: :jruby
     gem 'better_errors', require: false, platforms: [:ruby_20, :ruby_21]
@@ -48,7 +52,10 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
 
   # Rails edge
   appraise 'rails' do
-    gem 'rails', github: 'rails/rails'
+    git 'https://github.com/rails/rails.git' do
+      RAILS_GEMS.each { |rails_gem| gem rails_gem }
+    end
+
     gem 'rack', github: 'rack/rack'
     gem 'arel', github: 'rails/arel'
     gem 'sqlite3', '~> 1.4', platform: :mri

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 # minimal rails gems required to run rails
 # https://github.com/rails/rails/blob/main/rails.gemspec
-RAILS_GEMS = %w[activesupport activemodel activerecord railties]
+RAILS_GEMS = %w[activesupport activemodel activerecord railties actionpack]
 
 appraise 'standalone' do
 end

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 # minimal rails gems required to run rails
 # https://github.com/rails/rails/blob/main/rails.gemspec
-RAILS_GEMS = %w[activesupport activemodel activerecord railties actionpack]
+RAILS_GEMS = %w[activesupport activemodel activerecord activejob railties actionpack]
 
 appraise 'standalone' do
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,12 @@ gem 'webmock'
 gem 'capistrano'
 gem 'rake'
 
-gem "bump", "~> 0.9.0"
-
 # mathn has moved to a rubygem in Ruby 2.5.0: https://github.com/ruby/mathn
 platforms :ruby_25 do
   gem "mathn"
 end
 
+gem "bump", "~> 0.9.0"
 
 group :development do
   gem 'guard'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ gemspec
 gem 'allocation_stats', platforms: :mri, require: false
 gem 'appraisal', '~> 2.1'
 gem 'aruba', '~> 0.14'
-gem 'guard'
-gem 'guard-rspec'
-gem 'pry'
-gem 'pry-byebug', platforms: :mri
-gem 'rdoc'
 gem 'rspec', '~> 3.0'
 gem 'rspec-its'
 gem 'ruby-prof', platforms: :mri, require: false
@@ -20,9 +15,18 @@ gem 'webmock'
 gem 'capistrano'
 gem 'rake'
 
+gem "bump", "~> 0.9.0"
+
 # mathn has moved to a rubygem in Ruby 2.5.0: https://github.com/ruby/mathn
 platforms :ruby_25 do
   gem "mathn"
 end
 
-gem "bump", "~> 0.9.0"
+
+group :development do
+  gem 'guard'
+  gem 'guard-rspec'
+  gem 'pry'
+  gem 'pry-byebug', platforms: :mri
+  gem 'rdoc'
+end

--- a/gemfiles/binding_of_caller.gemfile
+++ b/gemfiles/binding_of_caller.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -19,6 +14,14 @@ gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
 gem "binding_of_caller"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -19,6 +14,14 @@ gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
 gem "delayed_job", "< 4.1.2"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -19,6 +14,14 @@ gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
 gem "rack", ">= 2.0.0"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rack_1.gemfile
+++ b/gemfiles/rack_1.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -19,6 +14,14 @@ gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
 gem "rack", "< 2.0"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -7,6 +7,7 @@ git "https://github.com/rails/rails.git" do
   gem "activemodel"
   gem "activerecord"
   gem "railties"
+  gem "actionpack"
 end
 
 gem "allocation_stats", platforms: :mri, require: false

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -6,6 +6,7 @@ git "https://github.com/rails/rails.git" do
   gem "activesupport"
   gem "activemodel"
   gem "activerecord"
+  gem "activejob"
   gem "railties"
   gem "actionpack"
 end

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -2,14 +2,16 @@
 
 source "https://rubygems.org"
 
+git "https://github.com/rails/rails.git" do
+  gem "activesupport"
+  gem "activemodel"
+  gem "activerecord"
+  gem "railties"
+end
+
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -18,13 +20,20 @@ gem "webmock"
 gem "capistrano", "~> 3.0"
 gem "rake"
 gem "bump", "~> 0.9.0"
-gem "rails", github: "rails/rails"
 gem "rack", github: "rack/rack"
 gem "arel", github: "rails/arel"
 gem "sqlite3", "~> 1.4", platform: :mri
 gem "better_errors", require: false, platforms: [:ruby_20, :ruby_21]
 gem "rspec-rails"
 gem "listen"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -16,6 +16,7 @@ gem "bump", "~> 0.9.0"
 gem "activesupport", "~> 5.2"
 gem "activemodel", "~> 5.2"
 gem "activerecord", "~> 5.2"
+gem "activejob", "~> 5.2"
 gem "railties", "~> 5.2"
 gem "actionpack", "~> 5.2"
 gem "sqlite3", "~> 1.4", platform: :mri

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -18,12 +13,23 @@ gem "webmock"
 gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
-gem "rails", "~> 5.2.0"
+gem "activesupport", "~> 5.2"
+gem "activemodel", "~> 5.2"
+gem "activerecord", "~> 5.2"
+gem "railties", "~> 5.2"
 gem "sqlite3", "~> 1.4", platform: :mri
 gem "activerecord-jdbcsqlite3-adapter", "~> 52", platform: :jruby
 gem "better_errors", require: false, platforms: [:ruby_20, :ruby_21]
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -17,6 +17,7 @@ gem "activesupport", "~> 5.2"
 gem "activemodel", "~> 5.2"
 gem "activerecord", "~> 5.2"
 gem "railties", "~> 5.2"
+gem "actionpack", "~> 5.2"
 gem "sqlite3", "~> 1.4", platform: :mri
 gem "activerecord-jdbcsqlite3-adapter", "~> 52", platform: :jruby
 gem "better_errors", require: false, platforms: [:ruby_20, :ruby_21]

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -18,12 +13,23 @@ gem "webmock"
 gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
-gem "rails", "~> 6.0.0"
+gem "activesupport", "~> 6.0"
+gem "activemodel", "~> 6.0"
+gem "activerecord", "~> 6.0"
+gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4", platform: :mri
 gem "activerecord-jdbcsqlite3-adapter", "~> 60", platform: :jruby
 gem "better_errors", require: false, platforms: [:ruby_20, :ruby_21]
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -17,6 +17,7 @@ gem "activesupport", "~> 6.0"
 gem "activemodel", "~> 6.0"
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
+gem "actionpack", "~> 6.0"
 gem "sqlite3", "~> 1.4", platform: :mri
 gem "activerecord-jdbcsqlite3-adapter", "~> 60", platform: :jruby
 gem "better_errors", require: false, platforms: [:ruby_20, :ruby_21]

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -16,6 +16,7 @@ gem "bump", "~> 0.9.0"
 gem "activesupport", "~> 6.0"
 gem "activemodel", "~> 6.0"
 gem "activerecord", "~> 6.0"
+gem "activejob", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "actionpack", "~> 6.0"
 gem "sqlite3", "~> 1.4", platform: :mri

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -20,6 +15,14 @@ gem "rake"
 gem "bump", "~> 0.9.0"
 gem "resque"
 gem "mock_redis"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -20,6 +15,14 @@ gem "rake"
 gem "bump", "~> 0.9.0"
 gem "sinatra", "~> 2.0.0.beta1"
 gem "rack-test"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/sinatra_1.gemfile
+++ b/gemfiles/sinatra_1.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -20,6 +15,14 @@ gem "rake"
 gem "bump", "~> 0.9.0"
 gem "sinatra", "< 2.0"
 gem "rack-test"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/gemfiles/standalone.gemfile
+++ b/gemfiles/standalone.gemfile
@@ -5,11 +5,6 @@ source "https://rubygems.org"
 gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 0.14"
-gem "guard"
-gem "guard-rspec"
-gem "pry"
-gem "pry-byebug", platforms: :mri
-gem "rdoc"
 gem "rspec", "~> 3.0"
 gem "rspec-its"
 gem "ruby-prof", platforms: :mri, require: false
@@ -18,6 +13,14 @@ gem "webmock"
 gem "capistrano"
 gem "rake"
 gem "bump", "~> 0.9.0"
+
+group :development do
+  gem "guard"
+  gem "guard-rspec"
+  gem "pry"
+  gem "pry-byebug", platforms: :mri
+  gem "rdoc"
+end
 
 platforms :ruby_25 do
   gem "mathn"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'aruba/rspec'
 require 'fileutils'
 require 'logger'
 require 'pathname'
-require 'pry'
 require 'rspec/its'
 require 'webmock/rspec'
 


### PR DESCRIPTION
- Programmatically pulls in rails dependencies
- Moves non-necessary gems into development so they dont need to be installed in gh-actions
- Should improve bundle install speed
- Removes `require 'pry'` since it shouldnt be needed in the spec helper (one less thing to install for gh-actions)