### PR TITLE
fix: init karafka plugin only if monitor is available

### DIFF
--- a/lib/honeybadger/plugins/karafka.rb
+++ b/lib/honeybadger/plugins/karafka.rb
@@ -3,7 +3,7 @@ require 'honeybadger/plugin'
 module Honeybadger
   module Plugins
     Plugin.register :karafka do
-      requirement { defined?(::Karafka) }
+      requirement { defined?(::Karafka) && ::Karafka.respond_to?(:monitor) }
 
       execution do
         ::Karafka.monitor.subscribe('error.occurred') do |event|


### PR DESCRIPTION
If a ruby application is using only the `waterdrop` gem, the `Karafka` namespace is available, but the `monitor` method is not. The plugin will only work if the monitoring is available.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
