### PR TITLE
feat: only allow for insights to be enabled when public

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -289,7 +289,7 @@ module Honeybadger
     end
 
     def insights_enabled?
-      !!self[:'insights.enabled']
+      public? && !!self[:'insights.enabled']
     end
 
     def cluster_collection?(name)


### PR DESCRIPTION
This means that the gem must be able to report data as well requiring the environment to not be a `development_environment`. This should prevent any unexpected Insights related code to run in dev or test environments.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
