### PR TITLE
Fix Rails middleware on Rails 7.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,8 +33,6 @@ jobs:
           - sidekiq7.gemfile
           - standalone.gemfile
         exclude:
-          - gemfile: delayed_job.gemfile
-            ruby: '2.7'
           - gemfile: rails5.2.gemfile
             ruby: '3.0'
           - gemfile: rails5.2.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,6 +33,8 @@ jobs:
           - sidekiq7.gemfile
           - standalone.gemfile
         exclude:
+          - gemfile: delayed_job.gemfile
+            ruby: '2.7'
           - gemfile: rails5.2.gemfile
             ruby: '3.0'
           - gemfile: rails5.2.gemfile

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -13,7 +13,7 @@ module Honeybadger
         #
         # @return The super value of the middleware's +#render_exception()+
         #   method.
-        def render_exception(arg, exception)
+        def render_exception(arg, exception, *args)
           if arg.kind_of?(::ActionDispatch::Request)
             request = arg
             env = request.env
@@ -25,7 +25,7 @@ module Honeybadger
           env['honeybadger.exception'] = exception
           env['honeybadger.request.url'] = request.url rescue nil
 
-          super(arg, exception)
+          super(arg, exception, *args)
         end
       end
 


### PR DESCRIPTION
Fixes #463 

An extra argument was added to the `DebugExceptions` middleware in https://github.com/rails/rails/commit/c066440b92a31bfd5cdd78b4d2677fcf20860437. We should simply pass along all arguments.