### PR TITLE
Properly set environment in deployment tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
-- Properly set environment in deployment tracking (#xxx, @stmllr)
+- Properly set environment in deployment tracking (#404, @stmllr)
 
 ## [4.8.0] - 2021-03-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
+- Properly set environment in deployment tracking (#xxx, @stmllr)
 
 ## [4.8.0] - 2021-03-16
 ### Fixed

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -204,7 +204,7 @@ module Honeybadger
     #   otherwise.
     def track_deployment(env: nil, revision: nil, local_username: nil, repository: nil)
       opts = {
-        env: env || config[:env],
+        environment: env || config[:env],
         revision: revision || config[:revision],
         local_username: local_username,
         repository: repository

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -195,16 +195,16 @@ module Honeybadger
     # @example
     #   Honeybadger.track_deployment(revision: 'be2ceb6')
     #
-    # @param [String] :env The environment name. Defaults to the current configured environment.
+    # @param [String] :environment The environment name. Defaults to the current configured environment.
     # @param [String] :revision The VCS revision being deployed. Defaults to the currently configured revision.
     # @param [String] :local_username The name of the user who performed the deploy.
     # @param [String] :repository The base URL of the VCS repository. It should be HTTPS-style.
     #
     # @return [Boolean] true if the deployment was successfully tracked and false
     #   otherwise.
-    def track_deployment(env: nil, revision: nil, local_username: nil, repository: nil)
+    def track_deployment(environment: nil, revision: nil, local_username: nil, repository: nil)
       opts = {
-        environment: env || config[:env],
+        environment: environment || config[:env],
         revision: revision || config[:revision],
         local_username: local_username,
         repository: repository

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -65,7 +65,7 @@ describe Honeybadger::Agent do
     it 'passes the revision to the servce' do
       allow_any_instance_of(Honeybadger::Util::HTTP).to receive(:compress) { |_, body| body }
       stub_request(:post, "https://api.honeybadger.io/v1/deploys").
-         with(body: { env: nil, revision: '1234', local_username: nil, repository: nil }).
+         with(body: { environment: nil, revision: '1234', local_username: nil, repository: nil }).
          to_return(status: 200)
 
       expect(instance.track_deployment(revision: '1234')).to eq(true)


### PR DESCRIPTION
The new `Honeybadger.track_deployment()` takes keyword argument `env`, but the underlying service API expects `environment`.
This ends up in deployments without environment being set.

In order to fix this without breaking the new API, the PR keeps `env` keyword argument, but "translates" it to `environment`.

Unfortunately there is inconsistent documentation:
`environment` https://docs.honeybadger.io/lib/ruby/getting-started/tracking-deployments.html#heroku-deployment-tracking
vs
`env` https://docs.honeybadger.io/lib/ruby/getting-started/tracking-deployments.html#ruby-deployment-tracking

Follow-up to #397
