### PR TITLE
feat: disable all workers in rails console

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -377,6 +377,16 @@ module Honeybadger
       true
     end
 
+    # Stops the Honeybadger Insights related services.
+    #
+    # @example
+    #   Honeybadger.stop_insights # => nil
+    def stop_insights(force = false)
+      events_worker&.shutdown(force)
+      metrics_worker&.shutdown(force)
+      true
+    end
+
     # Sends event to events backend
     #
     # @example

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -34,7 +34,10 @@ module Honeybadger
         end
 
         console do
-          Honeybadger::Agent.instance.config[:'insights.enabled'] = Honeybadger::Agent.instance.config[:'insights.console.enabled']
+          unless Honeybadger::Agent.instance.config[:'insights.enabled'] = Honeybadger::Agent.instance.config[:'insights.console.enabled']
+            Honeybadger::Agent.instance.config.logger.debug("Rails console detected, shutting down Honeybadger Insights workers.")
+            Honeybadger::Agent.instance.stop_insights
+          end
         end
       end
     end


### PR DESCRIPTION
As it turns out, the `console` callback is called after `after_initialize` config callback in the Railtie. This can still cause the metric worker to startup when it's not meant to. This change will shutdown the `MetricsWorker` and `EventWorker` when the Rails console is loaded.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
