### PR TITLE
feat: implement metric registry for aggregation

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -414,7 +414,10 @@ module Honeybadger
     end
 
     def registry
-      @registry ||= Honeybadger::Registry.new
+      return @registry if defined?(@registry)
+      @registry = Honeybadger::Registry.new.tap do |r|
+        collect(Honeybadger::RegistryExecution.new(r, config, {}))
+      end
     end
 
     # @api private
@@ -539,7 +542,6 @@ module Honeybadger
     def init_collector_worker
       return if @collector_worker
       @collector_worker = CollectorWorker.new(config)
-      @collector_worker.push(Honeybadger::RegistryExecution.new(config, {}))
       @collector_worker
     end
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -10,6 +10,8 @@ require 'honeybadger/worker'
 require 'honeybadger/events_worker'
 require 'honeybadger/collector_worker'
 require 'honeybadger/breadcrumbs'
+require 'honeybadger/registry'
+require 'honeybadger/registry_execution'
 
 module Honeybadger
   # The Honeybadger agent contains all the methods for interacting with the
@@ -411,6 +413,10 @@ module Honeybadger
       collector_worker.push(collector)
     end
 
+    def registry
+      @registry ||= Honeybadger::Registry.new
+    end
+
     # @api private
     attr_reader :config
 
@@ -533,6 +539,8 @@ module Honeybadger
     def init_collector_worker
       return if @collector_worker
       @collector_worker = CollectorWorker.new(config)
+      @collector_worker.push(Honeybadger::RegistryExecution.new(config, {}))
+      @collector_worker
     end
 
     def with_error_handling

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -532,6 +532,11 @@ module Honeybadger
     # @see Honeybadger::Instrumentation#increment_counter
     def_delegator :'Honeybadger::Instrumentation', :increment_counter
 
+    # @api private
+    # @!method decrement_counter
+    # @see Honeybadger::Instrumentation#decrement_counter
+    def_delegator :'Honeybadger::Instrumentation', :decrement_counter
+
     private
 
     def validate_notify_opts!(opts)

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -570,7 +570,6 @@ module Honeybadger
     def init_collector_worker
       return if @collector_worker
       @collector_worker = CollectorWorker.new(config)
-      @collector_worker
     end
 
     def with_error_handling

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -348,6 +348,11 @@ module Honeybadger
         description: "Enable/Disable Honeybadger Insights built-in instrumentation.",
         default: false,
         type: Boolean
+      },
+      :'insights.registry_flush_interval' => {
+        description: "Number of seconds between registry flushes.",
+        default: 60,
+        type: Integer
       }
     }.freeze
 

--- a/lib/honeybadger/counter.rb
+++ b/lib/honeybadger/counter.rb
@@ -1,0 +1,16 @@
+require 'honeybadger/metric'
+
+module Honeybadger
+  class Counter < Metric
+    def count(by=1)
+      @sampled += 1
+
+      @counter ||= 0
+      @counter = @counter + by
+    end
+
+    def payloads
+      [{ counter: @counter }]
+    end
+  end
+end

--- a/lib/honeybadger/gauge.rb
+++ b/lib/honeybadger/gauge.rb
@@ -1,0 +1,28 @@
+require 'honeybadger/metric'
+
+module Honeybadger
+  class Gauge < Metric
+    def record(value)
+      @sampled += 1
+
+      @total ||= 0
+      @total = @total + value
+
+      @min = value if @min.nil? || @min > value
+      @max = value if @max.nil? || @max < value
+      @avg = @total.to_f / @sampled
+      @latest = value
+    end
+
+    def payloads
+      [
+        {
+          min: @min,
+          max: @max,
+          avg: @avg,
+          latest: @latest
+        }
+      ]
+    end
+  end
+end

--- a/lib/honeybadger/histogram.rb
+++ b/lib/honeybadger/histogram.rb
@@ -1,0 +1,30 @@
+require 'honeybadger/metric'
+
+module Honeybadger
+  class Histogram < Metric
+    DEFAULT_BINS = [
+      0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, # standard (from Prometheus)
+      30, 60, 120, 300, 1800, 3600, 21_600, # Sidekiq tasks may be very long-running
+    ]
+
+    def record(value)
+      @sampled += 1
+      @bin_counts ||= Hash.new(0)
+      @bin_counts[find_bin(value)] += 1
+    end
+
+    def find_bin(value)
+      bin = bins.find {|b| b >= value  }
+      bin = "+Inf" if bin.nil?
+      bin
+    end
+
+    def bins
+      @attributes.fetch(:bins, DEFAULT_BINS).sort
+    end
+
+    def payloads
+      [@bin_counts]
+    end
+  end
+end

