### PR TITLE
fix: disable insights when loading rails console

### DIFF
--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -32,6 +32,10 @@ module Honeybadger
         config.after_initialize do
           Honeybadger.load_plugins!
         end
+
+        console do
+          Honeybadger::Agent.instance.config[:'insights.enabled'] = false unless Honeybadger::Agent.instance.config.env.has_key?(:'insights.enabled')
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes: https://github.com/honeybadger-io/honeybadger-ruby/issues/579

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
