### PR TITLE
fix: buffer more and warn less

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -93,7 +93,7 @@ module Honeybadger
       },
       :'events.max_queue_size' => {
         description: 'Maximum number of event for the event worker queue.',
-        default: 10000,
+        default: 100000,
         type: Integer
       },
       :'events.batch_size' => {

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -208,6 +208,7 @@ module Honeybadger
       send_now(mutex.synchronize { send_queue })
       mutex.synchronize do
         @last_sent = Time.now
+        debug { sprintf('Sending %s events', send_queue.length) }
         send_queue.clear
         if @dropped_events > 0
           warn { sprintf('Dropped %s messages due to exceeding max queue size of %s', @dropped_events, config.events_max_queue_size) }

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -216,7 +216,7 @@ module Honeybadger
         to_send
       end
 
-      debug { sprintf('Sending %s events', send_queue.length) }
+      debug { sprintf('Sending %s events', batch.length) }
       send_now(batch)
     end
 

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -208,6 +208,7 @@ module Honeybadger
       batch = mutex.synchronize do
         to_send = send_queue
         @send_queue = Queue.new
+        @send_queue = []
         @last_sent = Time.now
         if @dropped_events > 0
           warn { sprintf('Dropped %s messages due to exceeding max queue size of %s', @dropped_events, config.events_max_queue_size) }

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -205,16 +205,19 @@ module Honeybadger
     end
 
     def send_batch
-      send_now(mutex.synchronize { send_queue })
-      mutex.synchronize do
+      batch = mutex.synchronize do
+        to_send = send_queue
+        @send_queue = Queue.new
         @last_sent = Time.now
-        debug { sprintf('Sending %s events', send_queue.length) }
-        send_queue.clear
         if @dropped_events > 0
           warn { sprintf('Dropped %s messages due to exceeding max queue size of %s', @dropped_events, config.events_max_queue_size) }
+          @dropped_events = 0
         end
-        @dropped_events = 0
+        to_send
       end
+
+      debug { sprintf('Sending %s events', send_queue.length) }
+      send_now(batch)
     end
 
     def check_and_send

--- a/spec/unit/honeybadger/events_worker_spec.rb
+++ b/spec/unit/honeybadger/events_worker_spec.rb
@@ -125,12 +125,6 @@ describe Honeybadger::EventsWorker do
         expect(instance.send(:queue)).not_to receive(:push)
         expect(instance.push(event)).to eq false
       end
-
-      it "warns the logger" do
-        allow(config.logger).to receive(:warn)
-        expect(config.logger).to receive(:warn).with(/reached max/i)
-        instance.push(event)
-      end
     end
   end
 


### PR DESCRIPTION
We've had a few cases of people getting too many warnings in their logs about the queue being full. This PR increases the default queue size, and it also triggers the warning message only when sending a batch of events instead of every time an event is added to the queue.