### PR TITLE
Replace fixed number with Sidekiq constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
-- Replced fixed number for retries in Sidekiq Plugin with Sidekiq::JobRetry constant
+- Replaced fixed number for retries in Sidekiq Plugin with Sidekiq::JobRetry constant
 
 ## [4.8.0] - 2021-03-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
+- Replced fixed number for retries in Sidekiq Plugin with Sidekiq::JobRetry constant
 
 ## [4.8.0] - 2021-03-16
 ### Fixed


### PR DESCRIPTION
To avoid problems when Sidekiq may change the default JobRetry constant it may be better to replace the fixed number by the Sidekiq::JobRetry constant