### PR TITLE
CI: Configure dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
It’d be possible to add gems there, too, but, this is the smallest thing that won’t be much in the way.

Hope this helps!
