### PR TITLE
fix: ensure instrumentation durations are unique during threaded executions

### DIFF
--- a/lib/honeybadger/backend/test.rb
+++ b/lib/honeybadger/backend/test.rb
@@ -42,13 +42,17 @@ module Honeybadger
         self.class.check_ins
       end
 
+      def events
+        self.class.events
+      end
+
       def notify(feature, payload)
         notifications[feature] << payload
         super
       end
 
       def event(payload)
-        events << payload
+        events.concat(payload.dup)
         super
       end
 

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -6,17 +6,16 @@ module Honeybadger
     include Honeybadger::InstrumentationHelper
 
     def start(name, id, payload)
-      @start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      payload[:_start_time] = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
     end
 
     def finish(name, id, payload)
-      @finish_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-
+      finish_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       return unless process?(name, payload)
 
       payload = {
         instrumenter_id: id,
-        duration: ((@finish_time - @start_time) * 1000).round(2)
+        duration: ((finish_time - payload.delete(:_start_time)) * 1000).round(2)
       }.merge(format_payload(payload).compact)
 
       record(name, payload)

--- a/spec/integration/rails/notification_subscriber_spec.rb
+++ b/spec/integration/rails/notification_subscriber_spec.rb
@@ -1,0 +1,73 @@
+require_relative "../rails_helper"
+require "honeybadger/notification_subscriber"
+
+class TestSubscriber < Honeybadger::NotificationSubscriber; end
+
+describe "Rails Insights Notification Subscribers", if: RAILS_PRESENT, type: :request do
+  load_rails_hooks(self)
+
+  before do
+    Honeybadger::Backend::Test.events.clear
+  end
+
+  it "records correct durations for concurrent notifications" do
+    Honeybadger.config[:"insights.enabled"] = true
+    Honeybadger.config[:"events.batch_size"] = 0
+
+    mutex, sequence = Mutex.new, 1
+    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+      if caller_locations.any? { |loc| loc.base_label == "finish" }
+        10
+      else
+        mutex.synchronize { sequence += 1 }
+      end
+    end
+
+    ActiveSupport::Notifications.subscribe("test.timing", TestSubscriber.new)
+
+    # Create multiple threads that will fire notifications
+    threads = 5.times.map do
+      Thread.new do
+        ActiveSupport::Notifications.instrument("test.timing") do
+          sleep(0.1)
+        end
+      end
+    end
+
+    threads.each(&:join)
+    sleep(0.2)
+
+    expect(Honeybadger::Backend::Test.events.map { |e| e[:duration] }.uniq.length).to eq(5)
+  end
+
+  it "records correct durations with regex subscription" do
+    Honeybadger.config[:"insights.enabled"] = true
+    Honeybadger.config[:"events.batch_size"] = 0
+
+    sequence = 1
+    allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC) do
+      if caller_locations.any? { |loc| loc.base_label == "finish" }
+        10
+      else
+        sequence += 1
+      end
+    end
+
+    # Subscribe to multiple notification types with a regex
+    ActiveSupport::Notifications.subscribe(/^test\.(foo|bar|baz)/, TestSubscriber.new)
+
+    # Send different types of notifications sequentially
+    %w[test.foo test.bar test.baz].each do |notification_type|
+      ActiveSupport::Notifications.instrument(notification_type) do
+        sleep(0.1)
+      end
+    end
+
+    events = Honeybadger::Backend::Test.events
+    sleep(0.2)
+
+    expect(events.size).to eq(3)
+    expect(events.map { |e| e[:event_type] }.sort).to eq(%w[test.foo test.bar test.baz].sort)
+    expect(events.map { |e| e[:duration] }.uniq.size).to eq(3)
+  end
+end


### PR DESCRIPTION
We noticed some inconsistencies in the timing of some of our Insights events, so I ran some tests and was able to hackily replicate with multiple concurrent requests.

What I believe is happening is the `Honeybadger::NotificationSubscriber` is shared between all threads of the web server, and since we were using an instance variable to set the start time, if `start` is called multiple times without a called `finish`, we override the time. 

This was a bear to test without getting really nasty. I opted to get sorta nasty and stub `Process.clock_gettime` to return an incrementing number only when called during the `start` method. This test is very brittle since it relies on caller stack. For concurrent executions, this would be overridden and the final durations would have duplicates. __Please__ let me know if you have a better way to test this.

For the fix, I stored the start time in the payload, as that should be unique to each instrumentation dispatch.