--- a/lib/honeybadger/histogram.rb
+++ b/lib/honeybadger/histogram.rb
@@ -2,10 +2,7 @@ require 'honeybadger/metric'
 
 module Honeybadger
   class Histogram < Metric
-    DEFAULT_BINS = [
-      0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, # standard (from Prometheus)
-      30, 60, 120, 300, 1800, 3600, 21_600, # Sidekiq tasks may be very long-running
-    ]
+    DEFAULT_BINS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
 
     def record(value)
       @sampled += 1

--- a/lib/honeybadger/histogram.rb
+++ b/lib/honeybadger/histogram.rb
@@ -24,7 +24,7 @@ module Honeybadger
     end
 
     def payloads
-      [@bin_counts]
+      [{bins: @bin_counts}]
     end
   end
 end

--- a/lib/honeybadger/instrumentation.rb
+++ b/lib/honeybadger/instrumentation.rb
@@ -57,6 +57,12 @@ module Honeybadger
       end
     end
 
+    def self.decrement_counter(name, count: 1, attributes: {})
+      Honeybadger::Counter.register(name, attributes).tap do |counter|
+        counter.count(count * -1)
+      end
+    end
+
     def self.gauge(name, value:, attributes: {})
       Honeybadger::Gauge.register(name, attributes).tap do |gauge|
         gauge.record(value)
@@ -121,6 +127,12 @@ module Honeybadger
       attributes = extract_attributes(args)
       count = args.select { |a| a.respond_to?(:call) }.first&.call || 1
       Honeybadger::Instrumentation.increment_counter(name, count: count, attributes: attributes)
+    end
+
+    def decrement_counter(name, *args)
+      attributes = extract_attributes(args)
+      count = args.select { |a| a.respond_to?(:call) }.first&.call || 1
+      Honeybadger::Instrumentation.decrement_counter(name, count: count, attributes: attributes)
     end
 
     def gauge(name, *args)

