### PR TITLE
chore!: Remove second opts argument in Honeybadger.notify

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -119,9 +119,8 @@ module Honeybadger
     #
     # @return [String] UUID reference to the notice within Honeybadger.
     # @return [false] when ignored.
-    def notify(exception_or_opts = nil, opts = {}, **kwargs)
+    def notify(exception_or_opts = nil, **opts)
       opts = opts.dup
-      opts.merge!(kwargs)
 
       if exception_or_opts.is_a?(Exception)
         already_reported_notice_id = exception_or_opts.instance_variable_get(:@__hb_notice_id)

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -51,10 +51,10 @@ module Honeybadger
   # @!method notify(...)
   # Forwards to {Agent.instance}.
   # @see Agent#notify
-  def notify(exception_or_opts=nil, opts = {}, **kwargs)
+  def notify(exception_or_opts = nil, **opts)
     # Note this is defined directly (instead of via forwardable) so that
     # generated stack traces work as expected.
-    Agent.instance.notify(exception_or_opts, opts, **kwargs)
+    Agent.instance.notify(exception_or_opts, **opts)
   end
 
   # @api private

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -102,43 +102,20 @@ describe Honeybadger::Agent do
       opts = {error_message: 'test'}
       prev = opts.dup
       instance = described_class.new(Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER))
-      instance.notify('test', opts)
+      instance.notify('test', **opts)
       expect(prev).to eq(opts)
     end
 
-    it "does take keyword arguments" do
-      opts = {error_message: 'test'}
-      config = Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER)
-      instance = described_class.new(config)
-     
-      expect(instance.worker).to receive(:push) do |notice|
-        expect(notice.error_message).to match('test')
-      end
-      instance.notify(**opts)
-    end
-
-    it "does take keyword arguments as second argument" do
+    it "accepts keyword arguments as second argument" do
       opts = {tags: 'testing, kwargs'}
       config = Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER)
       instance = described_class.new(config)
-      
+
       expect(instance.worker).to receive(:push) do |notice|
         expect(notice.error_message).to match('test')
         expect(notice.tags).to eq(['testing', 'kwargs'])
       end
       instance.notify('test', **opts)
-    end
-
-    it "does take explicit hash as second argument" do
-      opts = {tags: 'testing, hash'}
-      config = Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER)
-      instance = described_class.new(config)
-      
-      expect(instance.worker).to receive(:push) do |notice|
-        expect(notice.error_message).to match('test')
-        expect(notice.tags).to eq(['testing', 'hash'])
-      end
-      instance.notify('test', opts)
     end
 
     it "does not report an already reported exception" do


### PR DESCRIPTION
This moves to keyword arguments exclusively. See #426 for further context.

BREAKING CHANGE: The following signature is no longer supported:

```ruby
Honeybadger.notify("test", {tags: 'testing, hash'})
```

Instead, you must do this:

```ruby
Honeybadger.notify("test", tags: 'testing, hash')
```


**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Add an entry to the CHANGELOG.