### PR TITLE
Handle 413 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support for Karafka (#480)
 - Support for nested `to_honeybadger_context` (#488)
+- Explain 413 responses from API (#492)
 
 ### Fixed
 - `Honeybadger::Config#respond_to?` would always return true (#490)

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -15,7 +15,8 @@ module Honeybadger
         429 => "Your project is currently sending too many errors.\nThis issue should resolve itself once error traffic is reduced.".freeze,
         503 => "Your project is currently sending too many errors.\nThis issue should resolve itself once error traffic is reduced.".freeze,
         402 => "The project owner's billing information has expired (or the trial has ended).\nPlease check your payment details or email support@honeybadger.io for help.".freeze,
-        403 => "The API key is invalid. Please check your API key and try again.".freeze
+        403 => "The API key is invalid. Please check your API key and try again.".freeze,
+        413 => "The payload is too large.".freeze
       }.freeze
 
       # Initializes the Response instance.

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -223,6 +223,8 @@ module Honeybadger
       when 403
         warn { sprintf('Error report failed: API key is invalid. id=%s code=%s', msg.id, response.code) }
         suspend(3600)
+      when 413
+        warn { sprintf('Error report failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
       when 201
         if throttle = dec_throttle
           info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -304,6 +304,15 @@ describe Honeybadger::Worker do
       end
     end
 
+    context "when 413" do
+      let(:response) { Honeybadger::Backend::Response.new(413, %({"error":"Payload exceeds maximum size"})) }
+
+      it "warns the logger" do
+        expect(config.logger).to receive(:warn).with(/too large/)
+        handle_response
+      end
+    end
+
     context "when 201" do
       let(:response) { Honeybadger::Backend::Response.new(201) }
 


### PR DESCRIPTION
Inform the user about the reason for a 413 response from the API.