### PR TITLE
docs: correct spelling, YARD formatting

### DIFF
--- a/lib/honeybadger/instrumentation.rb
+++ b/lib/honeybadger/instrumentation.rb
@@ -9,20 +9,19 @@ module Honeybadger
   # instance. There are three usage variations as show in the example below:
   #
   # @example
+  #   class TicketsController < ApplicationController
+  #     def create
+  #       # pass a block
+  #       Honeybadger.time('create.ticket') { Ticket.create(params[:ticket]) }
   #
-  # class TicketsController < ApplicationController
-  #   def create
-  #     # pass a block
-  #     Honeybadger.time('create.ticket') { Ticket.create(params[:ticket]) }
+  #       # pass a lambda argument
+  #       Honeybadger.time 'create.ticket', ->{ Ticket.create(params[:ticket]) }
   #
-  #     # pass a lambda argument
-  #     Honeybadger.time 'create.ticket', ->{ Ticket.create(params[:ticket]) }
-  #
-  #     # pass the duration argument
-  #     duration = timing_method { Ticket.create(params[:ticket]) }
-  #     Honeybadger.time 'create.ticket', duration: duration
+  #       # pass the duration argument
+  #       duration = timing_method { Ticket.create(params[:ticket]) }
+  #       Honeybadger.time 'create.ticket', duration: duration
+  #     end
   #   end
-  # end
   #
   #
   class Instrumentation

--- a/lib/honeybadger/instrumentation_helper.rb
+++ b/lib/honeybadger/instrumentation_helper.rb
@@ -2,31 +2,28 @@ require 'honeybadger/instrumentation'
 
 module Honeybadger
   # +Honeybadger::InstrumentationHelper+ is a module that can be included into any class. This module
-  # provides a convenient DSL around the instrumentation methods to prvoide a cleaner interface.
+  # provides a convenient DSL around the instrumentation methods to provide a cleaner interface.
   # There are three usage variations as show in the example below:
   #
   # @example
+  #   class TicketsController < ApplicationController
+  #     include Honeybadger::InstrumentationHelper
   #
-  # class TicketsController < ApplicationController
-  #   include Honeybadger::InstrumentationHelper
+  #     def create
+  #       metric_source 'controller'
+  #       metric_attributes { foo: 'bar' } # These attributes get tagged to all metrics called after.
   #
-  #   def create
-  #     metric_source 'controller'
-  #     metric_attributes { foo: 'bar' } # These attributes get tagged to all metrics called after.
+  #       # pass a block
+  #       time('create.ticket') { Ticket.create(params[:ticket]) }
   #
-  #     # pass a block
-  #     time('create.ticket') { Ticket.create(params[:ticket]) }
+  #       # pass a lambda argument
+  #       time 'create.ticket', ->{ Ticket.create(params[:ticket]) }
   #
-  #     # pass a lambda argument
-  #     time 'create.ticket', ->{ Ticket.create(params[:ticket]) }
-  #
-  #     # pass the duration argument
-  #     duration = timing_method { Ticket.create(params[:ticket]) }
-  #     time 'create.ticket', duration: duration
+  #       # pass the duration argument
+  #       duration = timing_method { Ticket.create(params[:ticket]) }
+  #       time 'create.ticket', duration: duration
+  #     end
   #   end
-  # end
-  #
-  #
   module InstrumentationHelper
 
     # returns two parameters, the first is the duration of the execution, and the second is


### PR DESCRIPTION
This tries to format the example to hold lines together, and using an indent level.

I saw that the first code line wasn't understood by YARD.

# Screenshots: After this change

The module, I could not get it to render highlighting:

![image](https://github.com/user-attachments/assets/e4a19f7f-1587-41e0-bcc0-c8ce20bc396a)

The regular class worked per normal:

![image](https://github.com/user-attachments/assets/6afc5d46-7cd7-4bf3-a36e-f42301fbf2bb)


# Screenshots: Before this change

![image](https://github.com/user-attachments/assets/74a11b0c-24a2-49da-a93e-56ee6fdc8da1)

![image](https://github.com/user-attachments/assets/17d3ba01-3a7e-4f0a-8f36-5e4219a9857a)
