### PR TITLE
hb_wrap_handler: Support calling on Kernel

### DIFF
--- a/lib/honeybadger/plugins/lambda.rb
+++ b/lib/honeybadger/plugins/lambda.rb
@@ -39,6 +39,7 @@ module Honeybadger
         end
 
         self.singleton_class.prepend(mod)
+        Kernel.singleton_class.prepend(mod) if self == TOPLEVEL_BINDING.eval("self")
       end
     end
 


### PR DESCRIPTION
Small (but key) addition to #423

## TL; DR:

I noticed that `serverless-offline` [invokes top-level handlers via `Kernel.send(:handler)`](https://github.com/dherault/serverless-offline/blob/dc510b3eec4567aa4d1558b6218cc7a40c297031/src/lambda/handler-runner/ruby-runner/invoke.rb#L77-L83) (as opposed to just `handler` or even `main.handler`). This means it doesn't call our wrapped handler (because it's defined on `main`, not `Kernel`).


This PR fixes that by ensuring the method is also present on `Kernel`, so either way of invoking works.


## Full details
Turns out that Ruby's top level is more complicated than I thought. It's not just an instance of `Object` called `main`, it's also the `Kernel` module, which is included in every class (including Kernel's own singleton class). So every "global" function is actually a private method on every object. So, you can do something like this:

```ruby
def my_handler; p "called"; end

class X; end

X.new.send(:my_handler) # Works!
X.send(:my_handler) # Also works!
```

But our wrapped methods are currently only prepended to main. The only foolproof way would be to add them to Kernel, so they can be available everywhere.

I did _not_ do this however, because we want to avoid silently patching every single class. I added it to Kernel's singleton class so it works with `Kernel.send`, since that's (I think) the only other way this is likely to be invoked.

