### PR TITLE
fix: don't run middleware in Sinatra when not configured

### DIFF
--- a/lib/honeybadger/init/sinatra.rb
+++ b/lib/honeybadger/init/sinatra.rb
@@ -31,8 +31,8 @@ module Honeybadger
             if config[:'exceptions.enabled']
               # These two must come before the ErrorNotifier, since an error/response
               # passes through middleware from inner to outer (bottom to top)
-              install_honeybadger_middleware(Honeybadger::Rack::UserFeedback)
-              install_honeybadger_middleware(Honeybadger::Rack::UserInformer)
+              install_honeybadger_middleware(Honeybadger::Rack::UserFeedback) if config[:'feedback.enabled']
+              install_honeybadger_middleware(Honeybadger::Rack::UserInformer) if config[:'user_informer.enabled']
               install_honeybadger_middleware(Honeybadger::Rack::ErrorNotifier)
             end
           end


### PR DESCRIPTION
While #549 has removed middleware loading for Rails unless configured, it has also removed the code that prevented the middleware from executing in other frameworks unless configured i.e. `return @app.call(env) unless config[:FLAG]`.

A similar change to rails initializer in #549 is now also required for Sinatra (perhaps the same for Hanami?), because currently it loads **and executes** the feedback and user informer middleware even when they are not configured.

