### PR TITLE
Support nested (block-level) context (closes #247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- `Honeybadger.context` now accepts a block; the local context Hash will be added only
+  to exceptions that occur within the block.
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
 - Replaced fixed number for retries in Sidekiq Plugin with Sidekiq::JobRetry constant

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -213,10 +213,15 @@ module Honeybadger
       response.success?
     end
 
-    # Save global context for the current request.
+    # Save global context for the current request, or for a specific block.
     #
     # @example
     #   Honeybadger.context({my_data: 'my value'})
+    #
+    #   # Block-level context:
+    #   Honeybadger.context({local_data: 'my value'}) do
+    #     # Only exceptions raised here will have `local_data` added
+    #   end
     #
     #   # Inside a Rails controller:
     #   before_action do
@@ -250,8 +255,10 @@ module Honeybadger
     #   (optional).
     #
     # @return [self] so that method calls can be chained.
-    def context(context = nil)
-      context_manager.set_context(context) unless context.nil?
+    def context(context = nil, &block)
+      raise ArgumentError, 'The context Hash must be provided with a block' if block_given? && context.nil?
+      context_manager.set_context(context, &block) unless context.nil?
+
       self
     end
 


### PR DESCRIPTION
Another attempt at #247 

```ruby
Honeybadger.context({local1: value1}) do
    Honeybadger.context({local2: value2}) do
        # If an exception is raised here, the reported context will be
        # {local1: value1, local2: value2} + any global context
    end
end
```

The original attempt (#229) had a problem with possibly unintentional deletes when popping the stack. There was also a second problem—it actually didn't work because the [`ensure` section](https://github.com/honeybadger-io/honeybadger-ruby/pull/229/files#diff-222a2fa969feb3356be61fc923301b9be66f79d4801774a2111804157f621ecfR32-R33) gets called before the exception is rescued and reported, so the context was always deleted before being reported.😅

This PR leverages the existing `to_honeybadger_context` support. If an exception is raised, the local context will be attached to it, so when the agent eventually calls `to_honeybadger_context` on the exception ([here](https://github.com/honeybadger-io/honeybadger-ruby/blob/d6b301b18ed868ddf51713ad1770a080265ad63e/lib/honeybadger/notice.rb#L380)), it gets the local context. It only touches the raised exception, so it's thread-safe.

Note that this means this will only work for uncaught exceptions. If you manually call `honeybadger.notify` in a block, the nested context won't be added automatically. But I think that's a reasonable expectation, since you can manually set the context when calling `notify`.


