### PR TITLE
Remove Ruby 2.6 from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
@@ -35,8 +34,6 @@ jobs:
             ruby: '3.0'
           - gemfile: rails5.2.gemfile
             ruby: '3.1'
-          - gemfile: rails7.0.gemfile
-            ruby: '2.6'
 
     # Has to be top level to cache properly
     env:


### PR DESCRIPTION
Ref: #429 

There's also a bunch of dead code for supporting 2.5 and below that I've removed locally; once we bump the official minimum version to 2.6, I can raise a PR for those too.