### PR TITLE
fix: rename sample rate config option

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -582,8 +582,8 @@ module Honeybadger
     def sample_event?(event)
       # Always send metrics events
       return true if event[:event_type] == "metric.hb"
-      
-      sample_rate = config[:'insights.sample_rate']
+
+      sample_rate = config[:'events.sample_rate']
       sample_rate = event.dig(:_hb, :sample_rate) if event.dig(:_hb, :sample_rate).is_a?(Numeric)
 
       return true if sample_rate >= 100

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -129,6 +129,11 @@ module Honeybadger
         default: nil,
         type: Array
       },
+      :'events.sample_rate' => {
+        description: 'Percentage of events to send to the API (0-100). A value of 0 means no events are sent, 100 means all events are sent.',
+        default: 100,
+        type: Integer
+      },
       plugins: {
         description: 'An optional list of plugins to load. Default is to load all plugins.',
         default: nil,
@@ -481,11 +486,6 @@ module Honeybadger
         description: "Enable/Disable Honeybadger Insights built-in instrumentation.",
         default: false,
         type: Boolean
-      },
-      :'insights.sample_rate' => {
-        description: 'Percentage of events to send to the API (0-100). A value of 0 means no events are sent, 100 means all events are sent.',
-        default: 100,
-        type: Integer
       },
       :'insights.console.enabled' => {
         description: "Enable/Disable Honeybadger Insights built-in instrumentation in a Rails console.",

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -348,8 +348,8 @@ describe Honeybadger::Agent do
       end
     end
 
-    describe "sampling events using insights.sample_rate config" do
-      let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER, backend: :debug, :'insights.sample_rate' => sample_rate) }
+    describe "sampling events using events.sample_rate config" do
+      let(:config) { Honeybadger::Config.new(api_key:'fake api key', logger: NULL_LOGGER, backend: :debug, :'events.sample_rate' => sample_rate) }
       let(:payload) { { some_data: "is here" } }
       let(:event_type) { "test_event" }
 


### PR DESCRIPTION
This is more in line with the other `events.*` options.
