### PR TITLE
feat: define default events to ignore, allow for override

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -405,7 +405,7 @@ module Honeybadger
       end
 
       return if config.ignored_events.any? do |check|
-        check.any? do |keys, value|
+        check.all? do |keys, value|
           if keys == [:event_type]
             event.event_type&.match?(value)
           elsif event.dig(*keys)

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -405,11 +405,13 @@ module Honeybadger
       end
 
       return if config.ignored_events.any? do |check|
-        check.all? do |keys, value|
-          if keys == [:event_type]
-            event.event_type&.match?(value)
-          elsif event.dig(*keys)
-            event.dig(*keys).to_s.match?(value)
+        with_error_handling do
+          check.all? do |keys, value|
+            if keys == [:event_type]
+              event.event_type&.match?(value)
+            elsif event.dig(*keys)
+              event.dig(*keys).to_s.match?(value)
+            end
           end
         end
       end

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -601,6 +601,9 @@ module Honeybadger
       error { "Rescued an error in a before hook: #{ex.message}" }
     end
 
+    # Converts a nested hash into a single layer where keys become arrays:
+    # ex: > flat_hash({ :nested => { :hash => "value" }})
+    #     > { [:nested, :hash] => "value" }
     def flat_hash(h,f=[],g={})
       return g.update({ f=>h }) unless h.is_a? Hash
       h.each { |k,r| flat_hash(r,f+[k],g) }

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -193,9 +193,11 @@ module Honeybadger
     end
 
     def ignored_events
-      self[:'events.ignore'].map do |check|
-        check.is_a?(String) ? /^#{check}$/ : check
-      end
+      ignore_only = get(:'events.ignore_only')
+      return ignore_only if ignore_only
+      return DEFAULTS[:'events.ignore'] unless ignore = get(:'events.ignore')
+
+      DEFAULTS[:'events.ignore'] | Array(ignore)
     end
 
     def ca_bundle_path

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -207,7 +207,7 @@ module Honeybadger
         elsif check.is_a?(Hash)
           flat_hash(check).transform_keys! { |key_array| key_array.map(&:to_sym) }
         end
-      end
+      end.compact
     end
 
     def ca_bundle_path

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -32,7 +32,7 @@ module Honeybadger
                       'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
     IGNORE_EVENTS_DEFAULT = [
-      { event_type: 'sql.active_record', query: /(^begin$|^commit$|solid_queue)/i },
+      { event_type: 'sql.active_record', query: /(^begin$|^commit$|solid_queue|good_job)/i },
       { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' }
     ].freeze
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -32,7 +32,8 @@ module Honeybadger
                       'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
     IGNORE_EVENTS_DEFAULT = [
-      { event_type: 'sql.active_record', query: /(^begin$|^commit$|solid_queue|good_job)/i },
+      { event_type: 'sql.active_record', query: /^(begin|commit)( transaction)?$/i },
+      { event_type: 'sql.active_record', query: /(solid_queue|good_job)/i },
       { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' }
     ].freeze
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -31,6 +31,11 @@ module Honeybadger
                       'Sinatra::NotFound',
                       'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
+    IGNORE_EVENTS_DEFAULT = [
+      { event_type: 'sql.active_record', query: /(^begin$|^commit$|solid_queue)/i },
+      { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' }
+    ].freeze
+
     DEVELOPMENT_ENVIRONMENTS = ['development', 'test', 'cucumber'].map(&:freeze).freeze
 
     DEFAULT_PATHS = ['honeybadger.yml', 'config/honeybadger.yml', "#{ENV['HOME']}/honeybadger.yml"].map(&:freeze).freeze
@@ -112,8 +117,13 @@ module Honeybadger
         type: Boolean
       },
       :'events.ignore' => {
-        description: 'A list of events to ignore. Use a string to specify exact matches, or regex for more flexibility.',
-        default: [],
+        description: 'A list of additional events to ignore. Use a hash to query nested payloads, match using a string or regex. Non-hash will match on the event_type.',
+        default: IGNORE_EVENTS_DEFAULT,
+        type: Array
+      },
+      :'events.ignore_only' => {
+        description: 'A list of events to ignore (overrides the default ignored events).',
+        default: nil,
         type: Array
       },
       plugins: {

--- a/lib/honeybadger/event.rb
+++ b/lib/honeybadger/event.rb
@@ -14,6 +14,7 @@ module Honeybadger
     attr_reader :payload
 
     def_delegator :payload, :[]
+    def_delegator :payload, :dig
 
     # @api private
     def initialize(event_type_or_payload, payload={})

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -66,7 +66,6 @@ module Honeybadger
 
     def process?(event, payload)
       return false if payload[:name] == "SCHEMA"
-      return false if payload[:sql]&.match?(/^(begin|commit)( transaction)?$/i)
       true
     end
   end

--- a/lib/honeybadger/plugins/solid_queue.rb
+++ b/lib/honeybadger/plugins/solid_queue.rb
@@ -2,7 +2,7 @@ module Honeybadger
   module Plugins
     module SolidQueue
       Plugin.register :solid_queue do
-        requirement { defined?(::SolidQueue) }
+        requirement { config.load_plugin_insights?(:solid_queue) && defined?(::SolidQueue) }
 
         collect do
           if config.cluster_collection?(:solid_queue)

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -430,7 +430,7 @@ describe Honeybadger::Agent do
 
       context "by default ignores Rails::HealthController" do
         let(:ignored_events) { [] }
-        let(:event_type) { "perform_action.action_controller" }
+        let(:event_type) { "process_action.action_controller" }
         let(:payload) { { controller: "Rails::HealthController" } }
 
         it "does not push an event" do
@@ -462,6 +462,16 @@ describe Honeybadger::Agent do
         let(:ignored_events) { [] }
         let(:event_type) { "sql.active_record" }
         let(:payload) { { query: 'UPDATE "solid_queue_processes" SET "last_heartbeat_at" = ? WHERE "solid_queue_processes"."id" = ?' } }
+
+        it "does not push an event" do
+          expect(events_worker).not_to receive(:push)
+        end
+      end
+
+      context "by default ignores good_job processor sql events" do
+        let(:ignored_events) { [] }
+        let(:event_type) { "sql.active_record" }
+        let(:payload) { { query: 'SELECT * FROM "good_jobs"' } }
 
         it "does not push an event" do
           expect(events_worker).not_to receive(:push)

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -418,6 +418,16 @@ describe Honeybadger::Agent do
         end
       end
 
+      context "when configured with a hash with string keys" do
+        let(:ignored_events) { [{ "nested" => { "data"  => "test" }}] }
+        let(:event_type) { "report.system" }
+        let(:payload) { { nested: { "data" => "test" }} }
+
+        it "does push an event" do
+          expect(events_worker).to receive(:push)
+        end
+      end
+
       context "by default ignores Rails::HealthController" do
         let(:ignored_events) { [] }
         let(:event_type) { "perform_action.action_controller" }


### PR DESCRIPTION
Fixes: https://github.com/honeybadger-io/honeybadger-ruby/issues/569

This adds some default events to be ignored:

* sql queries: `BEGIN`, `COMMIT`, and anything related to `solid_queue` and `good_job`.
* calls to the default `Rails::HealthController`.

The config `events.ignore` now behaves exactly like `exceptions.ignore` where if you define it in your config file, it will append to the defaults. There is now a `events.ignore_only` where you can override the defaults.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
