### PR TITLE
 Improved AWS Lambda integration using decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Improved AWS Lambda integration with `hb_lambda` decorator
+- Added `hb_wrap_handler` to automatically capture AWS Lambda handler errors
 
 ### Fixed
 - Change `:exception_message` key name to just `:exception` for error breadcrumb metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Improved AWS Lambda integration with `hb_lambda` decorator
 
 ## [4.11.0] - 2022-02-15
 ### Fixed

--- a/lib/honeybadger/plugin.rb
+++ b/lib/honeybadger/plugin.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 
 module Honeybadger
   # +Honeybadger::Plugin+ defines the API for registering plugins with
-  # Honeybadger. Each plugin has requirements which must be satisified before
+  # Honeybadger. Each plugin has requirements which must be satisfied before
   # executing the plugin's execution block(s). This allows us to detect
   # optional dependencies and load the plugin for each dependency only if it's
   # present in the application.
@@ -62,7 +62,7 @@ module Honeybadger
       #     execution { }
       #   end
       #
-      # @param [String] name The optional name of the plugin. Should use
+      # @param [String, Symbol] name The optional name of the plugin. Should use
       #   +snake_case+. The name is inferred from the current file name if omitted.
       #
       # @return nil

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -48,7 +48,7 @@ module Honeybadger
         # So we provide a decorator for both cases
         main = TOPLEVEL_BINDING.eval("self")
         main.extend(LambdaExtension)
-        Class.include(LambdaExtension)
+        ::Class.include(LambdaExtension)
 
         (config[:before_notify] ||= []) << lambda do |notice|
           data = Util::Lambda.normalized_data

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -27,7 +27,7 @@ module Honeybadger
           mod = Module.new do
             handler_names.each do |handler|
               define_method(handler) do |event:, context:|
-                Honeybadger.context({ aws_request_id: context.aws_request_id }) if context.respond_to?(:aws_request_id)
+                Honeybadger.context(aws_request_id: context.aws_request_id) if context.respond_to?(:aws_request_id)
 
                 super(event: event, context: context)
               rescue => e

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -13,7 +13,9 @@ module Honeybadger
         #   # Handler code
         # end
         #
-        # class Lambda
+        # class MyLambdaApp
+        #   extend ::Honeybadger::Plugins::LambdaExtension
+        #
         #   hb_lambda def self.my_lambda_handler(event:, context:)
         #     # Handler code
         #   end
@@ -43,12 +45,8 @@ module Honeybadger
       execution do
         config[:sync] = true
 
-        # AWS Lambda handlers may be top-level methods or class methods
-        # See https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html
-        # So we provide a decorator for both cases
         main = TOPLEVEL_BINDING.eval("self")
         main.extend(LambdaExtension)
-        ::Class.include(LambdaExtension)
 
         (config[:before_notify] ||= []) << lambda do |notice|
           data = Util::Lambda.normalized_data

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -20,10 +20,10 @@ module Honeybadger
         # end
         def hb_lambda(handler_name)
           original_method = method(handler_name)
-          self.define_singleton_method(handler_name) do |*args|
-            Honeybadger.context({ aws_request_id: args[0][:context].aws_request_id }) if args[0][:context].respond_to?(:aws_request_id)
+          self.define_singleton_method(handler_name) do |event:, context:|
+            Honeybadger.context({ aws_request_id: context.aws_request_id }) if context.respond_to?(:aws_request_id)
 
-            original_method.call(*args)
+            original_method.call(event: event, context: context)
           rescue => e
             Honeybadger.notify(e)
             # Bubble the error up to Lambda, but disable other reporting to avoid duplicates in local emulated environments

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -3,12 +3,53 @@ require 'honeybadger/util/lambda'
 
 module Honeybadger
   module Plugins
