### PR TITLE
tests: add parallel_tests to gh_actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -49,8 +49,10 @@ jobs:
         bundler-cache: true
 
     - name: Build and test regular ruby
+      # Use 2 processes since GH actions has only 2 cores.
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       run: |
-        bundle exec rake
+        bundle exec rake parallel:spec[2]
 
   jruby:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -52,7 +52,7 @@ jobs:
       # Use 2 processes since GH actions has only 2 cores.
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       run: |
-        bundle exec rake parallel:spec[2]
+        bundle exec parallel_test -n 2 -e "rake spec"
 
   jruby:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'appraisal', '~> 2.1'
 gem 'aruba', '~> 0.14'
 gem 'rspec', '~> 3.0'
 gem 'rspec-its'
+gem 'parallel_tests'
 gem 'ruby-prof', platforms: :mri, require: false
 gem 'timecop'
 gem 'webmock'


### PR DESCRIPTION
## Parallelize tests

- Adds parallel_tests to parallelize the workflow in CI. (only 2 processes since its all GH actions supports)

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

https://github.com/grosser/parallel_tests