### PR TITLE
Fix a bug where the auto-detected revision is blank instead of nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fix a bug where the auto-detected revision is blank instead of nil
 
 ## [4.12.1] - 2022-04-01
 ### Fixed

--- a/lib/honeybadger/util/revision.rb
+++ b/lib/honeybadger/util/revision.rb
@@ -7,8 +7,8 @@ module Honeybadger
             from_capistrano(root) ||
             from_git
 
-          revision.strip!
-          return nil unless revision =~ /\S/
+          revision = revision.to_s.strip
+          return unless revision =~ /\S/
 
           revision
         end
@@ -20,7 +20,7 @@ module Honeybadger
         #
         # See https://devcenter.heroku.com/articles/dyno-metadata
         def from_heroku
-          ENV['HEROKU_SLUG_COMMIT'].dup
+          ENV['HEROKU_SLUG_COMMIT']
         end
 
         def from_capistrano(root)

--- a/lib/honeybadger/util/revision.rb
+++ b/lib/honeybadger/util/revision.rb
@@ -3,9 +3,14 @@ module Honeybadger
     class Revision
       class << self
         def detect(root = Dir.pwd)
-          from_heroku ||
+          revision = from_heroku ||
             from_capistrano(root) ||
             from_git
+
+          revision.strip!
+          return nil unless revision =~ /\S/
+
+          revision
         end
 
         private
@@ -15,18 +20,18 @@ module Honeybadger
         #
         # See https://devcenter.heroku.com/articles/dyno-metadata
         def from_heroku
-          ENV['HEROKU_SLUG_COMMIT']
+          ENV['HEROKU_SLUG_COMMIT'].dup
         end
 
         def from_capistrano(root)
           file = File.join(root, 'REVISION')
           return nil unless File.file?(file)
-          File.read(file).strip rescue nil
+          File.read(file) rescue nil
         end
 
         def from_git
           return nil unless File.directory?('.git')
-          `git rev-parse HEAD 2> #{File::NULL}`.strip rescue nil
+          `git rev-parse HEAD 2> #{File::NULL}` rescue nil
         end
       end
     end

--- a/spec/unit/honeybadger/util/revision_spec.rb
+++ b/spec/unit/honeybadger/util/revision_spec.rb
@@ -19,8 +19,13 @@ describe Honeybadger::Util::Revision do
     expect(Honeybadger::Util::Revision.detect).to eq('heroku revision')
   end
 
-  it "removes empty string revision" do
+  it "returns nil when detected value is a blank string" do
     allow(Honeybadger::Util::Revision).to receive(:from_git).and_return(" ")
+    expect(Honeybadger::Util::Revision.detect).to eq(nil)
+  end
+
+  it "returns nil when detected value is nil" do
+    allow(Honeybadger::Util::Revision).to receive(:from_git).and_return(nil)
     expect(Honeybadger::Util::Revision.detect).to eq(nil)
   end
 end

--- a/spec/unit/honeybadger/util/revision_spec.rb
+++ b/spec/unit/honeybadger/util/revision_spec.rb
@@ -18,4 +18,9 @@ describe Honeybadger::Util::Revision do
     ENV['HEROKU_SLUG_COMMIT'] = 'heroku revision'
     expect(Honeybadger::Util::Revision.detect).to eq('heroku revision')
   end
+
+  it "removes empty string revision" do
+    allow(Honeybadger::Util::Revision).to receive(:from_git).and_return(" ")
+    expect(Honeybadger::Util::Revision.detect).to eq(nil)
+  end
 end


### PR DESCRIPTION
This came up in a support ticket. I don't know *why* the detected revision was blank, but this should prevent that case in the future.

<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_70eox)