### PR TITLE
Ignore Sidekiq::JobRetry::Skip by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+- Ignore Sidekiq::JobRetry skip exception. Since support was added for Rails 7
+  error reporting interface these exeptions are being reported in addition to
+  the exception that caused the job to be retried. Mike Perham says these
+  exceptions can safely be ignored.
+  See https://github.com/rails/rails/pull/43625#issuecomment-1071574110
 ## [5.0.0] - 2022-10-18
 ### Changed
 - `Honeybadger.notify` is now idempotent; it will skip reporting exception

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -28,7 +28,8 @@ module Honeybadger
                       'Rack::QueryParser::InvalidParameterError',
                       'CGI::Session::CookieStore::TamperedWithCookie',
                       'Mongoid::Errors::DocumentNotFound',
-                      'Sinatra::NotFound'].map(&:freeze).freeze
+                      'Sinatra::NotFound',
+                      'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
     DEVELOPMENT_ENVIRONMENTS = ['development', 'test', 'cucumber'].map(&:freeze).freeze
 


### PR DESCRIPTION
* Since upgrading to Honeybadger 5.0 we are getting duplicate errors reported for Sidekiq::JobRetry::Skip and another reported error for the exception that caused the Sidekiq job to be retried.
* There was a pr merged to Sentry for a similar issue and Mike Perham said this exception could be ignored. https://github.com/getsentry/sentry-ruby/pull/1763 https://github.com/rails/rails/pull/43625#issuecomment-1071574110

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Add an entry to the CHANGELOG.
