### PR TITLE
fix: cli test for rails 8

### DIFF
--- a/lib/honeybadger/cli/test.rb
+++ b/lib/honeybadger/cli/test.rb
@@ -142,6 +142,7 @@ module Honeybadger
         end
         CONTROLLER
 
+        ::Rails.application.try(:reload_routes_unless_loaded)
         ::Rails.application.routes.tap do |r|
           # RouteSet#disable_clear_and_finalize prevents existing routes from
           # being cleared. We'll set it back to the original value when we're


### PR DESCRIPTION
In Rails 8, [route drawing is deferred](https://github.com/rails/rails/commit/cdb283566c5d5251e2f7e663e655e57e8e10abbc#diff-84292fcaae327f1a70e7c3b1ebb55b193dea016c1118a8566930bc5cd2a51ba5R157). It seems the easiest fix is to explicitly reload the routes manually.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
