### PR TITLE
fix: store pr title before usage

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -21,5 +21,7 @@ jobs:
           echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
 
       - name: Verify PR title is in the correct format
+        env:
+            TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "${{ github.event.pull_request.title }}" | npx commitlint -V
+          echo $TITLE | npx commitlint -V


### PR DESCRIPTION
Stores the PR title in an environment variable before usage. This should prevent any unwanted remote code execution.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
