### PR TITLE
fix: pin rspec-its gem to 1.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'allocation_stats', platforms: :mri, require: false
 gem 'appraisal', '~> 2.1'
 gem 'aruba', '~> 2.0'
 gem 'rspec', '~> 3.0'
-gem 'rspec-its'
+gem "rspec-its", "~> 1.3.1"
 gem 'ruby-prof', platforms: :mri, require: false
 gem 'timecop'
 gem 'webmock'

--- a/gemfiles/binding_of_caller.gemfile
+++ b/gemfiles/binding_of_caller.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/hanami.gemfile
+++ b/gemfiles/hanami.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rack.gemfile
+++ b/gemfiles/rack.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rack_1.gemfile
+++ b/gemfiles/rack_1.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/rails8.gemfile
+++ b/gemfiles/rails8.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/resque.gemfile
+++ b/gemfiles/resque.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/sidekiq.gemfile
+++ b/gemfiles/sidekiq.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/sidekiq7.gemfile
+++ b/gemfiles/sidekiq7.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/gemfiles/standalone.gemfile
+++ b/gemfiles/standalone.gemfile
@@ -6,7 +6,7 @@ gem "allocation_stats", platforms: :mri, require: false
 gem "appraisal", "~> 2.1"
 gem "aruba", "~> 2.0"
 gem "rspec", "~> 3.0"
-gem "rspec-its"
+gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -1,4 +1,5 @@
 begin
+  require 'ostruct'
   require 'sidekiq'
   SIDEKIQ_PRESENT = true
 rescue LoadError


### PR DESCRIPTION
A recent change to rspec-its drops support for ruby 3 as well as using `public_send` for calling methods. We use this for testing private methods which is why some tests were failing.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