+    module LambdaExtension
+      unless self.respond_to?(:hb_lambda)
+        # Decorator for Lambda handlers so exceptions can be automatically captured
+        #
+        # Usage:
+        #
+        # hb_lambda def my_lambda_handler(event:, context:)
+        #   # Handler code
+        # end
+        #
+        # class Lambda
+        #   hb_lambda def self.my_lambda_handler(event:, context:)
+        #     # Handler code
+        #   end
+        # end
+        def hb_lambda(handler_name)
+          original_method = method(handler_name)
+          self.define_singleton_method(handler_name) do |*args|
+            Honeybadger.context({ aws_request_id: args[0][:context].aws_request_id }) if args[0][:context].respond_to?(:aws_request_id)
+
+            original_method.call(*args)
+          rescue => e
+            Honeybadger.notify(e)
+            # Bubble the error up to AWS Lambda, but mark as reported
+            # to avoid duplicates in local emulated environments
+            Honeybadger.config[:'exceptions.notify_at_exit'] = false
+            raise
+          end
+        end
+      end
+    end
+
+
     # @api private
     Plugin.register :lambda do
       requirement { Util::Lambda.lambda_execution? }
 
       execution do
         config[:sync] = true
+
+        # AWS Lambda handlers may be top-level methods or class methods
+        # See https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html
+        # So we provide a decorator for both cases
+        main = TOPLEVEL_BINDING.eval("self")
+        main.extend(LambdaExtension)
+        Class.include(LambdaExtension)
+
         (config[:before_notify] ||= []) << lambda do |notice|
           data = Util::Lambda.normalized_data
 

--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -26,8 +26,8 @@ module Honeybadger
             original_method.call(*args)
           rescue => e
             Honeybadger.notify(e)
-            # Bubble the error up to AWS Lambda, but mark as reported
-            # to avoid duplicates in local emulated environments
+            # Bubble the error up to Lambda, but disable other reporting to avoid duplicates in local emulated environments
+            # Since the process immediately exits, nothing else is affected
             Honeybadger.config[:'exceptions.notify_at_exit'] = false
             raise
           end

--- a/spec/unit/honeybadger/plugins/lambda_spec.rb
+++ b/spec/unit/honeybadger/plugins/lambda_spec.rb
@@ -23,12 +23,14 @@ describe "Lambda Plugin" do
     it 'auto-captures errors from class methods when decorator is used' do
       expect(Honeybadger).to receive(:notify).with kind_of(RuntimeError)
       Honeybadger::Plugin.instances[:lambda].load!(config)
+
       klass = Class.new do
         extend ::Honeybadger::Plugins::LambdaExtension
-        hb_wrap_handler :test_handler
+
         def self.test_handler(event:, context:)
           raise "An exception"
         end
+        hb_wrap_handler :test_handler
       end
 
       expect { klass.test_handler(event: {}, context: {}) }.to raise_error(RuntimeError, "An exception")
@@ -45,6 +47,7 @@ describe "Lambda Plugin" do
         end
         hb_wrap_handler :test_handler
       end
+
       expect { main.test_handler(event: {}, context: {}) }.to raise_error(RuntimeError, "An exception")
     end
   end

--- a/spec/unit/honeybadger/plugins/lambda_spec.rb
+++ b/spec/unit/honeybadger/plugins/lambda_spec.rb
@@ -1,7 +1,7 @@
 require 'honeybadger/plugins/lambda'
 require 'honeybadger/config'
 
-describe "Lambda Plugin", :focus do
+describe "Lambda Plugin" do
   let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, backend: :test, api_key: "noop") }
 
   before do


### PR DESCRIPTION
This PR addresses the issues raised on Slack with the AWS Lambda integration. [The docs say](https://docs.honeybadger.io/lib/ruby/integration-guides/aws-lambda-exception-tracking/#capturing-exceptions):

> Our client does not provide an automatic way to handle uncaught lambda exceptions

Well, let's fix that!

```ruby
hb_lambda def my_lambda_handler(event:, context:)
  # Handler code
end
```

With the `hb_lambda ` decorator, errors will now be caught automatically. The `aws_request_id` will also be included in the captured context. It's opt-in (you have to decorate your handlers), so fully backwards-compatible.

### Notes
1. I've included this method twice, on the global object `main`, and on all `Class` objects, since [Lambda handlers can also be class methods](https://docs.aws.amazon.com/lambda/latest/dg/ruby-handler.html).
2. When the exception is reported, it disables the  "report on exit" setting, because on a local environment, the `at_exist` handler is also triggered, leading to two reports of each error.
3. I'm not sold on the name; would `lambda_handler` be better?

---

Will send in a docs PR later.