### PR TITLE
Initialize Honeybadger before other Rails initializers (closes #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Honeybadger is now initialized before Rails' initializers, allowing you to report errors raised during startup.
+
 ### Fixed
 - Fix a bug where the auto-detected revision is blank instead of nil
 

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -17,7 +17,7 @@ module Honeybadger
           app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback)
         end
 
-        config.after_initialize do
+        config.before_initialize do
           Honeybadger.init!({
             :root           => ::Rails.root.to_s,
             :env            => ::Rails.env,
@@ -25,6 +25,9 @@ module Honeybadger
             :logger         => Logging::FormattedLogger.new(::Rails.logger),
             :framework      => :rails
           })
+        end
+
+        config.after_initialize do
           Honeybadger.load_plugins!
         end
       end

--- a/spec/integration/rails_helper.rb
+++ b/spec/integration/rails_helper.rb
@@ -28,6 +28,7 @@ def load_rails_hooks(spec)
     # Because we create a new Agent after each spec run, we need to make sure
     # that rerun the after_initialize hook to initilize our Agent
     if RailsApp.initialized?
+      ActiveSupport.run_load_hooks(:before_initialize, RailsApp)
       ActiveSupport.run_load_hooks(:after_initialize, RailsApp)
     else
       RailsApp.initialize!


### PR DESCRIPTION
Closes #383 

Makes use of the Railtie `before_initialize` hook, which has been around [for a while](https://github.com/rails/rails/commit/3afdfc35e8aec7e6379e093dd1278cb3de54f21b).

`before_initialize` runs after Rails' config and application has booted, but before the framework initializers are run ([docs](https://guides.rubyonrails.org/configuring.html#initialization-events)).

Results:

Error is captured in `at_exit` hook. Basic env information is present.

![image](https://user-images.githubusercontent.com/14361073/181619178-a8960be9-6144-4fad-a9f9-f6f7f076c5b1.png)


![image](https://user-images.githubusercontent.com/14361073/181619321-c1271bb5-b4d3-47e4-9011-76742f461524.png)
