### PR TITLE
By default ignore 'ActionDispatch::Http::MimeNegotiation::InvalidType'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
+  default ignore list.
+
 ## [4.8.0] - 2021-03-16
 ### Fixed
 - Suppress any error output from the `git rev-parse` command. ([#394](https://github.com/honeybadger-io/honeybadger-ruby/pull/394))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
-  default ignore list.
+  default ignore list. (#402, @jrochkind)
 
 ## [4.8.0] - 2021-03-16
 ### Fixed

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -23,6 +23,7 @@ module Honeybadger
                       'ActionController::ParameterMissing',
                       'ActiveRecord::RecordNotFound',
                       'ActionController::UnknownAction',
+                      'ActionDispatch::Http::MimeNegotiation::InvalidType',
                       'Rack::QueryParser::ParameterTypeError',
                       'Rack::QueryParser::InvalidParameterError',
                       'CGI::Session::CookieStore::TamperedWithCookie',


### PR DESCRIPTION
If a user-agent sends an Accept or Content-Type header with a mal-formed mime-type, then Rails raises. this happens in my app a lot as a result of what seems to be security vulnerability scanning, people sending Accept headers like `"../../../../../../../../../../etc/passwd{%00`

Rails is not vulnerable, everything is fine, but it raises. And Honeybadger then catches and reports. (This started in maybe Rails 6.0, before that malformed MIME type didn't raise, it was just ignored). 

Prior to Rals 6.1, the exception class was non-specific so it was hard to ignore/filter. But Rails 6.1 introduces an exception class just for this. Honeybadger should by default ignore it, it fits in with the other Rails stuff Honeybadger ignores by default.

