### PR TITLE
fix: don't raise an exception when ActiveJob isn't loaded

### DIFF
--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -5,11 +5,8 @@ module Honeybadger
       Plugin.register {
         requirement { defined?(::Rails.application) && ::Rails.application }
         requirement {
-          begin
+          ::Rails.application.config.respond_to?(:active_job) &&
             ::Rails.application.config.active_job[:queue_adapter] == :async
-          rescue NoMethodError
-            false
-          end
         }
         
         execution {

--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -4,8 +4,12 @@ module Honeybadger
             
       Plugin.register {
         requirement { defined?(::Rails.application) && ::Rails.application }
-        requirement { 
-          ::Rails.application.config.active_job[:queue_adapter] == :async
+        requirement {
+          begin
+            ::Rails.application.config.active_job[:queue_adapter] == :async
+          rescue NoMethodError
+            false
+          end
         }
         
         execution {


### PR DESCRIPTION
If ActiveJob isn't loaded (by not requiring active_job/railtie in config/application.rb), then this error occur when Honeybadger is loaded:

plugin error name=active_job class=NoMethodError message="undefined method `active_job' for an instance of Rails::Application::Configuration"

This change rescues that error and disables the plugin.
