### PR TITLE
fix: ignore vendor/bundle when creating gem

### DIFF
--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |s|
 
   s.files  = Dir['lib/**/*.{rb,erb}']
   s.files += Dir['bin/*']
-  s.files += Dir['vendor/**/*.{rb,rake,cap}']
+  # CI installs caches installed gems in vendor/bundle, but we don't want to include them in the gem.
+  s.files += Dir['vendor/**/*.{rb,rake,cap}'].reject { |file| file.start_with?("vendor/bundle") }
   s.files += Dir['resources/**/*.crt']
   s.files += Dir['*.md']
   s.files += ['LICENSE']


### PR DESCRIPTION
The [setup ruby](https://github.com/ruby/setup-ruby?tab=readme-ov-file#caching-bundle-install-automatically) action comes with a recommended `bundler-cache` option that caches installed gems locally.
The cache folder is in `vendor/bundle` which eventually ends up in the gem and increases the total size of the gem significantly.
This PR makes sure that the folder is excluded from the gem.

Fixes: #514