### PR TITLE
feat: implement simple debug backend endpoint for events

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -7,6 +7,7 @@ require 'honeybadger/notice'
 require 'honeybadger/plugin'
 require 'honeybadger/logging'
 require 'honeybadger/worker'
+require 'honeybadger/events_worker'
 require 'honeybadger/breadcrumbs'
 
 module Honeybadger
@@ -74,7 +75,7 @@ module Honeybadger
         @breadcrumbs = nil
       end
 
-      init_worker
+      init_workers
     end
 
     # Sends an exception to Honeybadger. Does not report ignored exceptions by
@@ -375,7 +376,7 @@ module Honeybadger
         logger.error("Event has non-hash payload")
         return
       end
-      backend.event({event_type: event_type, ts: ts}.merge(payload))
+      events_worker.push({event_type: event_type, ts: ts}.merge(payload))
     end
 
     # @api private
@@ -450,7 +451,7 @@ module Honeybadger
     end
 
     # @api private
-    attr_reader :worker
+    attr_reader :worker, :events_worker
 
     # @api private
     # @!method init!(...)
@@ -487,8 +488,9 @@ module Honeybadger
       true
     end
 
-    def init_worker
+    def init_workers
       @worker = Worker.new(config)
+      @events_worker = EventsWorker.new(config)
     end
 
     def with_error_handling

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -375,8 +375,7 @@ module Honeybadger
         logger.error("Event has non-hash payload")
         return
       end
-      log_string = payload.merge({event_type: event_type, ts: ts}).to_json
-      logger.debug(log_string)
+      backend.event(event_type, ts, payload)
     end
 
     # @api private

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -375,7 +375,7 @@ module Honeybadger
         logger.error("Event has non-hash payload")
         return
       end
-      backend.event(event_type, ts, payload)
+      backend.event({event_type: event_type, ts: ts}.merge(payload))
     end
 
     # @api private

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -355,6 +355,7 @@ module Honeybadger
       yield
     ensure
       worker.flush
+      events_worker.flush
     end
 
     # Stops the Honeybadger service.
@@ -363,6 +364,7 @@ module Honeybadger
     #   Honeybadger.stop # => nil
     def stop(force = false)
       worker.shutdown(force)
+      events_worker.shutdown(force)
       true
     end
 

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -113,10 +113,8 @@ module Honeybadger
       # @example
       #   backend.event("email_received", "2023-03-04T12:12:00+1:00", { subject: 'Re: Aquisition' })
       #
-      # @param [String] event_type Type of event to send
-      # @param [String] timestamp RFC3339 conforming formatted timestamp
-      # @param [Hash]   payload Generic payload
-      def event(event_type, timestamp, payload = {})
+      # @param [Hash] payload event payload
+      def event(payload)
         raise NotImplementedError, "must define #event on subclass"
       end
 

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -111,9 +111,10 @@ module Honeybadger
 
       # Send event
       # @example
-      #   backend.event("email_received", "2023-03-04T12:12:00+1:00", { subject: 'Re: Aquisition' })
+      #   backend.event([{event_type: "email_received", ts: "2023-03-04T12:12:00+1:00", subject: 'Re: Aquisition' }})
       #
-      # @param [Hash] payload event payload
+      # @param [Array] payload array of event hashes to send
+      # @raise NotImplementedError
       def event(payload)
         raise NotImplementedError, "must define #event on subclass"
       end

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -109,6 +109,17 @@ module Honeybadger
         notify(:deploys, payload)
       end
 
+      # Send event
+      # @example
+      #   backend.event("email_received", "2023-03-04T12:12:00+1:00", { subject: 'Re: Aquisition' })
+      #
+      # @param [String] event_type Type of event to send
+      # @param [String] timestamp RFC3339 conforming formatted timestamp
+      # @param [Hash]   payload Generic payload
+      def event(event_type, timestamp, payload = {})
+        raise NotImplementedError, "must define #event on subclass"
+      end
+
       private
 
       attr_reader :config

