### PR TITLE
fix: don't raise errors in instrumentation metrics

### DIFF
--- a/gemfiles/hanami.gemfile
+++ b/gemfiles/hanami.gemfile
@@ -16,6 +16,7 @@ gem "bump", "~> 0.10.0"
 gem "hanami", "~> 2.0"
 gem "hanami-router", "~> 2.0"
 gem "rack-test"
+gem "dry-system", "~> 1.0.1"
 
 group :development do
   gem "guard"

--- a/gemfiles/hanami.gemfile
+++ b/gemfiles/hanami.gemfile
@@ -16,6 +16,10 @@ gem "bump", "~> 0.10.0"
 gem "hanami", "~> 2.0"
 gem "hanami-router", "~> 2.0"
 gem "rack-test"
+
+# Pin the dry-system gem because hanami 2.1.1 relies on a method
+# (#find_and_load_provider) that was removed from dry-system 1.1.0. Once hanami
+# 2.2.0 is released, we can remove this gem and rely on the dependency only.
 gem "dry-system", "~> 1.0.1"
 
 group :development do

--- a/lib/honeybadger/instrumentation.rb
+++ b/lib/honeybadger/instrumentation.rb
@@ -57,10 +57,12 @@ module Honeybadger
         value = attributes.delete(:duration) || attributes.delete(:value)
       end
 
-      raise 'No value found' if value.nil?
-
       Honeybadger::Timer.register(registry, name, attributes).tap do |timer|
-        timer.record(value)
+        if value.nil?
+          agent.config.logger.warn("No value found for timer #{name}. Must specify either duration or value. Skipping.")
+        else
+          timer.record(value)
+        end
       end
     end
 
@@ -77,10 +79,12 @@ module Honeybadger
         value = attributes.delete(:duration) || attributes.delete(:value)
       end
 
-      raise 'No value found' if value.nil?
-
       Honeybadger::Histogram.register(registry, name, attributes).tap do |histogram|
-        histogram.record(value)
+        if value.nil?
+          agent.config.logger.warn("No value found for histogram #{name}. Must specify either duration or value. Skipping.")
+        else
+          histogram.record(value)
+        end
       end
     end
 
@@ -134,7 +138,11 @@ module Honeybadger
       end
 
       Honeybadger::Gauge.register(registry, name, attributes).tap do |gauge|
-        gauge.record(value)
+        if value.nil?
+          agent.config.logger.warn("No value found for gauge #{name}. Must specify value. Skipping.")
+        else
+          gauge.record(value)
+        end
       end
     end
 

--- a/lib/honeybadger/registry_execution.rb
+++ b/lib/honeybadger/registry_execution.rb
@@ -19,6 +19,7 @@ module Honeybadger
 
     def call
       @registry.metrics.each do |metric|
+        next if metric.samples == 0
         metric.event_payloads.each do |payload|
           Honeybadger.event(payload.merge(interval: @interval))
         end


### PR DESCRIPTION
Raising an error just because a value isn't specified is a little too aggressive. Instead, we can still register the metric and just log the issue. This should prevent unwanted exceptions from bubbling up into the application. We should also not send any metrics if no samples have been collected.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
