### PR TITLE
Return existing notice ID if already reported

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -37,6 +37,7 @@ appraise 'rails5.2' do
   gem 'better_errors', require: false, platforms: :mri
   gem 'rack-mini-profiler', require: false
   gem 'rspec-rails'
+  gem 'tzinfo-data' # Needed for timezones to work on Windows
 end
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
@@ -57,6 +58,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
     gem 'rack-mini-profiler', require: false
     gem 'rspec-rails'
     gem 'listen'
+    gem 'tzinfo-data' # Needed for timezones to work on Windows
   end
 
   appraise 'rails7.0' do
@@ -66,6 +68,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
     gem 'better_errors', require: false, platforms: :mri
     gem 'rack-mini-profiler', require: false
     gem 'rspec-rails'
+    gem 'tzinfo-data' # Needed for timezones to work on Windows
   end
 
   # Rails edge
@@ -82,6 +85,7 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
     # it present when generating a new Rails app), so Rails expects it to be
     # there. See https://github.com/rails/rails/pull/24066
     gem 'listen'
+    gem 'tzinfo-data' # Needed for timezones to work on Windows
   end
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Replace deployhook with release webhook (#444)
   See https://blog.heroku.com/deployhooks-sunset
 
+### Changed
+- `Honeybadger.notify` is now idempotent; it will skip reporting exception objects that have already been reported before, and simply return the existing notice ID.
+
 ## [5.0.0.beta1] - 2022-08-15
 ### Changed
 - Honeybadger is now initialized before Rails' initializers, allowing you to

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -25,6 +25,7 @@ gem "sqlite3", "~> 1.4", platforms: :mri
 gem "better_errors", require: false, platforms: :mri
 gem "rspec-rails"
 gem "listen"
+gem "tzinfo-data"
 
 group :development do
   gem "guard"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -24,6 +24,7 @@ gem "activerecord-jdbcsqlite3-adapter", "~> 52", platforms: :jruby
 gem "better_errors", require: false, platforms: :mri
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
+gem "tzinfo-data"
 
 group :development do
   gem "guard"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -25,6 +25,7 @@ gem "better_errors", require: false, platforms: :mri
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
 gem "listen"
+gem "tzinfo-data"
 
 group :development do
   gem "guard"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -24,6 +24,7 @@ gem "activerecord-jdbcsqlite3-adapter", "~> 60", platforms: :jruby
 gem "better_errors", require: false, platforms: :mri
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
+gem "tzinfo-data"
 
 group :development do
   gem "guard"

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -174,7 +174,10 @@ module Honeybadger
         push(notice)
       end
 
-      exception_or_opts.instance_variable_set(:@__hb_notice_id, notice.id) if exception_or_opts.is_a?(Exception)
+      if exception_or_opts.is_a?(Exception)
+        exception_or_opts.instance_variable_set(:@__hb_notice_id, notice.id) unless exception_or_opts.frozen?
+      end
+
       notice.id
     end
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -122,7 +122,9 @@ module Honeybadger
       opts = opts.dup
 
       if exception_or_opts.is_a?(Exception)
-        return nil if exception_or_opts.instance_variable_get(:@__hb_handled)
+        already_reported_notice_id = exception_or_opts.instance_variable_get(:@__hb_notice_id)
+        return already_reported_notice_id if already_reported_notice_id
+
         opts[:exception] = exception_or_opts
       elsif exception_or_opts.respond_to?(:to_hash)
         opts.merge!(exception_or_opts.to_hash)
@@ -172,6 +174,7 @@ module Honeybadger
         push(notice)
       end
 
+      exception_or_opts.instance_variable_set(:@__hb_notice_id, notice.id) if exception_or_opts.is_a?(Exception)
       notice.id
     end
 

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -36,7 +36,6 @@ module Honeybadger
           tags = ["severity:#{severity}", "handled:#{handled}"]
           tags << "source:#{source}" if source
           Honeybadger.notify(exception, context: context, tags: tags)
-          exception.instance_variable_set(:@__hb_handled, true)
         end
       end
 

--- a/spec/integration/rails/error_subscriber_spec.rb
+++ b/spec/integration/rails/error_subscriber_spec.rb
@@ -52,7 +52,7 @@ describe "Rails error subscriber integration", if: defined?(::ActiveSupport::Err
 
   it "doesn't report errors from ignored sources", if: RAILS_ERROR_SOURCE_SUPPORTED do
     Honeybadger.configure do |config|
-      config[:'rails.subscriber_ignore_sources'] += [/ignored/]
+      config.rails.subscriber_ignore_sources += [/ignored/]
     end
 
     Honeybadger.flush do

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -109,8 +109,9 @@ describe Honeybadger::Agent do
     it "does not report an already reported exception" do
       instance = described_class.new(Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER))
       exception = RuntimeError.new
-      exception.instance_variable_set(:@__hb_handled, true)
-      expect(instance.notify(exception)).to be_nil
+      notice_id = '4g09ko4f'
+      exception.instance_variable_set(:@__hb_notice_id, notice_id)
+      expect(instance.notify(exception)).to be notice_id
       expect(Honeybadger::Notice).to_not receive(:new)
     end
 


### PR DESCRIPTION
More testing of the Rails' error subscriber shows an error might be reported multiple times (for instance, relayed by Rails to our error subscriber, then raised and caught by our Rack middleware). We already handle this, but we don't set the Rack env's `honeybadger.error_id` properly if the error is already reported. This PR fixes that.
