### PR TITLE
feat: add ability to link to a custom domain after creating a notice

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -166,6 +166,11 @@ module Honeybadger
         default: 'api.honeybadger.io'.freeze,
         type: String
       },
+      :'connection.ui_host' => {
+        description: 'The host to use when viewing data.',
+        default: 'app.honeybadger.io'.freeze,
+        type: String
+      },
       :'connection.port' => {
         description: 'The port to use when sending data.',
         default: nil,

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -226,10 +226,11 @@ module Honeybadger
       when 413
         warn { sprintf('Error report failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
       when 201
+        host = config.get(:'connection.host')
         if throttle = dec_throttle
-          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
+          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
         else
-          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
+          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
         end
       when :stubbed
         info { sprintf('Success ⚡ Development mode is enabled; this error will be reported if it occurs after you deploy your app. id=%s', msg.id) }

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -226,7 +226,7 @@ module Honeybadger
       when 413
         warn { sprintf('Error report failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
       when 201
-        host = config.get(:'connection.host')
+        host = config.get(:'connection.ui_host')
         if throttle = dec_throttle
           info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
         else


### PR DESCRIPTION
Instead of always linking to app.honeybadger.io, the link shown for the just-created notice should point to the new `connection.ui_host` setting, which defaults to app.honeybadger.io.
