### PR TITLE
Supress git rev-parse error when fetching Git revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Suppress any error output from the `git rev-parse` command. ([#394](https://github.com/honeybadger-io/honeybadger-ruby/pull/394))
 
 ## [4.7.3] - 2021-02-10
 ### Fixed

--- a/lib/honeybadger/util/revision.rb
+++ b/lib/honeybadger/util/revision.rb
@@ -26,7 +26,7 @@ module Honeybadger
 
         def from_git
           return nil unless File.directory?('.git')
-          `git rev-parse HEAD`.strip rescue nil
+          `git rev-parse HEAD 2> #{File::NULL}`.strip rescue nil
         end
       end
     end

--- a/spec/fixtures/rails/config/application.rb
+++ b/spec/fixtures/rails/config/application.rb
@@ -59,6 +59,6 @@ class RailsController < ApplicationController
 end
 
 Rails.env = 'production'
-Rails.logger = Logger.new('/dev/null')
+Rails.logger = Logger.new(File::NULL)
 
 require_relative './breadcrumbs'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ Dir[File.expand_path('../support/**/*.rb', __FILE__)].each {|f| require f}
 
 TMP_DIR = Pathname.new(File.expand_path('../../tmp', __FILE__))
 FIXTURES_PATH = Pathname.new(File.expand_path('../fixtures/', __FILE__))
-NULL_LOGGER = Logger.new('/dev/null')
+NULL_LOGGER = Logger.new(File::NULL)
 NULL_LOGGER.level = Logger::Severity::DEBUG
 
 Aruba.configure do |config|

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -254,8 +254,8 @@ describe Honeybadger::Config do
   describe "#configure" do
     context "when the app has already been initialized" do
       it "overrides the logger with the configured logger" do
-        INIT_LOGGER = Logger.new('/dev/null')
-        CONFIGURE_LOGGER = Logger.new('/dev/null')
+        INIT_LOGGER = Logger.new(File::NULL)
+        CONFIGURE_LOGGER = Logger.new(File::NULL)
 
         honeybadger = Honeybadger::Config.new.init!(logger: INIT_LOGGER)
 

--- a/spec/unit/honeybadger/logging_spec.rb
+++ b/spec/unit/honeybadger/logging_spec.rb
@@ -38,7 +38,7 @@ describe Honeybadger::Logging::BootLogger.instance do
 end
 
 describe Honeybadger::Logging::FormattedLogger do
-  let(:logger) { Logger.new('/dev/null') }
+  let(:logger) { Logger.new(File::NULL) }
 
   subject { described_class.new(logger) }
 
@@ -54,7 +54,7 @@ end
 
 describe Honeybadger::Logging::ConfigLogger do
   let(:config) { Honeybadger::Config.new(debug: true, :'logging.tty_level' => tty_level) }
-  let(:logger) { Logger.new('/dev/null') }
+  let(:logger) { Logger.new(File::NULL) }
   let(:tty_level) { 'ERROR' }
 
   subject { described_class.new(config, logger) }


### PR DESCRIPTION
Pipe stderr from the `git rev-parse HEAD` to the null device (`/dev/null` on *nix, `NUL` on Windows). Also replaced references to /dev/null in the tests with Ruby's [`FIle::NULL`](https://ruby-doc.org/core-2.5.1/File/Constants.html) (available since Ruby 1.9), so tests can work on Windows also.