### PR TITLE
Jobs: Use backend-specific error handlers rather than Rails' ErrorSubscriber

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -303,7 +303,7 @@ module Honeybadger
       },
       :'rails.subscriber_ignore_sources' => {
         description: "Sources (strings or regexes) that should be ignored when using the Rails' (7+) native error reporter.",
-        default: [],
+        default: [/sidekiq.active_job/], # Sidekiq's error handler provides more context than Rails'
         type: Array
       },
       :'resque.resque_retry.send_exceptions_when_retrying' => {


### PR DESCRIPTION
Turns out that using the Rails ErrorSubscriber for jobs may result in a loss of context. Sidekiq [wraps its executions in Rails' reloader](https://github.com/mperham/sidekiq/blob/93f8ede3c1f8644263552f242088d9537ec03b9e/lib/sidekiq/rails.rb#L14) but does not call `Rails.error.report` when an error happens. This means the error is reported by ActiveSupport, which has no context about the specific job, etc. We should stick to the native error handler for the job backend.

Currently observed this only with SIdekiq, but will check if it applies to other backends too. Also, this change will only work when https://github.com/mperham/sidekiq/pull/5682 is merged.