### PR TITLE
feat: skip middleware, plugins, and exception reporting when exceptions are disabled

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -125,6 +125,11 @@ module Honeybadger
     # @return [String] UUID reference to the notice within Honeybadger.
     # @return [false] when ignored.
     def notify(exception_or_opts = nil, opts = {}, **kwargs)
+      if !config[:'notices.enabled']
+        debug { 'disabled feature=notices' }
+        return false
+      end
+
       opts = opts.dup
       opts.merge!(kwargs)
 

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -125,7 +125,7 @@ module Honeybadger
     # @return [String] UUID reference to the notice within Honeybadger.
     # @return [false] when ignored.
     def notify(exception_or_opts = nil, opts = {}, **kwargs)
-      if !config[:'notices.enabled']
+      if !config[:'exceptions.enabled']
         debug { 'disabled feature=notices' }
         return false
       end

--- a/lib/honeybadger/init/hanami.rb
+++ b/lib/honeybadger/init/hanami.rb
@@ -8,7 +8,7 @@ Honeybadger.init!({
 
 Honeybadger.load_plugins!
 
-if Hanami::VERSION >= '2.0'
+if Hanami::VERSION >= '2.0' && Honeybadger.config[:'exceptions.enabled']
   Hanami.app.instance_eval do
     config.middleware.use Honeybadger::Rack::UserFeedback
     config.middleware.use Honeybadger::Rack::UserInformer

--- a/lib/honeybadger/init/rails.rb
+++ b/lib/honeybadger/init/rails.rb
@@ -14,9 +14,11 @@ module Honeybadger
         initializer 'honeybadger.install_middleware' do |app|
           honeybadger_config = Honeybadger::Agent.instance.config
 
-          app.config.middleware.insert(0, Honeybadger::Rack::ErrorNotifier)
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer) if honeybadger_config[:'user_informer.enabled']
-          app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback) if honeybadger_config[:'feedback.enabled']
+          if honeybadger_config[:'exceptions.enabled']
+            app.config.middleware.insert(0, Honeybadger::Rack::ErrorNotifier)
+            app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserInformer) if honeybadger_config[:'user_informer.enabled']
+            app.config.middleware.insert_before(Honeybadger::Rack::ErrorNotifier, Honeybadger::Rack::UserFeedback) if honeybadger_config[:'feedback.enabled']
+          end
         end
 
         config.before_initialize do

--- a/lib/honeybadger/plugins/active_job.rb
+++ b/lib/honeybadger/plugins/active_job.rb
@@ -51,7 +51,7 @@ module Honeybadger
         end
 
         execution do
-          ::ActiveJob::Base.set_callback(:perform, :around, &ActiveJob.method(:perform_around))
+          ::ActiveJob::Base.set_callback(:perform, :around, &ActiveJob.method(:perform_around)) if Honeybadger.config[:'exceptions.enabled']
 
           if config.load_plugin_insights?(:active_job)
             ::ActiveSupport::Notifications.subscribe(/(enqueue_at|enqueue|enqueue_retry|enqueue_all|perform|retry_stopped|discard)\.active_job/, Honeybadger::ActiveJobSubscriber.new)

--- a/lib/honeybadger/plugins/delayed_job.rb
+++ b/lib/honeybadger/plugins/delayed_job.rb
@@ -15,6 +15,7 @@ module Honeybadger
     end
 
     execution do
+      return unless Honeybadger.config[:'exceptions.enabled']
       require 'honeybadger/plugins/delayed_job/plugin'
       ::Delayed::Worker.plugins << Plugins::DelayedJob::Plugin
     end

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -15,6 +15,7 @@ module Honeybadger
         requirement { defined?(::Faktory) }
 
         execution do
+          return unless Honeybadger.config[:'exceptions.enabled']
           ::Faktory.configure_worker do |faktory|
             faktory.worker_middleware do |chain|
               chain.prepend Middleware

--- a/lib/honeybadger/plugins/karafka.rb
+++ b/lib/honeybadger/plugins/karafka.rb
@@ -8,9 +8,11 @@ module Honeybadger
       execution do
         require 'honeybadger/karafka'
 
-        errors_listener = ::Honeybadger::Karafka::ErrorsListener.new
-        ::Karafka.monitor.subscribe(errors_listener)
-        ::Karafka.producer.monitor.subscribe(errors_listener) if ::Karafka.respond_to?(:producer)
+        if Honeybadger.config[:'exceptions.enabled']
+          errors_listener = ::Honeybadger::Karafka::ErrorsListener.new
+          ::Karafka.monitor.subscribe(errors_listener)
+          ::Karafka.producer.monitor.subscribe(errors_listener) if ::Karafka.respond_to?(:producer)
+        end
 
         if config.load_plugin_insights?(:karafka)
           ::Karafka.monitor.subscribe(::Honeybadger::Karafka::InsightsListener.new)

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -64,7 +64,7 @@ module Honeybadger
             ::ActionDispatch::ShowExceptions.prepend(ExceptionsCatcher)
           end
 
-          if defined?(::ActiveSupport::ErrorReporter) # Rails 7
+          if Honeybadger.config[:'exceptions.enabled'] && defined?(::ActiveSupport::ErrorReporter) # Rails 7
             ::Rails.error.subscribe(ErrorSubscriber)
           end
         end

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -64,6 +64,7 @@ module Honeybadger
         end
 
         execution do
+          return unless Honeybadger.config[:'exceptions.enabled']
           ::Resque::Job.send(:include, Installer)
         end
       end

--- a/lib/honeybadger/plugins/shoryuken.rb
+++ b/lib/honeybadger/plugins/shoryuken.rb
@@ -40,6 +40,7 @@ module Honeybadger
         requirement { defined?(::Shoryuken) }
 
         execution do
+          return unless Honeybadger.config[:'exceptions.enabled']
           ::Shoryuken.configure_server do |config|
             config.server_middleware do |chain|
               chain.add Middleware

--- a/lib/honeybadger/plugins/sucker_punch.rb
+++ b/lib/honeybadger/plugins/sucker_punch.rb
@@ -6,6 +6,7 @@ module Honeybadger
     requirement { defined?(::SuckerPunch) }
 
     execution do
+      return unless Honeybadger.config[:'exceptions.enabled']
       if SuckerPunch.respond_to?(:exception_handler=) # >= v2
         SuckerPunch.exception_handler = ->(ex, klass, args) { Honeybadger.notify(ex, { :component => klass, :parameters => args }) }
       else

--- a/lib/honeybadger/plugins/thor.rb
+++ b/lib/honeybadger/plugins/thor.rb
@@ -25,6 +25,7 @@ module Honeybadger
       requirement { defined?(::Thor.no_commands) }
 
       execution do
+        return unless Honeybadger.config[:'exceptions.enabled']
         ::Thor.send(:include, Thor)
       end
     end


### PR DESCRIPTION
This PR makes the `exceptions.enabled` configuration option work a little better by doing the following:

* Skip loading ErrorNotifier and associated middleware
* Skip hooking into Sidekiq, etc. to report exceptions
* Abort sending any notifications when calling `Honeybadger.notify`