### PR TITLE
fix: safe navigate adapter_name for payload connection

### DIFF
--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -59,7 +59,7 @@ module Honeybadger
   class ActiveRecordSubscriber < NotificationSubscriber
     def format_payload(payload)
       {
-        query: Util::SQL.obfuscate(payload[:sql], payload[:connection].adapter_name),
+        query: Util::SQL.obfuscate(payload[:sql], payload[:connection]&.adapter_name),
         async: payload[:async]
       }
     end


### PR DESCRIPTION
In some cases, the payload connection may be nil, which we should handle gracefully.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
