### PR TITLE
fix: ignore transactions with the immediate keyword

### DIFF
--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -27,7 +27,7 @@ module Honeybadger
             exclude_when: lambda do |data|
               # Ignore schema, begin, and commit transaction queries
               data[:name] == "SCHEMA" ||
-                (data[:sql] && (Util::SQL.force_utf_8(data[:sql].dup) =~ /^(begin|commit)( transaction)?$/i))
+                (data[:sql] && (Util::SQL.force_utf_8(data[:sql].dup) =~ /^(begin|commit)( immediate)?( transaction)?$/i))
             end
           },
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -32,8 +32,8 @@ module Honeybadger
                       'Sidekiq::JobRetry::Skip'].map(&:freeze).freeze
 
     IGNORE_EVENTS_DEFAULT = [
-      { event_type: 'metric.hb', metric_name: 'duration.sql.active_record', query: /^(begin|commit)( transaction)?$/i },
-      { event_type: 'sql.active_record', query: /^(begin|commit)( transaction)?$/i },
+      { event_type: 'metric.hb', metric_name: 'duration.sql.active_record', query: /^(begin|commit)( immediate)?( transaction)?$/i },
+      { event_type: 'sql.active_record', query: /^(begin|commit)( immediate)?( transaction)?$/i },
       { event_type: 'sql.active_record', query: /(solid_queue|good_job)/i },
       { event_type: 'sql.active_record', name: /^GoodJob/ },
       { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' }


### PR DESCRIPTION
Apparently "immediate" is sometimes a thing. :)