### PR TITLE
feat: return block value if block was passed to Honeybadger.context

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -258,9 +258,11 @@ module Honeybadger
     #   When present, tags will be applied to errors with this context
     #   (optional).
     #
-    # @return [self] so that method calls can be chained.
+    # @return [Object, self] value of the block if passed, otherwise self
     def context(context = nil, &block)
-      context_manager.set_context(context, &block) unless context.nil?
+      block_result = context_manager.set_context(context, &block) unless context.nil?
+      return block_result if block_given?
+
       self
     end
 

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -73,6 +73,26 @@ describe Honeybadger::Agent do
     end
   end
 
+  describe '#context' do
+    let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER) }
+    subject(:instance) { described_class.new(config) }
+
+    it 'sets the context' do
+      instance.context({a: "context"})
+      expect(instance.get_context).to eq({a: "context"})
+    end
+
+    it 'allows chaining' do
+      expect(instance.context({a: "context"})).to eq(instance)
+    end
+
+    context 'with local context' do
+      it 'returns the return value of the block' do
+        expect(instance.context({ bar: :baz }) { :return_value }).to eq(:return_value)
+      end
+    end
+  end
+
   describe "#clear!" do
     it 'clears all transactional data' do
       config = Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER)


### PR DESCRIPTION
This PR improves on the local contexts feature introduced in #541 by making `Honeybadger.context` return the result of the block instead of the `Agent` instance when local contexts are used.

This allows seamless wrapping of existing application code:

```ruby
class SuperImportantPaymentProcessing
  def call
    Honeybadger.context({ tags: ['critical', 'payments'] }) do
      # bunch of things happening
      { success: true, charge: }
    rescue PaymentError => e
      Honeybadger.notify(e) # this still gets tagged!
      { success: false }
    end
  end
end
```