### PR TITLE
Add support for reporting nested context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Support for Karafka (#480)
+- Support for nested `to_honeybadger_context` (#487)
 
 ## [5.2.1] - 2023-03-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Support for Karafka (#480)
-- Support for nested `to_honeybadger_context` (#487)
+- Support for nested `to_honeybadger_context` (#488)
 
 ## [5.2.1] - 2023-03-14
 ### Fixed

--- a/lib/honeybadger/conversions.rb
+++ b/lib/honeybadger/conversions.rb
@@ -2,15 +2,24 @@ module Honeybadger
   # @api private
   module Conversions
     module_function
+    MAX_CONTEXT_DEPTH = 20
 
     # Convert context into a Hash.
     #
     # @param [Object] object The context object.
     #
     # @return [Hash] The hash context.
-    def Context(object)
+    def Context(object, depth = 1)
       object = object.to_honeybadger_context if object.respond_to?(:to_honeybadger_context)
-      Hash(object)
+      object = Hash(object)
+      object = object.transform_values do |value|
+        if value&.respond_to?(:to_honeybadger_context)
+          Context(value, depth + 1)
+        else
+          value
+        end
+      end if depth < MAX_CONTEXT_DEPTH
+      object
     end
   end
 end

--- a/lib/honeybadger/conversions.rb
+++ b/lib/honeybadger/conversions.rb
@@ -2,7 +2,7 @@ module Honeybadger
   # @api private
   module Conversions
     module_function
-    MAX_CONTEXT_DEPTH = 20
+    MAX_CONTEXT_DEPTH = 5
 
     # Convert context into a Hash.
     #

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -405,7 +405,7 @@ describe Honeybadger::Notice do
 
       context 'and a deeply nested context' do
         let(:global_context) do
-          (0..25).reduce({}) do |acc, depth|
+          (0..10).reduce({}) do |acc, depth|
             build_instance_with_hb_context({ depth => acc })
           end
         end
@@ -414,11 +414,8 @@ describe Honeybadger::Notice do
           # serialize/deserialize to simplify matching of the class at the end of the nesting
           ct = JSON.parse(notice.context.to_json)
           expect(ct).to eq({
-            '25' => { '24' => { '23' => { '22' => { '21' => {
-            '20' => { '19' => { '18' => { '17' => { '16' => {
-            '15' => { '14' => { '13' => { '12' => { '11' => {
             '10' => { '9' => { '8' => { '7' => { '6' => 'class with context'
-            }}}}}}}}}}}}}}}}}}}
+            }}}}
           })
         end
       end

--- a/spec/unit/honeybadger/notice_spec.rb
+++ b/spec/unit/honeybadger/notice_spec.rb
@@ -374,6 +374,74 @@ describe Honeybadger::Notice do
       hash = JSON.parse(notice.to_json)
       expect(hash['request']['context']).to eq({'debuga' => true, 'debugb' => false})
     end
+
+    context 'with nested context' do
+      def build_instance_with_hb_context(value)
+        Class.new do
+          def initialize(value)
+            @to_honeybadger_context = value
+          end
+
+          def to_honeybadger_context
+            @to_honeybadger_context
+          end
+
+          def to_json(_state)
+            '"class with context"'
+          end
+        end.new(value)
+      end
+
+      let(:notice) { build_notice(global_context: global_context) }
+      let(:global_context) do
+        build_instance_with_hb_context(
+          { 'foo' => build_instance_with_hb_context(
+            { 'bar' => build_instance_with_hb_context({ 'baz' => 'qux' }) }) })
+      end
+
+      it "drills into the context values when they respond to to_honeybadger_context" do
+        expect(notice.context).to eq({ 'foo' => { 'bar' => { 'baz' => 'qux' }}})
+      end
+
+      context 'and a deeply nested context' do
+        let(:global_context) do
+          (0..25).reduce({}) do |acc, depth|
+            build_instance_with_hb_context({ depth => acc })
+          end
+        end
+
+        it "drills into the context values, but only as far as the nesting limit of 20" do
+          # serialize/deserialize to simplify matching of the class at the end of the nesting
+          ct = JSON.parse(notice.context.to_json)
+          expect(ct).to eq({
+            '25' => { '24' => { '23' => { '22' => { '21' => {
+            '20' => { '19' => { '18' => { '17' => { '16' => {
+            '15' => { '14' => { '13' => { '12' => { '11' => {
+            '10' => { '9' => { '8' => { '7' => { '6' => 'class with context'
+            }}}}}}}}}}}}}}}}}}}
+          })
+        end
+      end
+
+      context 'and some non-nested contexts' do
+        let(:global_context) do
+          build_instance_with_hb_context(
+            { 'foo' => nil,
+              'bar' => 'baz',
+              'qux' => build_instance_with_hb_context({ 'fred' => 'thud' }),
+              'array' => ['item'],
+              'hash' => { 'key' => 'value' }
+            })
+        end
+
+        it "drills in only where the object can drill" do
+          expect(notice.context).to eq(
+            { 'foo' => nil, 'bar' => 'baz', 'qux' => { 'fred' => 'thud' },
+              'array' => ['item'], 'hash' => { 'key' => 'value' }}
+          )
+        end
+      end
+    end
   end
 
   describe "Rack features", if: defined?(::Rack) do


### PR DESCRIPTION
When providing an object to the context that comprises other objects that implement `to_honeybadger_context`, serialise them using the using their `to_honeybadger_context` rather than a simple `to_json`

Resolves #487 