### PR TITLE
Document `parsed_backtrace`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,7 +55,7 @@ jobs:
         bundle exec rake
 
   jruby:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # ubuntu-latest is currently 22.04, which doesn't have a supported JRuby 9 build yet
     strategy:
       matrix:
         ruby:

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -144,6 +144,14 @@ module Honeybadger
     # Custom details data
     attr_accessor :details
 
+    # The parsed exception backtrace. Lines in this backtrace that are from installed gems
+    # have the base path for gem installs replaced by "[GEM_ROOT]", while those in the project
+    # have "[PROJECT_ROOT]".
+    # @return [Array<{:number, :file, :method => String}>]
+    def parsed_backtrace
+      @parsed_backtrace ||= parse_backtrace(backtrace)
+    end
+
     # @api private
     # Cache project path substitutions for backtrace lines.
     PROJECT_ROOT_CACHE = {}
@@ -278,14 +286,6 @@ module Honeybadger
     # Determines if this notice will be discarded.
     def halted?
       !!@halted
-    end
-
-    # The parsed exception backtrace. Lines in this backtrace that are from installed gems
-    # have the base path for gem installs replaced by "[GEM_ROOT]", while those in the project
-    # have "[PROJECT_ROOT]".
-    # @return [Array<{:number, :file, :method => String}>]
-    def parsed_backtrace
-      @parsed_backtrace ||= parse_backtrace(backtrace)
     end
 
     private

--- a/lib/honeybadger/notice.rb
+++ b/lib/honeybadger/notice.rb
@@ -280,7 +280,10 @@ module Honeybadger
       !!@halted
     end
 
-    # Get the parsed exception backtrace.
+    # The parsed exception backtrace. Lines in this backtrace that are from installed gems
+    # have the base path for gem installs replaced by "[GEM_ROOT]", while those in the project
+    # have "[PROJECT_ROOT]".
+    # @return [Array<{:number, :file, :method => String}>]
     def parsed_backtrace
       @parsed_backtrace ||= parse_backtrace(backtrace)
     end


### PR DESCRIPTION
I noticed there's gem documentation at https://www.rubydoc.info/gems/honeybadger/Honeybadger/Notice, so I added YARD docs for the method. A bit tricky because YARD's syntax for Hash shapes is weak, but I think this should do it. Also relocated the method so it's together with other accessors.