--- a/lib/honeybadger/backend/debug.rb
+++ b/lib/honeybadger/backend/debug.rb
@@ -18,9 +18,8 @@ module Honeybadger
         super
       end
 
-      def event(event_type, timestamp, payload)
-        event_hash = payload.merge({event_type: event_type, ts: timestamp})
-        logger.unknown("sending event to debug backend with event=#{event_hash.to_json}")
+      def event(payload)
+        logger.unknown("sending event to debug backend with event=#{payload.to_json}")
         return Response.new(ENV['DEBUG_BACKEND_STATUS'].to_i, nil) if ENV['DEBUG_BACKEND_STATUS']
         super
       end

--- a/lib/honeybadger/backend/debug.rb
+++ b/lib/honeybadger/backend/debug.rb
@@ -17,6 +17,13 @@ module Honeybadger
         return Response.new(ENV['DEBUG_BACKEND_STATUS'].to_i, nil) if ENV['DEBUG_BACKEND_STATUS']
         super
       end
+
+      def event(event_type, timestamp, payload)
+        event_hash = payload.merge({event_type: event_type, ts: timestamp})
+        logger.unknown("sending event to debug backend with event=#{event_hash.to_json}")
+        return Response.new(ENV['DEBUG_BACKEND_STATUS'].to_i, nil) if ENV['DEBUG_BACKEND_STATUS']
+        super
+      end
     end
   end
 end

--- a/lib/honeybadger/backend/null.rb
+++ b/lib/honeybadger/backend/null.rb
@@ -24,6 +24,10 @@ module Honeybadger
       def check_in(id)
         StubbedResponse.new
       end
+
+      def event(event_type, timestamp, payload = {})
+        StubbedResponse.new
+      end
     end
   end
 end

--- a/lib/honeybadger/backend/null.rb
+++ b/lib/honeybadger/backend/null.rb
@@ -25,7 +25,7 @@ module Honeybadger
         StubbedResponse.new
       end
 
-      def event(event_type, timestamp, payload = {})
+      def event(payload)
         StubbedResponse.new
       end
     end

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -91,12 +91,12 @@ module Honeybadger
         default: 100,
         type: Integer
       },
