### PR TITLE
Fix Honeybadger::Config#respond_to?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 - Support for Karafka (#480)
 - Support for nested `to_honeybadger_context` (#488)
 
+### Fixed
+- `Honeybadger::Config#respond_to?` would always return true (#490)
+
 ## [5.2.1] - 2023-03-14
 ### Fixed
 - Remove ANSI escape codes from detailed error message in Ruby 3.2 (#473)

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -32,7 +32,12 @@ module Honeybadger
       end
 
       def respond_to_missing?(method_name, include_private = false)
-        true
+        m = method_name.to_s
+        if mash?(m) || setter?(m) || getter?(m)
+          true
+        else
+          super
+        end
       end
 
       def mash?(method)

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -280,5 +280,21 @@ describe Honeybadger::Config do
 
       expect(subject.before_notify_hooks.size).to eq(2)
     end
+
+    it "only responds to methods that correspond to default keys" do
+      known_key_response = nil
+      unknown_key_response = nil
+
+      subject.configure do |config|
+        known_key_response = config.respond_to?("api_key")
+      end
+
+      subject.configure do |config|
+        unknown_key_response = config.respond_to?("ejfhjskdhfkdjhf=")
+      end
+
+      expect(known_key_response).to eq(true)
+      expect(unknown_key_response).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Config#respond_to_missing? was hardcoded to `true` instead of mirroring the logic of the `method_missing`. Which can potentially cause issues when extending this gem.

Resolves https://github.com/honeybadger-io/honeybadger-ruby/issues/481 
