### PR TITLE
feat: add before_event hook for intercepting events

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -92,6 +92,10 @@ module Honeybadger
       (ruby[:before_notify] || []).clone
     end
 
+    def before_event_hooks
+      (ruby[:before_event] || []).clone
+    end
+
     def exception_filter(&block)
       if block_given?
         warn('DEPRECATED: exception_filter is deprecated. Please use before_notify instead. See https://docs.honeybadger.io/ruby/support/v4-upgrade#exception_filter')

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -89,13 +89,25 @@ module Honeybadger
       def before_notify(action = nil, &block)
         hooks = Array(get(:before_notify)).dup
 
-        if action && validate_before_action(action)
+        if action && validate_before_action(action, 'notify')
           hooks << action
-        elsif block_given? && validate_before_action(block)
+        elsif block_given? && validate_before_action(block, 'notify')
           hooks << block
         end
 
         hash[:before_notify] = hooks
+      end
+
+      def before_event(action = nil, &block)
+        hooks = Array(get(:before_event)).dup
+
+        if action && validate_before_action(action, 'event')
+          hooks << action
+        elsif block_given? && validate_before_action(block, 'event')
+          hooks << block
+        end
+
+        hash[:before_event] = hooks
       end
 
       def backtrace_filter(&block)
@@ -127,17 +139,17 @@ module Honeybadger
 
       private
 
-      def validate_before_action(action)
+      def validate_before_action(action, type)
         if !action.respond_to?(:call)
           logger.warn(
-            'You attempted to add a before notify hook that does not respond ' \
+            "You attempted to add a before #{type} hook that does not respond " \
             'to #call. We are discarding this hook so your intended behavior ' \
             'will not occur.'
           )
           false
         elsif action.arity != 1
           logger.warn(
-            'You attempted to add a before notify hook that has an arity ' \
+            "You attempted to add a before #{type} hook that has an arity " \
             'other than one. We are discarding this hook so your intended ' \
             'behavior will not occur.'
           )

--- a/lib/honeybadger/event.rb
+++ b/lib/honeybadger/event.rb
@@ -1,0 +1,56 @@
+require 'forwardable'
+
+module Honeybadger
+  class Event
+    extend Forwardable
+
+    # The timestamp of the event
+    attr_reader :ts
+
+    # The event_type of the event
+    attr_reader :event_type
+
+    # The payload data of the event
+    attr_reader :payload
+
+    def_delegator :payload, :[]
+
+    # @api private
+    def initialize(event_type_or_payload, payload={})
+      if event_type_or_payload.is_a?(String)
+        @event_type = event_type_or_payload
+        @payload = payload
+      elsif event_type_or_payload.is_a?(Hash)
+        @event_type = event_type_or_payload[:event_type] || event_type_or_payload["event_type"]
+        @payload = event_type_or_payload
+      end
+
+      @ts = payload[:ts] || Time.now.utc.strftime("%FT%T.%LZ")
+      @halted = false
+    end
+
+    # Halts the event and the before_event callback chain.
+    #
+    # Returns nothing.
+    def halt!
+      @halted ||= true
+    end
+
+    # @api private
+    # Determines if this event will be discarded.
+    def halted?
+      !!@halted
+    end
+
+    # @api private
+    # Template used to create JSON payload.
+    #
+    # @return [Hash] JSON representation of the event.
+    def as_json(*args)
+      payload.tap do |p|
+        p[:ts] = ts
+        p[:event_type] = event_type if event_type
+      end
+    end
+  end
+end

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -337,7 +337,18 @@ describe Honeybadger::Agent do
       end
     end
 
-    describe "ignoring events" do
+    describe "ignoring events using before_event callback" do
+      let(:halt_hook) { ->(event) { event.halt! } }
+
+      before { subject.configure { |config| config.before_event(halt_hook) } }
+      after { subject.event(event_type: "event_type", some_data: "is here") }
+
+      it "does not push an event" do
+        expect(events_worker).not_to receive(:push)
+      end
+    end
+
+    describe "ignoring events using events.ignore config" do
       let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER, backend: :debug, :'events.ignore' => ignored_events) }
 
       after { subject.event(event_type: event_type, some_data: "is here") }

--- a/spec/unit/honeybadger/event_spec.rb
+++ b/spec/unit/honeybadger/event_spec.rb
@@ -1,0 +1,56 @@
+require 'honeybadger/event'
+require 'timecop'
+
+describe Honeybadger::Event do
+  let(:event_type) { "event_type" }
+  let(:payload) { {} }
+
+  subject { described_class.new(event_type, payload) }
+
+  describe "initialize" do
+    context "event_type is passed as string" do
+      let(:event_type) { "action" }
+      let(:payload) { {} }
+
+      its(:event_type) { should eq "action" }
+      its(:payload) { should eq payload }
+    end
+
+    context "event_type is passed as part of payload" do
+      subject { described_class.new(event_type) }
+
+      let(:event_type) { { event_type: "action" } }
+
+      its(:event_type) { should eq "action" }
+      its(:payload) { should eq({ event_type: "action" }) }
+    end
+  end
+
+  describe "ts" do
+    before { Timecop.freeze }
+    after { Timecop.unfreeze }
+
+    its(:ts) { should eq Time.now.utc.strftime("%FT%T.%LZ") }
+  end
+
+  describe "halted" do
+    context "halt! is not called" do
+      its(:halted?) { should be false }
+    end
+
+    context "halt! is called" do
+      before { subject.halt! }
+      its(:halted?) { should be true }
+    end
+  end
+
+  describe "as_json" do
+    let(:event_type) { "action" }
+    let(:payload) { { data1: 1 } }
+
+    before { Timecop.freeze }
+    after { Timecop.unfreeze }
+
+    its(:as_json) { should eq({ event_type: "action", ts: Time.now.utc.strftime("%FT%T.%LZ"), data1: 1 }) }
+  end
+end


### PR DESCRIPTION
Similar to the `before_notify` callback, this adds a `before_event` callback to allow for intercepting of an event. Within the callback you can inspect or modify the payload, or `halt!` the event if you do not want it to be sent.

Example:
```ruby
Honeybadger.configure do |config|
  config.before_event do |event|
    if event.event_type == "process_action.action_controller" && event[:controller] == "Rails::HealthController"
      event.halt!
    end
  end
end
```

`Event#event_type` - Returns the `event_type` parameter.
`Event#ts` - Returns the generated timestamp, or the `:ts` value in the payload if one was present.
`Event#[]` - Allows you to access the event payload data.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
