### PR TITLE
feat: update puma and autotuner plugins

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -491,6 +491,31 @@ module Honeybadger
         description: "Number of seconds between registry flushes.",
         default: 60,
         type: Integer
+      },
+      :'puma.insights.events' => {
+        description: 'Enable automatic event capturing for Puma stats.',
+        default: true,
+        type: Boolean
+      },
+      :'puma.insights.metrics' => {
+        description: 'Enable automatic metric data aggregation for Puma stats.',
+        default: false,
+        type: Boolean
+      },
+      :'puma.insights.collection_interval' => {
+        description: 'The frequency in which the Honeybadger gem will collect Puma stats.',
+        default: 1,
+        type: Integer
+      },
+      :'autotuner.insights.events' => {
+        description: 'Enable automatic event capturing for Autotuner stats.',
+        default: true,
+        type: Boolean
+      },
+      :'autotuner.insights.metrics' => {
+        description: 'Enable automatic metric data aggregation for Autotuner stats.',
+        default: false,
+        type: Boolean
       }
     }.freeze
 

--- a/lib/honeybadger/plugins/autotuner.rb
+++ b/lib/honeybadger/plugins/autotuner.rb
@@ -10,17 +10,20 @@ module Honeybadger
         execution do
           singleton_class.include(Honeybadger::InstrumentationHelper)
 
-          ::Autotuner.enabled = true
-
           ::Autotuner.reporter = proc do |report|
             Honeybadger.event("report.autotuner", report: report.to_s)
           end
 
-          metric_source 'autotuner'
-
           ::Autotuner.metrics_reporter = proc do |metrics|
-            metrics.each do |key, val|
-              gauge key, ->{ val }
+            if config.load_plugin_insights_events?(:autotuner)
+              Honeybadger.event('stats.autotuner', metrics)
+            end
+
+            if config.load_plugin_insights_metrics?(:autotuner)
+              metric_source 'autotuner'
+              metrics.each do |key, val|
+                gauge key, ->{ val }
+              end
             end
           end
         end

--- a/lib/puma/plugin/honeybadger.rb
+++ b/lib/puma/plugin/honeybadger.rb
@@ -12,7 +12,7 @@ module Honeybadger
         in_background do
           loop do
             puma_plugin.record
-            sleep 1
+            sleep [::Honeybadger.config.collection_interval(:puma).to_i, 1].max
           end
         end
       end
@@ -35,8 +35,14 @@ module Honeybadger
     end
 
     def record_puma_stats(stats, context={})
-      STATS_KEYS.each do |stat|
-        gauge stat, context, ->{ stats[stat] } if stats[stat]
+      if Honeybadger.config.load_plugin_insights_events?(:puma)
+        Honeybadger.event('stats.puma', context.merge(stats))
+      end
+
+      if Honeybadger.config.load_plugin_insights_metrics?(:puma)
+        STATS_KEYS.each do |stat|
+          gauge stat, context, ->{ stats[stat] } if stats[stat]
+        end
       end
     end
   end


### PR DESCRIPTION
This allows the Puma and Autotuner to emit an event for stats, or alternavitely aggregate the stats to save on data.

Disable stats events for Puma and Autotuner:
```
puma:
  insights:
    events: false
autotuner:
  insights:
    events: false
```

Note: The Autotuner plugin will still event the `report.autotuner` event regardless of the above setting.

Enable aggregated metics for Puma and Autotuner.
```
puma:
  insights:
    metrics: true
autotuner:
  insights:
    metrics: true
```

In addition, you can now customer the frequency that the Puma plugin will record the stats. The default is every 1 second.
```
puma:
  insights:
    collection_interval: 1
```

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
