### PR TITLE
fix: ignore content-less SQL statements

### DIFF
--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -9,7 +9,7 @@ module Honeybadger
     def finish(name, id, payload)
       @finish_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
 
-      return unless process?(name)
+      return unless process?(name, payload)
 
       payload = {
         instrumenter_id: id,
@@ -23,7 +23,7 @@ module Honeybadger
       Honeybadger.event(name, payload)
     end
 
-    def process?(event)
+    def process?(event, payload)
       true
     end
 
@@ -61,6 +61,12 @@ module Honeybadger
         query: payload[:sql].to_s.gsub(/\s+/, ' ').strip,
         async: payload[:async]
       }
+    end
+
+    def process?(event, payload)
+      return false if payload[:name] == "SCHEMA"
+      return false if payload[:sql]&.match?(/^(begin|commit)( transaction)?$/i)
+      true
     end
   end
 


### PR DESCRIPTION
There's no point in reporting statements that equal SCHEMA, BEGIN, or COMMIT. :)