### PR TITLE
perf: don't insert middleware at all if they've been disabled

### DIFF
--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -12,9 +12,11 @@ module Honeybadger
         end
 
         initializer 'honeybadger.install_middleware' do |app|
+          honeybadger_config = Honeybadger::Agent.instance.config
+
           app.config.middleware.insert(0, Honeybadger::Rack::ErrorNotifier)
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer)
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback)
+          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer) if honeybadger_config[:'user_informer.enabled']
+          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback) if honeybadger_config[:'feedback.enabled']
         end
 
         config.before_initialize do

--- a/lib/honeybadger/rack/user_feedback.rb
+++ b/lib/honeybadger/rack/user_feedback.rb
@@ -27,7 +27,6 @@ module Honeybadger
       end
 
       def call(env)
-        return @app.call(env) unless config[:'feedback.enabled']
         status, headers, body = @app.call(env)
         if env['honeybadger.error_id'] && form = render_form(env['honeybadger.error_id'])
           new_body = []

--- a/lib/honeybadger/rack/user_informer.rb
+++ b/lib/honeybadger/rack/user_informer.rb
@@ -17,7 +17,6 @@ module Honeybadger
       end
 
       def call(env)
-        return @app.call(env) unless config[:'user_informer.enabled']
         status, headers, body = @app.call(env)
         if env['honeybadger.error_id']
           new_body = []


### PR DESCRIPTION
Following up on my comment from 7 years ago.

https://github.com/honeybadger-io/honeybadger-ruby/commit/ab2c8cb71253b096d8fa82e71b83d0bf6ad7489e#r22137232

If I've disabled the middlewares I would like to not see them in `rails middleware`

