### PR TITLE
feat: set context during rails error report

### DIFF
--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -32,6 +32,8 @@ module Honeybadger
 
       class ErrorSubscriber
         def self.report(exception, handled:, severity:, context: {}, source: nil)
+          Honeybadger.context(context)
+
           # We only report handled errors (`Rails.error.handle`)
           # Unhandled errors will be caught by our integrations (eg middleware),
           # which have richer context than the Rails error reporter
@@ -41,7 +43,7 @@ module Honeybadger
 
           tags = ["severity:#{severity}", "handled:#{handled}"]
           tags << "source:#{source}" if source
-          Honeybadger.notify(exception, context: context, tags: tags)
+          Honeybadger.notify(exception, tags: tags)
         end
 
         def self.source_ignored?(source)


### PR DESCRIPTION
This will always set the context from Rails when an error is reported even if it is not handled. This will allow applications to use `Rails.error.set_context` instead of `Honeybadger.context` and still see that context in errors in the UI.

It would have been nice if Rails provided an event for when `set_context` is called so that we can hook into that, but this should be ok for now.

Closes: https://github.com/honeybadger-io/honeybadger-ruby/issues/648

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
