### PR TITLE
chore: experiments to see why jruby test is flakey

### DIFF
--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -242,7 +242,7 @@ describe Honeybadger::Worker do
         allow(config.logger).to receive(:warn)
         expect(config.logger).to receive(:warn).with(/throttled/i)
 
-        30.times do
+        40.times do
           subject.push(obj)
         end
 


### PR DESCRIPTION
Can't repro locally, throwing a couple of things at the wall to see if something sticks.

Here's what I'm trying:

- Assume jruby is faster in that particular test and doesn't get to throttle, so see if adding more pushes helps.