### PR TITLE
chore: set ostruct as a gem dependency

### DIFF
--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |s|
   s.executables << 'honeybadger'
 
   s.add_dependency 'logger'
+  s.add_dependency 'ostruct'
 end


### PR DESCRIPTION
In Ruby 3.4, requiring ostruct without pulling it in as a gem brings up a deprecation warning. Ostruct is used in the cli and sidekiq load check.

```
$ bin/bundle exec honeybadger deploy --environment=production --revision=... --repository=git@github.com:.../....git'
/home/user/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/honeybadger-5.26.1/lib/honeybadger/cli/exec.rb:8: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

Added ostruct as a runtime dependency of the gem which should appease the warning.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
