### PR TITLE
Use thor capture instead of full `run_command` from aruba.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,7 +46,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: '2.2.9'
         bundler-cache: true
 
     - name: Build and test regular ruby
@@ -75,7 +74,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: '2.2.9'
         bundler-cache: true
 
     - name: Build and test jruby

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -4,50 +4,60 @@ feature "Running the deploy cli command" do
   before { set_environment_variable('HONEYBADGER_BACKEND', 'debug') }
 
   it "notifies Honeybadger of the deploy" do
-    expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user')).to be_successfully_executed
+    output = capture(:stdout) { Honeybadger::CLI.start(%w[deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user]) }
+    expect(output).to match(/Deploy notification complete/)
   end
 
   context "when the options are invalid" do
     it "notifies the user" do
-      expect(run_command('honeybadger deploy --api-key= --environment=test-env --revision=test-rev --repository=test-repo --user=test-user')).not_to be_successfully_executed
-      expect(all_output).to match(/required.+api-key/i)
+      output = capture(:stdout) { expect{Honeybadger::CLI.start(%w[deploy --api-key= --environment=test-env --revision=test-rev --repository=test-repo --user=test-user])}.to raise_error(SystemExit) }
+      expect(output).to match(/No value provided for required options '--api-key'/)
     end
   end
 
   context "when there is a server error" do
-    before { set_environment_variable('DEBUG_BACKEND_STATUS', '500') }
-
     it "notifies the user" do
-      expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user')).not_to be_successfully_executed
-      expect(all_output).to match(/request failed/i)
+      set_environment_variable('DEBUG_BACKEND_STATUS', '500')
+      # Needs to be run via run_command since it must actually hit the
+      # server [Honeybadger::CLI.start()] will not produce the error.
+      cmd = run_command("honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user")
+      expect(cmd).not_to be_successfully_executed
+      expect(cmd.output).to match(/request failed/i)
+
+      ENV.delete("DEBUG_BACKEND_STATUS")
     end
   end
 
   context "when Rails is not detected due to a missing environment.rb" do
     it "skips rails initialization without logging" do
-      expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user --skip-rails-load')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user --skip-rails-load]) }
+      expect(output).not_to match(/Skipping Rails initialization/i)
     end
   end
 
   context "when Rails is detected via the presence of environment.rb" do
     before do
-      config_path = File.join(Dir.pwd, 'tmp', 'features', 'config')
-      Dir.mkdir(config_path) unless File.exists?(config_path)
+      @features_dir = File.join(Dir.pwd, 'tmp', 'features')
+      config_path = File.join(@features_dir, 'config')
+      Dir.mkdir(config_path) unless File.exist?(config_path)
       File.open(File.join(config_path, 'environment.rb'), 'w')
+      @_previous_dir = Dir.pwd
+      Dir.chdir(@features_dir)
     end
 
+    after { Dir.chdir(@_previous_dir) }
+
     it "skips rails initialization when true" do
-      expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user --skip-rails-load')).to be_successfully_executed
-      expect(all_output).to match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI::Main.start(%w[deploy --skip-rails-load --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user]) }
+      expect(output).to match(/Skipping Rails initialization/i)
     end
 
     it "does not skip rails initialization when false or not set" do
-      expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user --skip-rails-load=false')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user --skip-rails-load=false]) }
+      expect(output).to_not match(/Skipping Rails initialization/i)
 
