### PR TITLE
change: change log level of init message to DEBUG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 .rbenv-vars
 java.hprof.txt
 .yardoc
+.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ Gemfile.lock
 .rbenv-vars
 java.hprof.txt
 .yardoc
-.tool-versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Accept three arguments for the Sidekiq error handler (#495)
+- Log level of init message changed to DEBUG (#497)
 
 ## [5.2.1] - 2023-03-14
 ### Fixed

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -55,7 +55,7 @@ module Honeybadger
       init_logging!
       init_backend!
 
-      logger.info(sprintf('Initializing Honeybadger Error Tracker for Ruby. Ship it! version=%s framework=%s', Honeybadger::VERSION, detected_framework))
+      logger.debug(sprintf('Initializing Honeybadger Error Tracker for Ruby. Ship it! version=%s framework=%s', Honeybadger::VERSION, detected_framework))
       logger.warn('Development mode is enabled. Data will not be reported until you deploy your app.') if warn_development?
 
       self

--- a/spec/features/test_spec.rb
+++ b/spec/features/test_spec.rb
@@ -7,13 +7,19 @@ feature "Running the test cli command" do
       expect(run_command("honeybadger test")).to be_successfully_executed
       expect(all_output).not_to match /Detected Rails/i
       expect(all_output).to match /asdf/
-      expect(all_output).to match /Initializing Honeybadger/
       expect(all_output).to match /HoneybadgerTestingException/
       # Make sure the worker timeout isn't being exceeded.
       expect(all_output).not_to match /kill/
       assert_notification('error' => {'class' => 'HoneybadgerTestingException'})
     end
-
+    
+    it "displays init message when debugging"  do
+      set_environment_variable('HONEYBADGER_API_KEY', 'asdf')
+      set_environment_variable('HONEYBADGER_DEBUG', '1')
+      expect(run_command("honeybadger test")).to be_successfully_executed
+      expect(all_output).to match /Initializing Honeybadger/
+    end
+    
     context "with invalid configuration" do
       it "displays expected debug output" do
         expect(run_command("honeybadger test --dry-run")).not_to be_successfully_executed
@@ -32,9 +38,9 @@ feature "Running the test cli command" do
 api_key: 'asdf'
 YML
       expect(run_command("honeybadger test")).to be_successfully_executed
+
       expect(all_output).to match /Detected Rails/i
       expect(all_output).to match /asdf/
-      expect(all_output).to match /Initializing Honeybadger/
       expect(all_output).to match /HoneybadgerTestingException/
       assert_notification('error' => {'class' => 'HoneybadgerTestingException'})
     end


### PR DESCRIPTION
As discussed in #447 this is the preferred solution: Simply make the init message a DEBUG level message

Fixes #447