--- a/lib/honeybadger/metric.rb
+++ b/lib/honeybadger/metric.rb
@@ -31,7 +31,7 @@ module Honeybadger
 
     def base_payload
       attributes.merge({
-        event_type: "hb.metrics",
+        event_type: "metric.hb",
         hostname: Honeybadger.config[:hostname].to_s,
         metric_name: name,
         metric_type: metric_type,

--- a/lib/honeybadger/metric.rb
+++ b/lib/honeybadger/metric.rb
@@ -2,9 +2,17 @@ module Honeybadger
   class Metric
     attr_reader :name, :attributes, :sampled
 
-    def self.register(name, attributes)
-      Honeybadger.registry.get(name, attributes) ||
-        Honeybadger.registry.register(new(name, attributes))
+    def self.metric_type
+      name.split('::').last.downcase
+    end
+
+    def self.signature(metric_type, name, attributes)
+      "#{metric_type}-#{name}-#{attributes.keys.join('-')}-#{attributes.values.join('-')}".to_sym
+    end
+
+    def self.register(metric_name, attributes)
+      Honeybadger.registry.get(metric_type, metric_name, attributes) ||
+        Honeybadger.registry.register(new(metric_name, attributes))
     end
 
     def initialize(name, attributes)
@@ -13,12 +21,20 @@ module Honeybadger
       @sampled = 0
     end
 
+    def metric_type
+      self.class.metric_type
+    end
+
+    def signature
+      self.class.signature(metric_type, name, attributes)
+    end
+
     def base_payload
       attributes.merge({
         event_type: "hb.metrics",
         hostname: Honeybadger.config[:hostname].to_s,
         metric_name: name,
-        metric_type: self.class.name.split('::').last.downcase,
+        metric_type: metric_type,
         sampled: sampled
       })
     end

--- a/lib/honeybadger/metric.rb
+++ b/lib/honeybadger/metric.rb
@@ -1,0 +1,32 @@
+module Honeybadger
+  class Metric
+    attr_reader :name, :attributes, :sampled
+
+    def self.register(name, attributes)
+      Honeybadger.registry.get(name, attributes) ||
+        Honeybadger.registry.register(new(name, attributes))
+    end
+
+    def initialize(name, attributes)
+      @name = name
+      @attributes = attributes || {}
+      @sampled = 0
+    end
+
+    def base_payload
+      attributes.merge({
+        event_type: "hb.metrics",
+        hostname: Honeybadger.config[:hostname].to_s,
+        metric_name: name,
+        metric_type: self.class.name.split('::').last.downcase,
+        sampled: sampled
+      })
+    end
+
+    def event_payloads
+      payloads.map do |payload|
+        base_payload.merge(payload)
+      end
+    end
+  end
+end

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -84,7 +84,7 @@ module Honeybadger
 
     def record(name, payload)
       metric_source 'active_job'
-      histogram name, payload
+      histogram name, { bins: [30, 60, 120, 300, 1800, 3600, 21_600] }.merge(payload)
     end
   end
 

--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -47,6 +47,7 @@ module Honeybadger
 
           if config.load_plugin_insights?(:active_job)
             ::ActiveSupport::Notifications.subscribe(/(enqueue_at|enqueue|enqueue_retry|enqueue_all|perform|retry_stopped|discard)\.active_job/, Honeybadger::ActiveJobSubscriber.new)
+            ::ActiveSupport::Notifications.subscribe('perform.active_job', Honeybadger::ActiveJobMetricsSubscriber.new)
           end
         end
       end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -39,6 +39,9 @@ module Honeybadger
           ensure
             context.merge!(duration: duration, status: status)
             Honeybadger.event('perform', context)
+
+            metric_source 'sidekiq'
+            histogram 'perform', context.slice(:worker, :queue, :duration)
           end
         end
       end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -41,7 +41,7 @@ module Honeybadger
             Honeybadger.event('perform', context)
 
             metric_source 'sidekiq'
-            histogram 'perform', context.slice(:worker, :queue, :duration)
+            histogram 'perform', { bins: [30, 60, 120, 300, 1800, 3600, 21_600] }.merge(context.slice(:worker, :queue, :duration))
           end
         end
       end

--- a/lib/honeybadger/registry.rb
+++ b/lib/honeybadger/registry.rb
@@ -7,15 +7,13 @@ module Honeybadger
 
     def register(metric)
       @mutex.synchronize do
-        @metrics[metric.name] ||= {}
-        @metrics[metric.name][metric.attributes] = metric
+        @metrics[metric.signature] = metric
       end
     end
 
-    def get(name, attributes)
+    def get(metric_type, name, attributes)
       @mutex.synchronize do
-        @metrics[name] ||= {}
-        @metrics[name][attributes]
+        @metrics[Honeybadger::Metric.signature(metric_type, name, attributes)]
       end
     end
 
@@ -27,8 +25,12 @@ module Honeybadger
 
     def metrics
       @mutex.synchronize do
-        @metrics.values.map(&:values).flatten
+        @metrics.values
       end
+    end
+
+    def debug_info
+      "#{Thread.current.inspect} #{Honeybadger::Agent.instance.collector_worker} #{object_id} #{@metrics.object_id} #{metrics.count} #{metrics.map(&:signature)}"
     end
   end
 end

--- a/lib/honeybadger/registry.rb
+++ b/lib/honeybadger/registry.rb
@@ -28,9 +28,5 @@ module Honeybadger
         @metrics.values
       end
     end
-
-    def debug_info
-      "#{Thread.current.inspect} #{Honeybadger::Agent.instance.collector_worker} #{object_id} #{@metrics.object_id} #{metrics.count} #{metrics.map(&:signature)}"
-    end
   end
 end

--- a/lib/honeybadger/registry.rb
+++ b/lib/honeybadger/registry.rb
@@ -1,0 +1,34 @@
+module Honeybadger
+  class Registry
+    def initialize
+      @mutex = Mutex.new
+      @metrics = Hash.new
+    end
+
+    def register(metric)
+      @mutex.synchronize do
+        @metrics[metric.name] ||= {}
+        @metrics[metric.name][metric.attributes] = metric
+      end
+    end
+
+    def get(name, attributes)
+      @mutex.synchronize do
+        @metrics[name] ||= {}
+        @metrics[name][attributes]
+      end
+    end
+
+    def flush
+      @mutex.synchronize do
+        @metrics = Hash.new
+      end
+    end
+
+    def metrics
+      @mutex.synchronize do
+        @metrics.values.map(&:values).flatten
+      end
+    end
+  end
+end

--- a/lib/honeybadger/registry_execution.rb
+++ b/lib/honeybadger/registry_execution.rb
@@ -1,6 +1,7 @@
 module Honeybadger
   class RegistryExecution
-    def initialize(config, options)
+    def initialize(registry, config, options)
+      @registry = registry
       @config = config
       @options = options
       @ticks = @interval = config[:'insights.registry_flush_interval'] || options.fetch(:interval, 60)
@@ -12,15 +13,11 @@ module Honeybadger
 
     def reset
       @ticks = @interval
-      Honeybadger.registry.flush
-    end
-
-    def register!
-      Honeybadger.collect(self)
+      @registry.flush
     end
 
     def call
-      Honeybadger.registry.metrics.each do |metric|
+      @registry.metrics.each do |metric|
         metric.event_payloads.each do |payload|
           Honeybadger.event(payload.merge(interval: @interval))
         end

--- a/lib/honeybadger/registry_execution.rb
+++ b/lib/honeybadger/registry_execution.rb
@@ -1,0 +1,30 @@
+module Honeybadger
+  class RegistryExecution
+    def initialize(config, options)
+      @config = config
+      @options = options
+      @ticks = @interval = config[:'insights.registry_flush_interval'] || options.fetch(:interval, 60)
+    end
+
+    def tick
+      @ticks = @ticks - 1
+    end
+
+    def reset
+      @ticks = @interval
+      Honeybadger.registry.flush
+    end
+
+    def register!
+      Honeybadger.collect(self)
+    end
+
+    def call
+      Honeybadger.registry.metrics.each do |metric|
+        metric.event_payloads.each do |payload|
+          Honeybadger.event(payload.merge(interval: @interval))
+        end
+      end
+    end
+  end
+end

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -40,6 +40,7 @@ module Honeybadger
   def_delegator :'Honeybadger::Agent.instance', :track_deployment
   def_delegator :'Honeybadger::Agent.instance', :event
   def_delegator :'Honeybadger::Agent.instance', :collect
+  def_delegator :'Honeybadger::Agent.instance', :registry
 
   # @!macro [attach] def_delegator
   #   @!method $2(...)

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -45,6 +45,7 @@ module Honeybadger
   def_delegator :'Honeybadger::Agent.instance', :histogram
   def_delegator :'Honeybadger::Agent.instance', :gauge
   def_delegator :'Honeybadger::Agent.instance', :increment_counter
+  def_delegator :'Honeybadger::Agent.instance', :decrement_counter
 
   # @!macro [attach] def_delegator
   #   @!method $2(...)

--- a/lib/honeybadger/timer.rb
+++ b/lib/honeybadger/timer.rb
@@ -1,0 +1,6 @@
+require 'honeybadger/gauge'
+
+module Honeybadger
+  class Timer < Gauge
+  end
+end

--- a/lib/puma/plugin/honeybadger.rb
+++ b/lib/puma/plugin/honeybadger.rb
@@ -4,6 +4,8 @@ module Honeybadger
   class PumaPlugin
     include Honeybadger::InstrumentationHelper
 
+    STATS_KEYS = %i(pool_capacity max_threads requests_count backlog running).freeze
+
     ::Puma::Plugin.create do
       def start(launcher)
         puma_plugin = ::Honeybadger::PumaPlugin.new
@@ -33,11 +35,9 @@ module Honeybadger
     end
 
     def record_puma_stats(stats, context={})
-      gauge "pool_capacity", context, ->{ stats[:pool_capacity] }
-      gauge "max_threads", context, ->{ stats[:max_threads] }
-      gauge "requests_count", context, ->{ stats[:requests_count] }
-      gauge "backlog", context, ->{ stats[:backlog] }
-      gauge "running", context, ->{ stats[:running] }
+      STATS_KEYS.each do |stat|
+        gauge stat, context, ->{ stats[stat] } if stats[stat]
+      end
     end
   end
 end


### PR DESCRIPTION
This adds metrics aggregation. 

### New Components

`Honeybadger::Registry` - This class stores all tracked metrics registered in the gem. The registry ensures that only one instance of each unique metric is stored at any time. A metric is defined as unique by it's type, name, and set of attributes.

`Honeybadger::RegistryExecution` - This class is injected into the `CollectorWorker` and is run on a configurable interval. When called, it iterates over all registered metrics, compiles payloads for each, and sent as an event. The registry is then flushed.

`Honeybadger::Metric` - A base metric class from which all other metric classes inherit from. These metric classes record data and compute/track values as needed.

### Shape of the Data

Each metric type's data is shaped differently. Below are examples of what that data looks like for each type.

#### counter

```json
{
  "counter": 1
}
```

#### gauge

```json
{
  "min": 1,
  "max": 10,
  "avg": 5.0,
  "latest": 5
}
```

#### timer

```json
{
  "min": 1,
  "max": 10,
  "avg": 5.0,
  "latest": 5
}
```

_Note: This may look the same as a gauge, however, the interface to use the metric provides a timing mechanism._

#### histogram

```json
{
  "bins": {
    "10": 1,
    "50": 10,
    "100": 5
  }
}
```

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
