### PR TITLE
Update checkout to v3 to resolve Node 12 deprecation warning.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -50,7 +50,7 @@ jobs:
       BUNDLE_PATH: "vendor/bundle"
       BUNDLE_WITHOUT: "development"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
@@ -81,7 +81,7 @@ jobs:
       BUNDLE_PATH: "vendor/bundle"
       BUNDLE_WITHOUT: "development"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JRuby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
I don't think this really merits a CHANGELOG entry so I didn't add one.