### PR TITLE
feat: add a separate configuration for Insights in a console

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -411,6 +411,11 @@ module Honeybadger
         default: false,
         type: Boolean
       },
+      :'insights.console.enabled' => {
+        description: "Enable/Disable Honeybadger Insights built-in instrumentation in a Rails console.",
+        default: false,
+        type: Boolean
+      },
       :'insights.registry_flush_interval' => {
         description: "Number of seconds between registry flushes.",
         default: 60,

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -34,7 +34,7 @@ module Honeybadger
         end
 
         console do
-          Honeybadger::Agent.instance.config[:'insights.enabled'] = false unless Honeybadger::Agent.instance.config.env.has_key?(:'insights.enabled')
+          Honeybadger::Agent.instance.config[:'insights.enabled'] = Honeybadger::Agent.instance.config[:'insights.console.enabled']
         end
       end
     end


### PR DESCRIPTION
This adds a separate configuration for enabling Insights in a console. By default any automatic instrumentation is disabled when you run `bin/rails console`, then you can set a configuration parameter if you need to have it enabled.

Fixes: https://github.com/honeybadger-io/honeybadger-ruby/issues/622

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
