### PR TITLE
feat: add sampling

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'zlib'
 
 require 'honeybadger/version'
 require 'honeybadger/config'
@@ -434,6 +435,10 @@ module Honeybadger
 
       return if event.halted?
 
+      return unless sample_event?(event)
+
+      strip_metadata(event)
+
       events_worker.push(event.as_json)
     end
 
@@ -569,6 +574,23 @@ module Honeybadger
     end
 
     private
+
+    def strip_metadata(event)
+      event.delete(:_hb)
+    end
+
+    def sample_event?(event)
+      sample_rate = config[:'insights.sample_rate']
+      sample_rate = event.dig(:_hb, :sample_rate) if event.dig(:_hb, :sample_rate).is_a?(Numeric)
+
+      return true if sample_rate >= 100
+
+      if event[:request_id] # Send all events for a given request
+        Zlib.crc32(event[:request_id].to_s) % 100 < sample_rate
+      else # Otherwise just take a random sample
+        rand(100) < sample_rate
+      end
+    end
 
     def validate_notify_opts!(opts)
       return if opts.has_key?(:exception)

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -580,6 +580,9 @@ module Honeybadger
     end
 
     def sample_event?(event)
+      # Always send metrics events
+      return true if event[:event_type] == "metric.hb"
+      
       sample_rate = config[:'insights.sample_rate']
       sample_rate = event.dig(:_hb, :sample_rate) if event.dig(:_hb, :sample_rate).is_a?(Numeric)
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -482,6 +482,11 @@ module Honeybadger
         default: false,
         type: Boolean
       },
+      :'insights.sample_rate' => {
+        description: 'Percentage of events to send to the API (0-100). A value of 0 means no events are sent, 100 means all events are sent.',
+        default: 100,
+        type: Integer
+      },
       :'insights.console.enabled' => {
         description: "Enable/Disable Honeybadger Insights built-in instrumentation in a Rails console.",
         default: false,

--- a/lib/honeybadger/event.rb
+++ b/lib/honeybadger/event.rb
@@ -15,7 +15,7 @@ module Honeybadger
     # The payload data of the event
     attr_reader :payload
 
-    def_delegators :payload, :dig, :[], :[]=
+    def_delegators :payload, :dig, :[], :[]=, :delete
 
     # @api private
     def initialize(event_type_or_payload, payload={})

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -438,6 +438,21 @@ describe Honeybadger::Agent do
           subject.event(payload.merge(event_type: event_type))
         end
       end
+
+      context "with metric events" do
+        let(:sample_rate) { 0 } # Global sample rate is 0 (no events)
+        let(:event_type) { "metric.hb" }
+        let(:payload) { { metric_name: "test.metric", value: 42 } }
+
+        it "always sends metric events regardless of sample rate" do
+          expect(events_worker).to receive(:push) do |msg|
+            expect(msg[:event_type]).to eq("metric.hb")
+            expect(msg[:metric_name]).to eq("test.metric")
+            expect(msg[:value]).to eq(42)
+          end
+          subject.event(payload.merge(event_type: event_type))
+        end
+      end
     end
 
     describe "ignoring events using events.ignore config" do


### PR DESCRIPTION
Give users a configuration option (`insights.sample_rate`) to specify what percentage of events will be sent to the API. The configuration option can be overridden with some event metadata (`{_hb: {sample_rate: 100}}`), which allows the user to specify that an event should always be sent, regardless of the default sampling. That metadata will be removed from the event payload before it is sent to the API. All metrics events will be sent to the API, regardless of the `sample_rate` setting.