### PR TITLE
Accept three arguments into Sidekiq error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - `Honeybadger::Config#respond_to?` would always return true (#490)
 
+### Changed
+- Accept three arguments for the Sidekiq error handler (#495)
+
 ## [5.2.1] - 2023-03-14
 ### Fixed
 - Remove ANSI escape codes from detailed error message in Ruby 3.2 (#473)

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -19,6 +19,9 @@ describe "Sidekiq Dependency" do
       Class.new do
         def self.configure_server
         end
+
+        def self.default_configuration
+        end
       end
     end
 


### PR DESCRIPTION
Closes #493

Starting with Sidekiq 7.1.5 the error handler is passed three arguments. The new argument is the Sidekiq config. The `_config` key from the second argument has been removed.

Support for passing two arguments and expecting the `_config` is still supported but will raise a deprication warning and will be removed in Sidekiq 8.

This change adds an optional third argument to the error handler lambda defaulted to `Sidekiq.default_configuration` as per the Sidekiq changelog on how to handle this.

This should make the gem forwards compatible with Sidekiq 8 (excluding any other breaking changes).

Sidekiq PR introducing this change: https://github.com/sidekiq/sidekiq/pull/6051
