### PR TITLE
feat: add event stats for sidekiq and sq

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -344,26 +344,6 @@ module Honeybadger
         default: true,
         type: Boolean
       },
-      :'sidekiq.insights.cluster_collection' => {
-        description: 'Collect cluster based metrics for Sidekiq.',
-        default: true,
-        type: Boolean
-      },
-      :'sidekiq.insights.collection_interval' => {
-        description: 'The frequency in which Sidekiq cluster metrics are sampled.',
-        default: 60,
-        type: Integer
-      },
-      :'solid_queue.insights.cluster_collection' => {
-        description: 'Collect cluster based metrics for SolidQueue.',
-        default: true,
-        type: Boolean
-      },
-      :'solid_queue.insights.collection_interval' => {
-        description: 'The frequency in which SolidQueue cluster metrics are sampled.',
-        default: 60,
-        type: Integer
-      },
       :'sidekiq.insights.enabled' => {
         description: 'Enable automatic data collection for Sidekiq.',
         default: true,
@@ -378,6 +358,41 @@ module Honeybadger
         description: 'Enable automatic metric data collection for Sidekiq.',
         default: false,
         type: Boolean
+      },
+      :'sidekiq.insights.cluster_collection' => {
+        description: 'Collect cluster based metrics for Sidekiq.',
+        default: true,
+        type: Boolean
+      },
+      :'sidekiq.insights.collection_interval' => {
+        description: 'The frequency in which Sidekiq cluster metrics are sampled.',
+        default: 5,
+        type: Integer
+      },
+      :'solid_queue.insights.enabled' => {
+        description: 'Enable automatic data collection for SolidQueue.',
+        default: true,
+        type: Boolean
+      },
+      :'solid_queue.insights.events' => {
+        description: 'Enable automatic event capturing for SolidQueue.',
+        default: true,
+        type: Boolean
+      },
+      :'solid_queue.insights.metrics' => {
+        description: 'Enable automatic metric data collection for SolidQueue.',
+        default: false,
+        type: Boolean
+      },
+      :'solid_queue.insights.cluster_collection' => {
+        description: 'Collect cluster based metrics for SolidQueue.',
+        default: true,
+        type: Boolean
+      },
+      :'solid_queue.insights.collection_interval' => {
+        description: 'The frequency in which SolidQueue cluster metrics are sampled.',
+        default: 5,
+        type: Integer
       },
       :'rails.insights.enabled' => {
         description: 'Enable automatic data collection for Ruby on Rails.',

--- a/lib/honeybadger/plugins/solid_queue.rb
+++ b/lib/honeybadger/plugins/solid_queue.rb
@@ -4,20 +4,46 @@ module Honeybadger
       Plugin.register :solid_queue do
         requirement { config.load_plugin_insights?(:solid_queue) && defined?(::SolidQueue) }
 
+        collect_solid_queue_stats = -> do
+          data = {}
+          data[:stats] = {
+            jobs_in_progress: ::SolidQueue::ClaimedExecution.count,
+            jobs_blocked: ::SolidQueue::BlockedExecution.count,
+            jobs_failed: ::SolidQueue::FailedExecution.count,
+            jobs_scheduled: ::SolidQueue::ScheduledExecution.count,
+            jobs_processed: ::SolidQueue::Job.where.not(finished_at: nil).count,
+            active_workers: ::SolidQueue::Process.where(kind: "Worker").count,
+            active_dispatchers: ::SolidQueue::Process.where(kind: "Dispatcher").count
+          }
+
+          data[:queues] = {}
+
+          ::SolidQueue::Queue.all.each do |queue|
+            data[:queues][queue.name] = { depth: queue.size }
+          end
+
+          data
+        end
+
         collect do
+          stats = collect_solid_queue_stats.call
+
           if config.cluster_collection?(:solid_queue)
-            metric_source 'solid_queue'
+            if Honeybadger.config.load_plugin_insights_events?(:solid_queue)
+              Honeybadger.event('stats.solid_queue', stats.except(:stats).merge(stats[:stats]))
+            end
 
-            gauge 'jobs_in_progress', ->{ ::SolidQueue::ClaimedExecution.count }
-            gauge 'jobs_blocked', ->{ ::SolidQueue::BlockedExecution.count }
-            gauge 'jobs_failed', ->{ ::SolidQueue::FailedExecution.count }
-            gauge 'jobs_scheduled', ->{ ::SolidQueue::ScheduledExecution.count }
-            gauge 'jobs_processed', ->{ ::SolidQueue::Job.where.not(finished_at: nil).count }
-            gauge 'active_workers', ->{ ::SolidQueue::Process.where(kind: "Worker").count }
-            gauge 'active_dispatchers', ->{ ::SolidQueue::Process.where(kind: "Dispatcher").count }
+            if Honeybadger.config.load_plugin_insights_metrics?(:solid_queue)
+              metric_source 'solid_queue'
+              stats[:stats].each do |stat_name, value|
+                gauge stat_name, value: value
+              end
 
-            ::SolidQueue::Queue.all.each do |queue|
-              gauge 'queue_depth', { queue: queue.name }, ->{ queue.size }
+              stats[:queues].each do |queue_name, data|
+                data.each do |key, value|
+                  gauge "queue_#{key}", queue: queue_name, value: value
+                end
+              end
             end
           end
         end

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -197,6 +197,9 @@ describe "Sidekiq Dependency" do
           def enqueued; end
           def dead_size; end
           def retry_size; end
+          def as_json
+            {}
+          end
         end
       end
 


### PR DESCRIPTION
Similar to Karafka's stats event, this adds the collected cluster based stats as a wide event for Sidekiq and SolidQueue. The previous aggregated metrics can be toggled on, while the new events can be toggled off.

```
# Turn off all events for Sidekiq and SolidQueue
sidekiq:
  insights:
    events: false
solid_queue:
  insights:
    events: false

# Turn on all aggregated metrics for Sidekiq and SolidQueue
sidekiq:
  insights:
    metrics: true
solid_queue:
  insights:
    metrics: true
```

In addition, the polling interval has been decreased to 5 seconds to allow for up to date readings.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
