### PR TITLE
Allow special characters in tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Allow special characters in tags. Also Support space-delimited tags:
+- Allow special characters in tags. Also support space-delimited tags:
   "one two three" and "one, two, three" are equivalent
 
 ## [4.10.0] - 2022-01-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Allow special characters in tags. Also Support space-delimited tags:
+  "one two three" and "one, two, three" are equivalent
 
 ## [4.10.0] - 2022-01-19
 ### Added

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -53,11 +53,11 @@ module Honeybadger
 
     # @api private
     # The String character used to split tag strings.
-    TAG_SEPERATOR = ','.freeze
+    TAG_SEPERATOR = /,|\s/.freeze
 
     # @api private
     # The Regexp used to strip invalid characters from individual tags.
-    TAG_SANITIZER = /[^\w]/.freeze
+    TAG_SANITIZER = /\s/.freeze
 
     # @api private
     class Cause

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -809,21 +809,25 @@ describe Honeybadger::Notice do
   context "adding tags" do
     context "directly" do
       it "converts String to tags Array" do
-        expect(build_notice(tags: ' foo  , bar, ,  $baz   ').tags).to eq(%w(foo bar baz))
+        expect(build_notice(tags: ' foo  , bar, ,  baz   ').tags).to eq(%w(foo bar baz))
       end
 
       it "accepts an Array" do
-        expect(build_notice(tags: [' foo  ', ' bar', ' ', '  $baz   ']).tags).to eq(%w(foo bar baz))
+        expect(build_notice(tags: [' foo  ', ' bar', ' ', '  baz   ']).tags).to eq(%w(foo bar baz))
+      end
+
+      it "accepts whitespace-delimited tags" do
+        expect(build_notice(tags: [' foo bar  baz']).tags).to eq(%w(foo bar baz))
       end
     end
 
     context "from context" do
       it "converts String to tags Array" do
-        expect(build_notice(context: { tags: ' foo  , , bar,  $baz   ' }).tags).to eq(%w(foo bar baz))
+        expect(build_notice(context: { tags: ' foo  , , bar,  baz   ' }).tags).to eq(%w(foo bar baz))
       end
 
       it "accepts an Array" do
-        expect(build_notice(tags: [' foo  ', ' bar', ' ', '  $baz   ']).tags).to eq(%w(foo bar baz))
+        expect(build_notice(tags: [' foo  ', ' bar', ' ', '  baz   ']).tags).to eq(%w(foo bar baz))
       end
     end
 
@@ -835,6 +839,10 @@ describe Honeybadger::Notice do
 
     it "converts nil to empty Array" do
       expect(build_notice(tags: nil).tags).to eq([])
+    end
+
+    it "allows non-word characters in tags while stripping whitespace" do
+      expect(build_notice(tags: 'word,  with_underscore ,with space, with-dash,with$special*char').tags).to eq(%w(word with_underscore with space with-dash with$special*char))
     end
   end
 


### PR DESCRIPTION
Also adds support for space-delimited tags; these strings are
equivalent:

- "foo, bar, baz"
- "foo bar baz"
- "foo, bar baz"

Fixes #421