### PR TITLE
fix: avoid database connections during asset precompilation

### DIFF
--- a/lib/honeybadger/plugins/solid_queue.rb
+++ b/lib/honeybadger/plugins/solid_queue.rb
@@ -3,6 +3,8 @@ module Honeybadger
     module SolidQueue
       Plugin.register :solid_queue do
         requirement { config.load_plugin_insights?(:solid_queue) && defined?(::SolidQueue) }
+        requirement { !defined?(Rake) || !Rake.application.top_level_tasks.include?('assets:precompile') }
+        requirement { defined?(ActiveRecord::Base) && ActiveRecord::Base.connected? }
 
         collect_solid_queue_stats = -> do
           data = {}

--- a/lib/honeybadger/plugins/solid_queue.rb
+++ b/lib/honeybadger/plugins/solid_queue.rb
@@ -3,7 +3,6 @@ module Honeybadger
     module SolidQueue
       Plugin.register :solid_queue do
         requirement { config.load_plugin_insights?(:solid_queue) && defined?(::SolidQueue) }
-        requirement { !defined?(Rake) || !Rake.application.top_level_tasks.include?('assets:precompile') }
         requirement { defined?(ActiveRecord::Base) && ActiveRecord::Base.connected? }
 
         collect_solid_queue_stats = -> do
@@ -28,9 +27,9 @@ module Honeybadger
         end
 
         collect do
-          stats = collect_solid_queue_stats.call
-
           if config.cluster_collection?(:solid_queue)
+            stats = collect_solid_queue_stats.call
+
             if Honeybadger.config.load_plugin_insights_events?(:solid_queue)
               Honeybadger.event('stats.solid_queue', stats.except(:stats).merge(stats[:stats]))
             end


### PR DESCRIPTION
Also, ensure the database is connected before loading the SolidQueue plugin.

Fixes #694