### PR TITLE
docs: shorten the gem summary

### DIFF
--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name        = 'honeybadger'
   s.version     = Honeybadger::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.summary     = 'The official honeybadger.io gem for full-stack error tracking, performance and uptime monitoring, and logging.'
+  s.summary     = 'Full-stack error tracking, performance monitoring, logging, and more.'
   s.description = 'Honeybadger.io unifies error tracking, performance and uptime monitoring, and logging in one powerfully simple platform. Detect, diagnose, and resolve production issues faster—so you can focus on building, not debugging.'
   s.authors     = ['Honeybadger Industries LLC']
   s.email       = ['support@honeybadger.io']


### PR DESCRIPTION
RubyGems is truncating the new gem summary in search results. This will look better:

![CleanShot 2025-04-30 at 11 02 30@2x](https://github.com/user-attachments/assets/78e3dcba-28cc-4a66-9cef-941688f753c3)

Release-As: 5.27.4