### PR TITLE
feat: add aggregated metrics for rails and more

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -363,6 +363,36 @@ module Honeybadger
         default: 60,
         type: Integer
       },
+      :'sidekiq.insights.enabled' => {
+        description: 'Enable automatic data collection for Sidekiq.',
+        default: true,
+        type: Boolean
+      },
+      :'sidekiq.insights.events' => {
+        description: 'Enable automatic event capturing for Sidekiq.',
+        default: true,
+        type: Boolean
+      },
+      :'sidekiq.insights.metrics' => {
+        description: 'Enable automatic metric data collection for Sidekiq.',
+        default: true,
+        type: Boolean
+      },
+      :'rails.insights.enabled' => {
+        description: 'Enable automatic data collection for Ruby on Rails.',
+        default: true,
+        type: Boolean
+      },
+      :'rails.insights.events' => {
+        description: 'Enable automatic event capturing for Ruby on Rails.',
+        default: true,
+        type: Boolean
+      },
+      :'rails.insights.metrics' => {
+        description: 'Enable automatic metric data collection for Ruby on Rails.',
+        default: true,
+        type: Boolean
+      },
       :'karafka.insights.enabled' => {
         description: 'Enable automatic data collection for Karafka.',
         default: true,
@@ -380,6 +410,16 @@ module Honeybadger
       },
       :'net_http.insights.enabled' => {
         description: 'Allow automatic instrumentation of Net::HTTP requests.',
+        default: true,
+        type: Boolean
+      },
+      :'net_http.insights.events' => {
+        description: 'Enable automatic event capturing for Net::HTTP requests.',
+        default: true,
+        type: Boolean
+      },
+      :'net_http.insights.metrics' => {
+        description: 'Enable automatic metric data collection for Net::HTTP requests.',
         default: true,
         type: Boolean
       },

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -32,6 +32,7 @@ module Honeybadger
                       'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
     IGNORE_EVENTS_DEFAULT = [
+      { event_type: 'metric.hb', metric_name: 'duration.sql.active_record', query: /^(begin|commit)( transaction)?$/i },
       { event_type: 'sql.active_record', query: /^(begin|commit)( transaction)?$/i },
       { event_type: 'sql.active_record', query: /(solid_queue|good_job)/i },
       { event_type: 'sql.active_record', name: /^GoodJob/ },
@@ -375,7 +376,7 @@ module Honeybadger
       },
       :'sidekiq.insights.metrics' => {
         description: 'Enable automatic metric data collection for Sidekiq.',
-        default: true,
+        default: false,
         type: Boolean
       },
       :'rails.insights.enabled' => {
@@ -390,7 +391,7 @@ module Honeybadger
       },
       :'rails.insights.metrics' => {
         description: 'Enable automatic metric data collection for Ruby on Rails.',
-        default: true,
+        default: false,
         type: Boolean
       },
       :'karafka.insights.enabled' => {
@@ -405,7 +406,7 @@ module Honeybadger
       },
       :'karafka.insights.metrics' => {
         description: 'Enable automatic metric data collection for Karafka.',
-        default: true,
+        default: false,
         type: Boolean
       },
       :'net_http.insights.enabled' => {
@@ -420,7 +421,7 @@ module Honeybadger
       },
       :'net_http.insights.metrics' => {
         description: 'Enable automatic metric data collection for Net::HTTP requests.',
-        default: true,
+        default: false,
         type: Boolean
       },
       :'net_http.insights.full_url' => {

--- a/lib/honeybadger/gauge.rb
+++ b/lib/honeybadger/gauge.rb
@@ -19,6 +19,7 @@ module Honeybadger
     def payloads
       [
         {
+          total: @total,
           min: @min,
           max: @max,
           avg: @avg,

--- a/lib/honeybadger/histogram.rb
+++ b/lib/honeybadger/histogram.rb
@@ -34,6 +34,7 @@ module Honeybadger
 
     def payloads
       [{
+        total: @total,
         min: @min,
         max: @max,
         avg: @avg,

--- a/lib/honeybadger/instrumentation.rb
+++ b/lib/honeybadger/instrumentation.rb
@@ -134,7 +134,7 @@ module Honeybadger
       elsif block_given?
         value = yield
       else
-        value = attributes.delete(:value)
+        value = attributes.delete(:duration) || attributes.delete(:value)
       end
 
       Honeybadger::Gauge.register(registry, name, attributes).tap do |gauge|

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -41,6 +41,8 @@ module Honeybadger
         gauge('duration.process_action.action_controller', value: payload[:duration], **payload.slice(:method, :controller, :action, :format, :status))
         gauge('db_runtime.process_action.action_controller', value: payload[:db_runtime], **payload.slice(:method, :controller, :action, :format, :status))
         gauge('view_runtime.process_action.action_controller', value: payload[:view_runtime], **payload.slice(:method, :controller, :action, :format, :status))
+      when 'perform.active_job'
+        gauge('duration.perform.active_job', value: payload[:duration], **payload.slice(:job_class, :queue_name))
       when /^cache_.*.active_support$/
         gauge("duration.#{name}", value: payload[:duration], **payload.slice(:store, :key))
       end

--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -55,7 +55,6 @@ module Honeybadger
 
           if config.load_plugin_insights?(:active_job)
             ::ActiveSupport::Notifications.subscribe(/(enqueue_at|enqueue|enqueue_retry|enqueue_all|perform|retry_stopped|discard)\.active_job/, Honeybadger::ActiveJobSubscriber.new)
-            ::ActiveSupport::Notifications.subscribe('perform.active_job', Honeybadger::ActiveJobMetricsSubscriber.new)
           end
         end
       end

--- a/lib/honeybadger/plugins/net_http.rb
+++ b/lib/honeybadger/plugins/net_http.rb
@@ -7,6 +7,12 @@ module Honeybadger
   module Plugins
     module Net
       module HTTP
+        @@hb_config = ::Honeybadger.config
+
+        def self.set_hb_config(config)
+          @@hb_config = config
+        end
+
         def request(request_data, body = nil, &block)
           return super unless started?
           return super if hb?
@@ -18,19 +24,26 @@ module Honeybadger
               status: response_data.code.to_i
             }.merge(parsed_uri_data(request_data))
 
-            Honeybadger.event('request.net_http', context)
+            if @@hb_config.load_plugin_insights_events?(:net_http)
+              Honeybadger.event('request.net_http', context)
+            end
+
+            if @@hb_config.load_plugin_insights_metrics?(:net_http)
+              context.delete(:url)
+              Honeybadger.gauge('duration.request', context.merge(metric_source: 'net_http'))
+            end
           end[1] # return the response data only
         end
 
         def hb?
-          address.to_s[/#{Honeybadger.config[:'connection.host'].to_s}/]
+          address.to_s[/#{@@hb_config[:'connection.host'].to_s}/]
         end
 
         def parsed_uri_data(request_data)
           uri = request_data.uri || build_uri(request_data)
           {}.tap do |uri_data|
             uri_data[:host] = uri.host
-            uri_data[:url] = uri.to_s if Honeybadger.config[:'net_http.insights.full_url']
+            uri_data[:url] = uri.to_s if @@hb_config[:'net_http.insights.full_url']
           end
         end
 
@@ -43,6 +56,7 @@ module Honeybadger
           requirement { config.load_plugin_insights?(:net_http) }
 
           execution do
+            Honeybadger::Plugins::Net::HTTP.set_hb_config(config)
             ::Net::HTTP.send(:prepend, Honeybadger::Plugins::Net::HTTP)
           end
         end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -38,10 +38,14 @@ module Honeybadger
             raise
           ensure
             context.merge!(duration: duration, status: status)
-            Honeybadger.event('perform.sidekiq', context)
+            if Honeybadger.config.load_plugin_insights_events?(:sidekiq)
+              Honeybadger.event('perform.sidekiq', context)
+            end
 
-            metric_source 'sidekiq'
-            histogram 'perform', { bins: [30, 60, 120, 300, 1800, 3600, 21_600] }.merge(context.slice(:worker, :queue, :duration))
+            if Honeybadger.config.load_plugin_insights_metrics?(:sidekiq)
+              metric_source 'sidekiq'
+              histogram 'perform', { bins: [30, 60, 120, 300, 1800, 3600, 21_600] }.merge(context.slice(:worker, :queue, :duration))
+            end
           end
         end
       end
@@ -55,7 +59,9 @@ module Honeybadger
             queue: queue
           }
 
-          Honeybadger.event('enqueue.sidekiq', context)
+          if Honeybadger.config.load_plugin_insights_events?(:sidekiq)
+            Honeybadger.event('enqueue.sidekiq', context)
+          end
 
           yield
         end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -44,7 +44,7 @@ module Honeybadger
 
             if Honeybadger.config.load_plugin_insights_metrics?(:sidekiq)
               metric_source 'sidekiq'
-              histogram 'perform', { bins: [30, 60, 120, 300, 1800, 3600, 21_600] }.merge(context.slice(:worker, :queue, :duration))
+              gauge 'perform', context.slice(:worker, :queue, :duration)
             end
           end
         end

--- a/spec/unit/honeybadger/gauge_spec.rb
+++ b/spec/unit/honeybadger/gauge_spec.rb
@@ -10,6 +10,6 @@ describe Honeybadger::Gauge do
 
     before { metric.record(1) }
 
-    it { should eq [{ avg: 1.0, latest: 1, max: 1, min: 1 }] }
+    it { should eq [{ total: 1, avg: 1.0, latest: 1, max: 1, min: 1 }] }
   end
 end

--- a/spec/unit/honeybadger/histogram_spec.rb
+++ b/spec/unit/honeybadger/histogram_spec.rb
@@ -13,6 +13,7 @@ describe Honeybadger::Histogram do
     it do
       should eq [
         {
+          total: 1,
           avg: 1.0,
           latest: 1,
           max: 1,

--- a/spec/unit/honeybadger/plugins/net_http_spec.rb
+++ b/spec/unit/honeybadger/plugins/net_http_spec.rb
@@ -6,10 +6,10 @@ describe "Net::HTTP integration" do
 
   before do
     Honeybadger::Plugin.instances[:net_http].reset!
+    Honeybadger::Plugin.instances[:net_http].load!(config)
   end
 
   it "includes integration module into Net::HTTP" do
-    Honeybadger::Plugin.instances[:net_http].load!(config)
     expect(Net::HTTP.ancestors).to include(Honeybadger::Plugins::Net::HTTP)
   end
 
@@ -19,15 +19,17 @@ describe "Net::HTTP integration" do
     context "report domain only" do
       it "contains a domain" do
         expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, host: "example.com"}))
+        expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
         Net::HTTP.get(URI.parse('http://example.com'))
       end
     end
 
     context "report domain and full url" do
-      before { ::Honeybadger.config[:'net_http.insights.full_url'] = true }
+      before { config[:'net_http.insights.full_url'] = true }
 
       it "contains a domain and url" do
         expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, url: "http://example.com", host: "example.com"}))
+        expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
         Net::HTTP.get(URI.parse('http://example.com'))
       end
     end

--- a/spec/unit/honeybadger/plugins/net_http_spec.rb
+++ b/spec/unit/honeybadger/plugins/net_http_spec.rb
@@ -19,7 +19,6 @@ describe "Net::HTTP integration" do
     context "report domain only" do
       it "contains a domain" do
         expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, host: "example.com"}))