-      events_batch_size: {
+      :'events.batch_size' => {
         description: 'Send events batch if n events have accumulated',
         default: 100,
         type: Integer
       },
-      events_timeout: {
+      :'events.timeout' => {
         description: 'Timeout after which the events batch will be sent regardless (in milliseconds)',
         default: 30_000,
         type: Integer

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -91,6 +91,16 @@ module Honeybadger
         default: 100,
         type: Integer
       },
+      events_batch_size: {
+        description: 'Send events batch if n events have accumulated',
+        default: 100,
+        type: Integer
+      },
+      events_timeout: {
+        description: 'Timeout after which the events batch will be sent regardless (in milliseconds)',
+        default: 30_000,
+        type: Integer
+      },
       plugins: {
         description: 'An optional list of plugins to load. Default is to load all plugins.',
         default: nil,

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -40,8 +40,8 @@ module Honeybadger
       @send_queue = []
       @last_sent = nil
 
-      @max_events = config.get(:events_batch_size)
-      @send_timeout = config.get(:events_timeout)
+      @max_events = config.get(:'events.batch_size')
+      @send_timeout = config.get(:'events.timeout')
     end
 
     def push(msg)
@@ -161,10 +161,7 @@ module Honeybadger
     def schedule_timeout_check
       loop do
         sleep(send_timeout / 1000.0)
-        ms_since = (Time.now.to_f - last_sent.to_f) * 1000.0
-        if ms_since >= send_timeout
-          queue.push(CHECK_TIMEOUT)
-        end
+        queue.push(CHECK_TIMEOUT)
       end
     end
 
@@ -243,7 +240,7 @@ module Honeybadger
       check_and_send
 
       if shutdown? && throttled?
-        warn { sprintf('Unable to semd %s events(s) to Honeybadger (currently throttled)', queue.size) } if queue.size > 1
+        warn { sprintf('Unable to send %s events(s) to Honeybadger (currently throttled)', queue.size) } if queue.size > 1
         kill!
         return
       end

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -60,7 +60,7 @@ module Honeybadger
     end
 
     def shutdown(force = false)
-      d { 'shutting down worker' }
+      d { 'shutting down events worker' }
 
       mutex.synchronize do
         @shutdown = true

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -1,0 +1,289 @@
+require 'forwardable'
+require 'net/http'
+
+require 'honeybadger/logging'
+
+module Honeybadger
+  # A concurrent queue to notify the backend.
+  # @api private
+  class EventsWorker
+    extend Forwardable
+
+    include Honeybadger::Logging::Helper
+
+    # Sub-class thread so we have a named thread (useful for debugging in Thread.list).
+    class Thread < ::Thread; end
+
+    # Used to signal the worker to shutdown.
+    SHUTDOWN = :__hb_worker_shutdown!
+
+    # The base number for the exponential backoff formula when calculating the
+    # throttle interval. `1.05 ** throttle` will reach an interval of 2 minutes
+    # after around 100 429 responses from the server.
+    BASE_THROTTLE = 1.05
+
+    SEND_TIMEOUT = 30
+    MAX_EVENTS = 200
+    MAX_EVENTS_SIZE = 400_000
+
+
+    def initialize(config)
+      @config = config
+      @throttle = 0
+      @throttle_interval = 0
+      @mutex = Mutex.new
+      @marker = ConditionVariable.new
+      @queue = Queue.new
+      @send_queue = Queue.new
+      @shutdown = false
+      @start_at = nil
+      @pid = Process.pid
+    end
+
+    def push(msg)
+      return false unless start
+
+      if queue.size >= config.max_queue_size
+        warn { sprintf('Unable to report error; reached max queue size of %s. id=%s', queue.size, msg.id) }
+        return false
+      end
+
+      queue.push(msg)
+    end
+
+    def send_now(msg)
+      handle_response(msg, send_to_backend(msg))
+    end
+
+    def shutdown(force = false)
+      d { 'shutting down worker' }
+
+      mutex.synchronize do
+        @shutdown = true
+      end
+
+      return true if force
+      return true unless thread&.alive?
+
+      if throttled?
+        warn { sprintf('Unable to report %s error(s) to Honeybadger (currently throttled)', queue.size) } unless queue.empty?
+        return true
+      end
+
+      info { sprintf('Waiting to report %s error(s) to Honeybadger', queue.size) } unless queue.empty?
+
+      queue.push(SHUTDOWN)
+      !!thread.join
+    ensure
+      queue.clear
+      kill!
+    end
+
+    # Blocks until queue is processed up to this point in time.
+    def flush
+      mutex.synchronize do
+        if thread && thread.alive?
+          queue.push(marker)
+          marker.wait(mutex)
+        end
+      end
+    end
+
+    def start
+      return false unless can_start?
+
+      mutex.synchronize do
+        @shutdown = false
+        @start_at = nil
+
+        return true if thread&.alive?
+
+        @pid = Process.pid
+        @thread = Thread.new { run }
+      end
+
+      true
+    end
+
+    private
+
+    attr_reader :config, :queue, :pid, :mutex, :marker, :thread, :throttle,
+      :throttle_interval, :start_at
+
+    def_delegator :config, :backend
+
+    def shutdown?
+      mutex.synchronize { @shutdown }
+    end
+
+    def suspended?
+      mutex.synchronize { start_at && Time.now.to_i < start_at }
+    end
+
+    def can_start?
+      return false if shutdown?
+      return false if suspended?
+      true
+    end
+
+    def throttled?
+      mutex.synchronize { throttle > 0 }
+    end
+
+    def kill!
+      d { 'killing worker thread' }
+
+      if thread
+        Thread.kill(thread)
+        thread.join # Allow ensure blocks to execute.
+      end
+
+      true
+    end
+
+    def suspend(interval)
+      mutex.synchronize do
+        @start_at = Time.now.to_i + interval
+        queue.clear
+      end
+
+      # Must be performed last since this may kill the current thread.
+      kill!
+    end
+
+    def run
+      begin
+        d { 'worker started' }
+        Thread.current.thread_variable_set(:last_sent, Time.now)
+        Thread.current.thread_variable_set(:send_queue, Queue.new)
+        Thread.current.thread_variable_set(:send_queue_byte_size, 0)
+
+        loop do
+          case msg = queue.pop
+          when SHUTDOWN then break
+          when ConditionVariable then signal_marker(msg)
+          else work(msg)
+          end
+        end
+      ensure
+        d { 'stopping worker' }
+      end
+    rescue Exception => e
+      error {
+        msg = "Error in worker thread (shutting down) class=%s message=%s\n\t%s"
+        sprintf(msg, e.class, e.message.dump, Array(e.backtrace).join("\n\t"))
+      }
+    ensure
+      release_marker
+    end
+
+    def enqueue_msg(msg)
+      queue = Thread.current.thread_variable_get(:send_queue)
+      queue_byte_size = Thread.current.thread_variable_get(:send_queue_byte_size)
+      size = msg.to_json.bytesize + 1
+      Thread.current.thread_variable_set(:send_queue_byte_size, queue_byte_size + size)
+      queue << msg
+    end
+
+    def check_and_send
+      queue = Thread.current.thread_variable_get(:send_queue)
+      return if queue.empty?
+      last_sent = Thread.current.thread_variable_get(:last_sent)
+      queue_byte_size = Thread.current.thread_variable_get(:send_queue_byte_size)
+
+      if queue.size >= MAX_EVENTS || (Time.now.to_i - last_sent.to_i) >= SEND_TIMEOUT || queue_byte_size >= MAX_EVENTS_SIZE
+        to_send = []
+        while !queue.empty?
+          to_send << queue.pop
+        end
+        send_now(to_send)
+      end
+    end
+
+    def work(msg)
+      enqueue_msg(msg)
+      check_and_send
+
+      if shutdown? && throttled?
+        warn { sprintf('Unable to report %s error(s) to Honeybadger (currently throttled)', queue.size) } if queue.size > 1
+        kill!
+        return
+      end
+
+      sleep(throttle_interval)
+    rescue StandardError => e
+      error {
+        msg = "Error in worker thread class=%s message=%s\n\t%s"
+        sprintf(msg, e.class, e.message.dump, Array(e.backtrace).join("\n\t"))
+      }
+    end
+
+    def send_to_backend(msg)
+      d { 'events_worker sending to backend' }
+      events_backend.send_event(msg)
+    end
+
+    def calc_throttle_interval
+      ((BASE_THROTTLE ** throttle) - 1).round(3)
+    end
+
+    def inc_throttle
+      mutex.synchronize do
+        @throttle += 1
+        @throttle_interval = calc_throttle_interval
+        throttle
+      end
+    end
+
+    def dec_throttle
+      mutex.synchronize do
+        return nil if throttle == 0
+        @throttle -= 1
+        @throttle_interval = calc_throttle_interval
+        throttle
+      end
+    end
+
+    def handle_response(msg, response)
+      d { sprintf('events_worker response code=%s message=%s', response.code, response.message.to_s.dump) }
+
+      case response.code
+      when 429, 503
+        throttle = inc_throttle
+        warn { sprintf('Event send failed: project is sending too many errors. id=%s code=%s throttle=%s interval=%s', msg.id, response.code, throttle, throttle_interval) }
+      when 402
+        warn { sprintf('Event send failed: payment is required. id=%s code=%s', msg.id, response.code) }
+        suspend(3600)
+      when 403
+        warn { sprintf('Event send failed: API key is invalid. id=%s code=%s', msg.id, response.code) }
+        suspend(3600)
+      when 413
+        warn { sprintf('Event send failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
+      when 201
+        if throttle = dec_throttle
+          info { sprintf('Success ⚡ Event sent code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
+        else
+          info { sprintf('Success ⚡ Event sent code=%s', response.code) }
+        end
+      when :stubbed
+        info { sprintf('Success ⚡ Development mode is enabled; This event will be sent after app is deployed.') }
+      when :error
+        warn { sprintf('Event send failed: an unknown error occurred. code=%s error=%s', response.code, response.message.to_s.dump) }
+      else
+        warn { sprintf('Event send failed: unknown response from server. code=%s', response.code) }
+      end
+    end
+
+    # Release the marker. Important to perform during cleanup when shutting
+    # down, otherwise it could end up waiting indefinitely.
+    def release_marker
+      signal_marker(marker)
+    end
+
+    def signal_marker(marker)
+      mutex.synchronize do
+        marker.signal
+      end
+    end
+  end
+end

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -172,10 +172,6 @@ module Honeybadger
           @last_sent = Time.now
         end
         loop do
-          # ms_since = (Time.now.to_f - @last_sent.to_f) * 1000.0
-          # if ms_since >= send_timeout
-          #   queue.push(CHECK_TIMEOUT)
-          # end
           case msg = queue.pop
           when SHUTDOWN then break
           when CHECK_TIMEOUT then check_timeout

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -285,14 +285,14 @@ describe Honeybadger::Agent do
 
   context "#event" do
     let(:logger) { double(NULL_LOGGER) }
-    let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: logger, debug: true) }
+    let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: logger, backend: :debug) }
     let(:instance) { Honeybadger::Agent.new(config) }
 
     subject { instance }
 
     it "logs an event" do
       expect(logger).to receive(:add) do |level, msg|
-        expect(level).to eq(Logger::Severity::INFO)
+        expect(level).to eq(Logger::Severity::UNKNOWN)
         expect(msg).to match(/"some_data":"is here"/)
         expect(msg).to match(/"event_type":"test_event"/)
         expect(msg).to match(/"ts":/)

--- a/spec/unit/honeybadger/backend/base_spec.rb
+++ b/spec/unit/honeybadger/backend/base_spec.rb
@@ -43,6 +43,7 @@ describe Honeybadger::Backend::Base do
   subject { described_class.new(config) }
 
   it { should respond_to :notify }
+  it { should respond_to :event }
 
   describe "#notify" do
     it "raises NotImplementedError" do

--- a/spec/unit/honeybadger/backend/debug_spec.rb
+++ b/spec/unit/honeybadger/backend/debug_spec.rb
@@ -36,4 +36,16 @@ describe Honeybadger::Backend::Debug do
       instance.check_in(10)
     end
   end
+
+  describe "#event" do
+    it "logs the event" do
+      expect(logger).to receive(:unknown) do |msg|
+        expect(msg).to match(/"some_data":"is here"/)
+        expect(msg).to match(/"event_type":"test_event"/)
+        expect(msg).to match(/"ts":"test_timestamp"/)
+      end
+
+      instance.event("test_event", "test_timestamp", {some_data: "is here"})
+    end
+  end
 end

--- a/spec/unit/honeybadger/backend/debug_spec.rb
+++ b/spec/unit/honeybadger/backend/debug_spec.rb
@@ -45,7 +45,7 @@ describe Honeybadger::Backend::Debug do
         expect(msg).to match(/"ts":"test_timestamp"/)
       end
 
-      instance.event("test_event", "test_timestamp", {some_data: "is here"})
+      instance.event({event_type: "test_event", ts: "test_timestamp", some_data: "is here"})
     end
   end
 end

--- a/spec/unit/honeybadger/events_worker_spec.rb
+++ b/spec/unit/honeybadger/events_worker_spec.rb
@@ -1,0 +1,356 @@
+require 'timecop'
+require 'thread'
+
+require 'honeybadger/events_worker'
+require 'honeybadger/config'
+require 'honeybadger/backend'
+
+describe Honeybadger::EventsWorker do
+  let!(:instance) { described_class.new(config) }
+  let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, backend: 'null') }
+  let(:event) { {event_type: "test", ts: "not-important"} }
+
+  subject { instance }
+
+  after do
+    Thread.list.each do |thread|
+      next unless thread.kind_of?(Honeybadger::EventsWorker::Thread)
+      Thread.kill(thread)
+    end
+  end
+
+  context "when an exception happens in the worker loop" do
+    before do
+      allow(instance.send(:queue)).to receive(:pop).and_raise('fail')
+    end
+
+    it "does not raise when shutting down" do
+      instance.push(event)
+
+      expect { instance.shutdown }.not_to raise_error
+    end
+
+    it "exits the loop" do
+      instance.push(event)
+      instance.flush
+
+      sleep(0.1)
+      expect(instance.send(:thread)).not_to be_alive
+    end
+
+    it "logs the error" do
+      allow(config.logger).to receive(:error)
+      expect(config.logger).to receive(:error).with(/error/i)
+
+      instance.push(event)
+      instance.flush
+    end
+  end
+
+  context "when an exception happens during processing" do
+    before do
+      allow(instance).to receive(:sleep)
+      allow(instance).to receive(:handle_response).and_raise('fail')
+    end
+
+    def flush
+      instance.push(event)
+      instance.flush
+    end
+
+    it "does not raise when shutting down" do
+      flush
+      expect { instance.shutdown }.not_to raise_error
+    end
+
+    it "does not exit the loop" do
+      flush
+      expect(instance.send(:thread)).to be_alive
+    end
+
+    # it "logs the error" do
+    #   allow(config.logger).to receive(:error)
+    #   expect(config.logger).to receive(:error).with(/error/i)
+    #   flush
+    # end
+  end
+
+  describe "#initialize" do
+    describe "#queue" do
+      subject { instance.send(:queue) }
+
+      it { should be_a Queue }
+    end
+
+    describe "#backend" do
+      subject { instance.send(:backend) }
+
+      before do
+        allow(Honeybadger::Backend::Null).to receive(:new).with(config).and_return(config.backend)
+      end
+
+      it { should be_a Honeybadger::Backend::Base }
+
+      it "is initialized from config" do
+        should eq config.backend
+      end
+    end
+  end
+
+  # describe "#push" do
+  #   it "flushes payload to backend" do
+  #     expect(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_call_original
+  #     expect(instance.push(obj)).not_to eq false
+  #     instance.flush
+  #   end
+
+  #   context "when not started" do
+  #     before do
+  #       allow(instance).to receive(:start).and_return false
+  #     end
+
+  #     it "rejects push" do
+  #       expect(instance.send(:queue)).not_to receive(:push)
+  #       expect(instance.push(obj)).to eq false
+  #     end
+  #   end
+
+  #   context "when queue is full" do
+  #     before do
+  #       allow(config).to receive(:max_queue_size).and_return(5)
+  #       allow(instance).to receive(:queue).and_return(double(size: 5))
+  #     end
+
+  #     it "rejects the push" do
+  #       expect(instance.send(:queue)).not_to receive(:push)
+  #       expect(instance.push(obj)).to eq false
+  #     end
+
+  #     it "warns the logger" do
+  #       allow(config.logger).to receive(:warn)
+  #       expect(config.logger).to receive(:warn).with(/reached max/i)
+  #       instance.push(obj)
+  #     end
+  #   end
+  # end
+
+  # describe "#start" do
+  #   it "starts the thread" do
+  #     expect { subject.start }.to change(subject, :thread).to(kind_of(Thread))
+  #   end
+
+  #   it "changes the pid to the current pid" do
+  #     allow(Process).to receive(:pid).and_return(:expected)
+  #     expect { subject.start }.to change(subject, :pid).to(:expected)
+  #   end
+
+  #   context "when shutdown" do
+  #     before do
+  #       subject.shutdown
+  #     end
+
+  #     it "doesn't start" do
+  #       expect { subject.start }.not_to change(subject, :thread)
+  #     end
+  #   end
+
+  #   context "when suspended" do
+  #     before do
+  #       subject.send(:suspend, 300)
+  #     end
+
+  #     context "and restart is in the future" do
+  #       it "doesn't start" do
+  #         expect { subject.start }.not_to change(subject, :thread)
+  #       end
+  #     end
+
+  #     context "and restart is in the past" do
+  #       it "starts the thread" do
+  #         Timecop.travel(Time.now + 301) do
+  #           expect { subject.start }.to change(subject, :thread).to(kind_of(Thread))
+  #         end
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "#shutdown" do
+  #   before { subject.start }
+
+  #   it "blocks until queue is processed" do
+  #     expect(subject.send(:backend)).to receive(:notify).with(kind_of(Symbol), obj).and_call_original
+  #     subject.push(obj)
+  #     subject.shutdown
+  #   end
+
+  #   it "stops the thread" do
+  #     subject.shutdown
+
+  #     sleep(0.1)
+  #     expect(subject.send(:thread)).not_to be_alive
+  #   end
+
+  #   context "when previously throttled" do
+  #     before do
+  #       100.times { subject.send(:inc_throttle) }
+  #       subject.push(obj)
+  #       sleep(0.01) # Pause to allow throttle to activate
+  #     end
+
+  #     it "shuts down immediately" do
+  #       expect(subject.send(:backend)).not_to receive(:notify)
+  #       subject.push(obj)
+  #       subject.shutdown
+  #     end
+
+  #     it "does not warn the logger when the queue is empty" do
+  #       allow(config.logger).to receive(:warn)
+  #       expect(config.logger).not_to receive(:warn)
+  #       subject.shutdown
+  #     end
+
+  #     it "warns the logger when queue has items" do
+  #       subject.push(obj)
+  #       allow(config.logger).to receive(:warn)
+  #       expect(config.logger).to receive(:warn).with(/throttled/i)
+  #       subject.shutdown
+  #     end
+  #   end
+
+  #   context "when throttled during shutdown" do
+  #     before do
+  #       allow(subject.send(:backend)).to receive(:notify).with(:notices, obj).and_return(Honeybadger::Backend::Response.new(429) )
+  #     end
+
+  #     it "shuts down immediately" do
+  #       expect(subject.send(:backend)).to receive(:notify).exactly(1).times
+  #       5.times { subject.push(obj) }
+  #       subject.shutdown
+  #     end
+
+  #     it "does not warn the logger when the queue is empty" do
+  #       allow(config.logger).to receive(:warn)
+  #       expect(config.logger).not_to receive(:warn).with(/throttled/)
+
+  #       subject.push(obj)
+  #       subject.shutdown
+  #     end
+
+  #     it "warns the logger when the queue has additional items" do
+  #       allow(config.logger).to receive(:warn)
+  #       expect(config.logger).to receive(:warn).with(/throttled/i)
+
+  #       30.times do
+  #         subject.push(obj)
+  #       end
+
+  #       subject.shutdown
+  #     end
+  #   end
+  # end
+
+  # describe "#flush" do
+  #   it "blocks until queue is flushed" do
+  #     expect(subject.send(:backend)).to receive(:notify).with(kind_of(Symbol), obj).and_call_original
+  #     subject.push(obj)
+  #     subject.flush
+  #   end
+  # end
+
+  # describe "#handle_response" do
+  #   def handle_response
+  #     instance.send(:handle_response, obj, response)
+  #   end
+
+  #   before do
+  #     allow(instance).to receive(:suspend).and_return true
+  #   end
+
+  #   context "when 429" do
+  #     let(:response) { Honeybadger::Backend::Response.new(429) }
+
+  #     it "adds throttle" do
+  #       expect { handle_response }.to change(instance, :throttle_interval).by(0.05)
+  #     end
+  #   end
+
+  #   context "when 402" do
+  #     let(:response) { Honeybadger::Backend::Response.new(402) }
+
+  #     it "shuts down the worker" do
+  #       expect(instance).to receive(:suspend)
+  #       handle_response
+  #     end
+
+  #     it "warns the logger" do
+  #       expect(config.logger).to receive(:warn).with(/payment/)
+  #       handle_response
+  #     end
+  #   end
+
+  #   context "when 403" do
+  #     let(:response) { Honeybadger::Backend::Response.new(403, %({"error":"unauthorized"})) }
+
+  #     it "shuts down the worker" do
+  #       expect(instance).to receive(:suspend)
+  #       handle_response
+  #     end
+
+  #     it "warns the logger" do
+  #       expect(config.logger).to receive(:warn).with(/invalid/)
+  #       handle_response
+  #     end
+  #   end
+
+  #   context "when 413" do
+  #     let(:response) { Honeybadger::Backend::Response.new(413, %({"error":"Payload exceeds maximum size"})) }
+
+  #     it "warns the logger" do
+  #       expect(config.logger).to receive(:warn).with(/too large/)
+  #       handle_response
+  #     end
+  #   end
+
+  #   context "when 201" do
+  #     let(:response) { Honeybadger::Backend::Response.new(201) }
+
+  #     context "and there is no throttle" do
+  #       it "doesn't change throttle" do
+  #         expect { handle_response }.not_to change(instance, :throttle_interval)
+  #       end
+  #     end
+
+  #     context "and a throttle is set" do
+  #       before { instance.send(:inc_throttle) }
+
+  #       it "removes throttle" do
+  #         expect { handle_response }.to change(instance, :throttle_interval).by(-0.05)
+  #       end
+  #     end
+
+  #     it "doesn't warn" do
+  #       expect(config.logger).not_to receive(:warn)
+  #       handle_response
+  #     end
+  #   end
+
+  #   context "when unknown" do
+  #     let(:response) { Honeybadger::Backend::Response.new(418) }
+
+  #     it "warns the logger" do
+  #       expect(config.logger).to receive(:warn).with(/failed/)
+  #       handle_response
+  #     end
+  #   end
+
+  #   context "when error" do
+  #     let(:response) { Honeybadger::Backend::Response.new(:error, nil, 'test error message') }
+
+  #     it "warns the logger" do
+  #       expect(config.logger).to receive(:warn).with(/test error message/)
+  #       handle_response
+  #     end
+  #   end
+  # end
+end

--- a/spec/unit/honeybadger/events_worker_spec.rb
+++ b/spec/unit/honeybadger/events_worker_spec.rb
@@ -10,8 +10,8 @@ describe Honeybadger::EventsWorker do
   let(:config) {
     Honeybadger::Config.new(
       logger: NULL_LOGGER, debug: true, backend: 'null',
-      events_batch_size: 5,
-      events_timeout: 10_000
+      :'events.batch_size' => 5,
+      :'events.timeout' => 10_000
     )
   }
   let(:event) { {event_type: "test", ts: "not-important"} }
@@ -73,12 +73,6 @@ describe Honeybadger::EventsWorker do
       flush
       expect(instance.send(:thread)).to be_alive
     end
-
-    # it "logs the error" do
-    #   allow(config.logger).to receive(:error)
-    #   expect(config.logger).to receive(:error).with(/error/i)
-    #   flush
-    # end
   end
 
   describe "#initialize" do
@@ -372,8 +366,8 @@ describe Honeybadger::EventsWorker do
       let(:config) {
         Honeybadger::Config.new(
           logger: NULL_LOGGER, debug: true, backend: 'null',
-          events_batch_size: 5,
-          events_timeout: 100
+          :'events.batch_size' => 5,
+          :'events.timeout' => 100
         )
       }
 


### PR DESCRIPTION
~~This currently is missing a queue and calls the backend directly from the agent.~~

~~Should I implement an events_worker within this PR or in the PR that adds the server backend?~~

Another question: Would it make sense to hand in the timestamp from the agent as an actual DateTime so that we could delegate the serialisation to the specific backend? Feels like it could be useful?
