### PR TITLE
Fix inadvertent creation of invalid sessions (closes #435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Fix a bug where the auto-detected revision is blank instead of nil
+- Fix inadvertent creation of invalid sessions (#441)
 
 ## [4.12.1] - 2022-04-01
 ### Fixed

--- a/lib/honeybadger/util/request_hash.rb
+++ b/lib/honeybadger/util/request_hash.rb
@@ -28,7 +28,7 @@ module Honeybadger
         return {} unless defined?(::Rack::Request)
         return {} unless env
 
-        hash, request = {}, ::Rack::Request.new(env)
+        hash, request = {}, ::Rack::Request.new(env.dup)
 
         hash[:url] = extract_url(request)
         hash[:params] = extract_params(request)


### PR DESCRIPTION
Fixes #435

A bit hidden, but the [Rack docs mention](https://www.rubydoc.info/gems/rack/Rack/Request)

> It is stateless, the environment env passed to the constructor will be directly modified.

This affects other things, like creating invalid sessions when in API mode.