### PR TITLE
chore: bump ubuntu runner

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,7 +71,7 @@ jobs:
         bundle exec rake
 
   jruby:
-    runs-on: ubuntu-20.04 # ubuntu-latest is currently 22.04, which doesn't have a supported JRuby 9 build yet
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     strategy:
       matrix:


### PR DESCRIPTION
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025.