-        expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
         Net::HTTP.get(URI.parse('http://example.com'))
       end
     end
@@ -29,8 +28,29 @@ describe "Net::HTTP integration" do
 
       it "contains a domain and url" do
         expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, url: "http://example.com", host: "example.com"}))
-        expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
         Net::HTTP.get(URI.parse('http://example.com'))
+      end
+    end
+
+    context "metrics collection enabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, :'insights.enabled' => true, :'net_http.insights.metrics' => true) }
+
+      context "report domain only" do
+        it "contains a domain" do
+          expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, host: "example.com"}))
+          expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
+          Net::HTTP.get(URI.parse('http://example.com'))
+        end
+      end
+
+      context "report domain and full url" do
+        before { config[:'net_http.insights.full_url'] = true }
+
+        it "contains a domain and url" do
+          expect(Honeybadger).to receive(:event).with('request.net_http', hash_including({method: "GET", status: 200, url: "http://example.com", host: "example.com"}))
+          expect(Honeybadger).to receive(:gauge).with('duration.request', hash_including({method: "GET", status: 200, host: "example.com"}))
+          Net::HTTP.get(URI.parse('http://example.com'))
+        end
       end
     end
   end

--- a/spec/unit/honeybadger/timer_spec.rb
+++ b/spec/unit/honeybadger/timer_spec.rb
@@ -10,6 +10,6 @@ describe Honeybadger::Timer do
 
     before { metric.record(1) }
 
-    it { should eq [{ avg: 1.0, latest: 1, max: 1, min: 1 }] }
+    it { should eq [{ total: 1, avg: 1.0, latest: 1, max: 1, min: 1 }] }
   end
 end


### PR DESCRIPTION
This adds aggregated metrics for the following plugins:

* rails
* net_http
* sidekiq

Similar to the Karafka plugin, there is now more configuration to fine tune the data:

* `rails.insights.events`
* `rails.insights.metrics`
* `sidekiq.insights.events`
* `sidekiq.insights.metrics`
* `net_http.insights.events`
* `net_http.insights.metrics`

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