-      expect(run_command('honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user]) }
+      expect(output).to_not match(/Skipping Rails initialization/i)
     end
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -11,20 +11,18 @@ feature "Running the deploy cli command" do
   context "when the options are invalid" do
     it "notifies the user" do
       output = capture(:stdout) { expect{Honeybadger::CLI.start(%w[deploy --api-key= --environment=test-env --revision=test-rev --repository=test-repo --user=test-user])}.to raise_error(SystemExit) }
-      expect(output).to match(/No value provided for required options '--api-key'/)
+      expect(output).to match(/required.+api-key/i)
     end
   end
 
   context "when there is a server error" do
+    before { set_environment_variable('DEBUG_BACKEND_STATUS', '500') }
+
     it "notifies the user" do
-      set_environment_variable('DEBUG_BACKEND_STATUS', '500')
-      # Needs to be run via run_command since it must actually hit the
-      # server [Honeybadger::CLI.start()] will not produce the error.
+
       cmd = run_command("honeybadger deploy --api-key=test-api-key --environment=test-env --revision=test-rev --repository=test-repo --user=test-user")
       expect(cmd).not_to be_successfully_executed
       expect(cmd.output).to match(/request failed/i)
-
-      ENV.delete("DEBUG_BACKEND_STATUS")
     end
   end
 

--- a/spec/features/exec_spec.rb
+++ b/spec/features/exec_spec.rb
@@ -1,25 +1,30 @@
 require 'honeybadger'
 
+
 feature "Running the exec cli command" do
   before { set_environment_variable('HONEYBADGER_BACKEND', 'debug') }
 
   it "quietly executes the requested command" do
-    expect(run_command('honeybadger exec --api-key=test-api-key ls')).to be_successfully_executed
-    expect(all_output).to be_empty
+    output = capture(:stdout) { Honeybadger::CLI.start(%w[exec --api-key=test-api-key ls]) }
+    expect(output).to be_empty
   end
 
   context "when the options are invalid" do
     it "notifies the user" do
-      expect(run_command('honeybadger exec --api-key= ls')).not_to be_successfully_executed
-      expect(all_output).to match(/required.+api-key/i)
+      output = capture(:stdout) do
+        expect{ Honeybadger::CLI.start(%w[exec --api-key= ls]) }.to raise_error(SystemExit)
+      end
+      expect(output).to match(/required.+api-key/i)
     end
   end
 
   context "when the command fails due to a non-zero exit code" do
     it "notifies Honeybadger of the failure" do
-      expect(run_command('honeybadger exec --api-key=test-api-key this-command-should-not-exist')).to be_successfully_executed
-      expect(all_output).to match(/failed.+this-command-should-not-exist/im)
-      expect(all_output).to match(/Successfully notified Honeybadger/i)
+      output = capture(:stdout) do
+        expect{Honeybadger::CLI.start(%w[exec --api-key=test-api-key this-command-should-not-exist])}.to raise_error(SystemExit)
+      end
+      expect(output).to match(/failed.+this-command-should-not-exist/im)
+      expect(output).to match(/Successfully notified Honeybadger/i)
     end
   end
 
@@ -32,31 +37,33 @@ feature "Running the exec cli command" do
     end
   end
 
-  context "when Rails is not detected due to a missing environment.rb" do
+context "when Rails is not detected due to a missing environment.rb" do
     it "skips rails initialization without logging" do
-      expect(run_command('honeybadger exec --api-key=test-api-key --skip-rails-load ls')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[exec --api-key=test-api-key --skip-rails-load ls]) }
+      expect(output).to_not match(/Skipping Rails initialization/i)
     end
   end
 
   context "when Rails is detected via the presence of environment.rb" do
-    before do
-      config_path = File.join(Dir.pwd, 'tmp', 'features', 'config')
-      Dir.mkdir(config_path) unless File.exists?(config_path)
-      File.open(File.join(config_path, 'environment.rb'), 'w')
+    before(:each) do
+      @config_path = File.join(Dir.pwd, 'config')
+      FileUtils.mkdir_p(@config_path) unless File.exist?(@config_path)
+      File.open(File.join(@config_path, 'environment.rb'), 'w')
     end
 
+    after(:each) { FileUtils.rm_rf(@config_path) }
+
     it "skips rails initialization when true" do
-      expect(run_command('honeybadger exec --api-key=test-api-key --skip-rails-load ls')).to be_successfully_executed
-      expect(all_output).to match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[exec --api-key=test-api-key --skip-rails-load ls]) }
+      expect(output).to match(/Skipping Rails initialization/i)
     end
 
     it "does not skip rails initialization when false or not set" do
