### PR TITLE
Change exception_message key name for error breadcrumb metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Change `:exception_message` key name to just `:exception` for error breadcrumb metadata.
+
+### Added
 - Added 'ActionDispatch::Http::MimeNegotiation::InvalidType' (Rails 6.1) to
   default ignore list. (#402, @jrochkind)
 

--- a/lib/honeybadger/rack/error_notifier.rb
+++ b/lib/honeybadger/rack/error_notifier.rb
@@ -74,7 +74,7 @@ module Honeybadger
           agent.add_breadcrumb(
             exception.class,
             metadata: {
-              exception_message: exception.message
+              message: exception.message
             },
             category: "error"
           )


### PR DESCRIPTION
This fixes a display issue:

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/474649/160012272-2871ff2d-21ae-4403-ae37-f6855d6a50d7.png">
