### PR TITLE
Expose `notice.parsed_backtrace` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG](http://keepachangelog.com/) for how to update this file. This project
 adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Expose `notice.parsed_backtrace` (#454)
 
 ## [5.0.2] - 2022-11-04
 ### Fixed

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -235,7 +235,7 @@ module Honeybadger
           token: id,
           class: s(error_class),
           message: s(error_message),
-          backtrace: s(parse_backtrace(backtrace)),
+          backtrace: s(parsed_backtrace),
           fingerprint: fingerprint_hash,
           tags: s(tags),
           causes: s(prepare_causes(causes))
@@ -278,6 +278,11 @@ module Honeybadger
     # Determines if this notice will be discarded.
     def halted?
       !!@halted
+    end
+
+    # Get the parsed exception backtrace.
+    def parsed_backtrace
+      @parsed_backtrace ||= parse_backtrace(backtrace)
     end
 
     private

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -655,6 +655,20 @@ describe Honeybadger::Notice do
     end
   end
 
+  describe "#parsed_backtrace" do
+    let(:backtrace) { ["my/file/backtrace.rb:3:in `magic'"] }
+
+    let(:exception) { build_exception({ backtrace: backtrace }) }
+
+    it "returns the parsed backtrace" do
+      expect(Honeybadger::Backtrace).to receive(:parse).once.and_call_original
+      notice =  build_notice({exception: exception, config: config})
+      expect(notice.parsed_backtrace.first[:number]).to eq '3'
+      expect(notice.parsed_backtrace.first[:file]).to eq 'my/file/backtrace.rb'
+      expect(notice.parsed_backtrace.first[:method]).to eq 'magic'
+    end
+  end
+
   describe "#to_json" do
     context "when local variables are found" do
       it "sends local_variables in request payload" do


### PR DESCRIPTION
Closes #442