### PR TITLE
feat: add --insights flag to install command

### DIFF
--- a/lib/honeybadger/cli/install.rb
+++ b/lib/honeybadger/cli/install.rb
@@ -73,6 +73,10 @@ development_environments:
 
 # Enable verbose debug logging (useful for troubleshooting).
 debug: false
+
+# Enable Honeybadger Insights
+insights:
+  enable: #{options["insights"]}
 CONFIG
           end
         end

--- a/lib/honeybadger/cli/install.rb
+++ b/lib/honeybadger/cli/install.rb
@@ -76,7 +76,7 @@ debug: false
 
 # Enable Honeybadger Insights
 insights:
-  enable: #{options["insights"]}
+  enabled: #{options["insights"]}
 CONFIG
           end
         end

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -48,6 +48,7 @@ WELCOME
       end
 
       desc 'install API_KEY', 'Install Honeybadger into a new project'
+      option :insights, type: :boolean, aliases: :'-i', default: false, desc: 'Enable Honeybadger Insights'
       def install(api_key)
         Install.new(options, api_key).run
       rescue => e

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -40,6 +40,18 @@ feature "Installing honeybadger via the cli" do
       end
     end
 
+    context "with the insights flag" do
+      it "enables insights" do
+        run_command_and_stop('honeybadger install asdf --insights', fail_on_error: true)
+        expect(YAML.load_file(config_file).dig("insights", "enable")).to eq(true)
+      end
+
+      it "disables insights" do
+        run_command_and_stop('honeybadger install asdf --no-insights', fail_on_error: true)
+        expect(YAML.load_file(config_file).dig("insights", "enable")).to eq(false)
+      end
+    end
+
     scenario "when the configuration file already exists" do
       before { File.write(config_file, <<-YML) }
 ---

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -43,12 +43,12 @@ feature "Installing honeybadger via the cli" do
     context "with the insights flag" do
       it "enables insights" do
         run_command_and_stop('honeybadger install asdf --insights', fail_on_error: true)
-        expect(YAML.load_file(config_file).dig("insights", "enable")).to eq(true)
+        expect(YAML.load_file(config_file).dig("insights", "enabled")).to eq(true)
       end
 
       it "disables insights" do
         run_command_and_stop('honeybadger install asdf --no-insights', fail_on_error: true)
-        expect(YAML.load_file(config_file).dig("insights", "enable")).to eq(false)
+        expect(YAML.load_file(config_file).dig("insights", "enabled")).to eq(false)
       end
     end
 


### PR DESCRIPTION
This makes it easy to enable (or disable) Honeybadger Insights when installing in an application.

```bash
bundle exec honeybadger install apikey --insights
```

cc @joshuap