-      expect(run_command('honeybadger exec --api-key=test-api-key --skip-rails-load=false ls')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[exec --api-key=test-api-key --skip-rails-load=false ls]) }
+      expect(output).to_not match(/Skipping Rails initialization/i)
 
-      expect(run_command('honeybadger exec --api-key=test-api-key ls')).to be_successfully_executed
-      expect(all_output).to_not match(/Skipping Rails initialization/i)
+      output = capture(:stdout) { Honeybadger::CLI.start(%w[exec --api-key=test-api-key ls]) }
+      expect(output).to_not match(/Skipping Rails initialization/i)
     end
   end
 end

--- a/spec/features/notify_spec.rb
+++ b/spec/features/notify_spec.rb
@@ -5,9 +5,9 @@ feature "Running the notify CLI command" do
   end
 
   it "requires the --message flag" do
-    expect(run_command('honeybadger notify')).to be_successfully_executed
-    expect(all_output).to match('--message')
-    assert_no_notification
+    output = capture(:stderr) { Honeybadger::CLI.start(%w[notify]) }
+    expect(output).to match('--message')
+    assert_no_notification(output)
   end
 
   context "with a message" do
@@ -42,7 +42,7 @@ feature "Running the notify CLI command" do
   context "when Rails is detected via the presence of environment.rb" do
     before do
       config_path = File.join(Dir.pwd, 'tmp', 'features', 'config')
-      Dir.mkdir(config_path) unless File.exists?(config_path)
+      Dir.mkdir(config_path) unless File.exist?(config_path)
       File.open(File.join(config_path, 'environment.rb'), 'w')
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'aruba/rspec'
+require 'aruba/api'
 require 'fileutils'
 require 'logger'
 require 'pathname'
@@ -48,7 +49,12 @@ RSpec.configure do |config|
   config.include Aruba::Api, type: :feature
   config.include FeatureHelpers, type: :feature
 
+  config.before(:all, type: :feature) do
+    require "honeybadger/cli"
+  end
+
   config.before(:each, type: :feature) do
+    setup_aruba
     set_environment_variable('HONEYBADGER_BACKEND', 'debug')
     set_environment_variable('HONEYBADGER_LOGGING_PATH', 'STDOUT')
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,7 +54,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :feature) do
-    setup_aruba
     set_environment_variable('HONEYBADGER_BACKEND', 'debug')
     set_environment_variable('HONEYBADGER_LOGGING_PATH', 'STDOUT')
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,10 +1,25 @@
 require 'json'
 
 module FeatureHelpers
+ # https://github.com/erikhuda/thor/blob/011dc48b5ea92767445b062f971664235973c8b4/spec/helper.rb#L49
+  def capture(stream)
+    begin
+      stream = stream.to_s
+      eval "$#{stream} = StringIO.new"
+      yield
+      result = eval("$#{stream}").string
+    ensure
+      eval("$#{stream} = #{stream.upcase}")
+    end
+
+    result
+  end
+
   # These override some deprecated Aruba helpers which are still useful to us.
   def all_output
     all_commands.map { |c| c.output }.join("\n")
   end
+
   def current_dir
     expand_path('.')
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -24,8 +24,8 @@ module FeatureHelpers
     expand_path('.')
   end
 
-  def assert_no_notification
-    expect(all_output).not_to match(/notifying debug backend of feature=notices/)
+  def assert_no_notification(output = all_output)
+    expect(output).not_to match(/notifying debug backend of feature=notices/)
   end
 
   def assert_notification(expected = {})


### PR DESCRIPTION
- Uses builtin thor capturing instead of spawning full processes.

So this isnt as full sweeping as I would have liked. Ideally I would have liked to rip out Aruba, but life is all about moderation. This will at least cut down on a decent number of `run_command` 's and should show at least a little improvement in speed. Let me know if you have any questions or comments!

I left the `install` and `notify` specs alone as they were quite...thorny...when attempting to refactor them, Aruba appears to do a lot of isolation for us.