### PR TITLE
chore: depend on 'logger' explicitly

### DIFF
--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib', 'vendor/capistrano-honeybadger/lib']
 
   s.executables << 'honeybadger'
+
+  s.add_dependency 'logger'
 end


### PR DESCRIPTION
The `logger` used to be shipped with Ruby, as a bundled gem, but Ruby 3.5.0 no longer includes this gem by default.

Explicitly depending  on it avoids a warning being emitted.
