### PR TITLE
fix: add event method for cli backend test

### DIFF
--- a/lib/honeybadger/backend/test.rb
+++ b/lib/honeybadger/backend/test.rb
@@ -13,6 +13,16 @@ module Honeybadger
         @notifications ||= Hash.new {|h,k| h[k] = [] }
       end
 
+      # The event list.
+      #
+      # @example
+      #   Test.events # => [{}, {}, ...]
+      #
+      # @return [Array<Hash>] List of event payloads.
+      def self.events
+        @events ||= []
+      end
+
       # @api public
       # The check in list.
       #
@@ -34,6 +44,11 @@ module Honeybadger
 
       def notify(feature, payload)
         notifications[feature] << payload
+        super
+      end
+
+      def event(payload)
+        events << payload
         super
       end
 

--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -24,9 +24,19 @@ module Honeybadger
           @callings ||= Hash.new {|h,k| h[k] = [] }
         end
 
+        def self.events
+          @events ||= []
+        end
+
         def notify(feature, payload)
           response = @backend.notify(feature, payload)
           self.class.callings[feature] << [payload, response]
+          response
+        end
+
+        def event(payload)
+          response = @backend.event(payload)
+          self.class.events << [payload, response]
           response
         end
       end

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -228,9 +228,9 @@ module Honeybadger
       when 201
         host = config.get(:'connection.ui_host')
         if throttle = dec_throttle
-          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s throttle=%s interval=%s', msg.id, msg.id, response.code, throttle, throttle_interval) }
+          info { sprintf('Success ⚡ https://%s/notice/%s id=%s code=%s throttle=%s interval=%s', host, msg.id, msg.id, response.code, throttle, throttle_interval) }
         else
-          info { sprintf('Success ⚡ https://#{host}/notice/%s id=%s code=%s', msg.id, msg.id, response.code) }
+          info { sprintf('Success ⚡ https://%s/notice/%s id=%s code=%s', host, msg.id, msg.id, response.code) }
         end
       when :stubbed
         info { sprintf('Success ⚡ Development mode is enabled; this error will be reported if it occurs after you deploy your app. id=%s', msg.id) }


### PR DESCRIPTION
This fixes an issue where the cli test would throw an error when Insights has been enabled.

In addition:
* Adds missing methods for the `Backend::Test` class for the sake of completeness.
* Fixes string interpolation for some info messages.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
