### PR TITLE
feat: set component to 'active_job' for active job errors

### DIFF
--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -20,7 +20,7 @@ module Honeybadger
 
         def context(job) # rubocop:disable Metrics/MethodLength
           {
-            component: job.class,
+            component: 'active_job',
             action: 'perform',
             enqueued_at: job.try(:enqueued_at),
             executions: job.executions,

--- a/spec/integration/rails/active_job_adapter_spec.rb
+++ b/spec/integration/rails/active_job_adapter_spec.rb
@@ -17,7 +17,7 @@ describe 'Rails ActiveJob Adapter Test', if: RAILS_PRESENT, type: :request do
     expect(Honeybadger::Backend::Test.notifications[:notices][0].params[:arguments][0]).to eq({ some: 'data' })
     expect(Honeybadger::Backend::Test.notifications[:notices][0].context).to \
       include(
-        component: ErrorJob,
+        component: 'active_job',
         action: 'perform',
         enqueued_at: anything,
         executions: 1,


### PR DESCRIPTION
* Set `component` to `active_job` so that it is easy to identify which events come from active_job in insights.