### PR TITLE
feat: exclude insights from rake tasks config

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -295,8 +295,12 @@ module Honeybadger
     end
 
     def insights_exclude_for_rake_tasks?
-      return unless defined?(Rake)
-      (Rake.application.top_level_tasks & self[:'insights.exclude_rake_tasks']).any?
+      return false unless defined?(Rake) && Rake.application&.top_level_tasks
+
+      current_tasks = Array(Rake.application.top_level_tasks)
+      excluded_tasks = Array(self[:'insights.exclude_rake_tasks'])
+
+      (current_tasks & excluded_tasks).any?
     end
 
     def cluster_collection?(name)

--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -289,7 +289,14 @@ module Honeybadger
     end
 
     def insights_enabled?
-      public? && !!self[:'insights.enabled']
+      return false unless public?
+      return false if insights_exclude_for_rake_tasks?
+      !!self[:'insights.enabled']
+    end
+
+    def insights_exclude_for_rake_tasks?
+      return unless defined?(Rake)
+      (Rake.application.top_level_tasks & self[:'insights.exclude_rake_tasks']).any?
     end
 
     def cluster_collection?(name)

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -497,6 +497,11 @@ module Honeybadger
         default: 60,
         type: Integer
       },
+      :'insights.exclude_rake_tasks' => {
+        description: "List of Rake tasks to exclude from Insights instrumentation.",
+        default: ['assets:precompile'],
+        type: Array
+      },
       :'puma.insights.events' => {
         description: 'Enable automatic event capturing for Puma stats.',
         default: true,


### PR DESCRIPTION
This introduces a new configuration option `insights.exclude_rake_tasks`. By default this includes the `assets:precompile` rake task commonly executed in Rails. This can be overridden to include other tasks when needed.

Closes: https://github.com/honeybadger-io/honeybadger-ruby/issues/694

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
