### PR TITLE
feat: add --host and --ui_host flags to install command

### DIFF
--- a/lib/honeybadger/cli/install.rb
+++ b/lib/honeybadger/cli/install.rb
@@ -78,6 +78,10 @@ debug: false
 insights:
   enabled: #{options["insights"]}
 CONFIG
+            if (connection = options.slice("host", "ui_host")).any?
+              file.puts("\n# Override hosts\nconnection:")
+              connection.each {|k,v| file.puts("  #{k}: '#{v}'") }
+            end
           end
         end
 

--- a/lib/honeybadger/cli/main.rb
+++ b/lib/honeybadger/cli/main.rb
@@ -49,6 +49,8 @@ WELCOME
 
       desc 'install API_KEY', 'Install Honeybadger into a new project'
       option :insights, type: :boolean, aliases: :'-i', default: false, desc: 'Enable Honeybadger Insights'
+      option :host, type: :string
+      option :ui_host, type: :string
       def install(api_key)
         Install.new(options, api_key).run
       rescue => e

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -166,6 +166,11 @@ module Honeybadger
         default: 'api.honeybadger.io'.freeze,
         type: String
       },
+      :'connection.ui_host' => {
+        description: 'The host to use when viewing data.',
+        default: 'app.honeybadger.io'.freeze,
+        type: String
+      },
       :'connection.port' => {
         description: 'The port to use when sending data.',
         default: nil,

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -226,10 +226,11 @@ module Honeybadger
       when 413
         warn { sprintf('Error report failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
       when 201
+        host = config.get(:'connection.host')
         if throttle = dec_throttle
-          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
+          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
         else
-          info { sprintf('Success ⚡ https://app.honeybadger.io/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
+          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
         end
       when :stubbed
         info { sprintf('Success ⚡ Development mode is enabled; this error will be reported if it occurs after you deploy your app. id=%s', msg.id) }

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -226,7 +226,7 @@ module Honeybadger
       when 413
         warn { sprintf('Error report failed: Payload is too large. id=%s code=%s', msg.id, response.code) }
       when 201
-        host = config.get(:'connection.host')
+        host = config.get(:'connection.ui_host')
         if throttle = dec_throttle
           info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
         else

--- a/spec/features/install_spec.rb
+++ b/spec/features/install_spec.rb
@@ -51,6 +51,26 @@ feature "Installing honeybadger via the cli" do
         expect(YAML.load_file(config_file).dig("insights", "enabled")).to eq(false)
       end
     end
+    
+    context "with host and/or UI host flags" do
+      let(:yaml) { YAML.load_file(config_file) }
+      
+      it "configures the host" do
+        run_command_and_stop('honeybadger install asdf --host api.honeybadger.io', fail_on_error: true)
+        expect(yaml.dig("connection", "host")).to eq('api.honeybadger.io')
+      end
+      
+      it "configures the UI host" do
+        run_command_and_stop('honeybadger install asdf --ui_host app.honeybadger.io', fail_on_error: true)
+        expect(yaml.dig("connection", "ui_host")).to eq('app.honeybadger.io')
+      end
+      
+      it "configures both hosts" do
+        run_command_and_stop('honeybadger install asdf --host api.honeybadger.io --ui_host app.honeybadger.io', fail_on_error: true)
+        expect(yaml.dig("connection", "host")).to eq('api.honeybadger.io')
+        expect(yaml.dig("connection", "ui_host")).to eq('app.honeybadger.io')
+      end
+    end
 
     scenario "when the configuration file already exists" do
       before { File.write(config_file, <<-YML) }


### PR DESCRIPTION
Make it easy to configure the connection hosts when running the install command.