### PR TITLE
chore: deal with ruby-head/bundler problems in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: head
-          bundler-cache: true
+          bundler-cache: false
 
       - name: Publish gem
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
The [release workflow failed](https://github.com/honeybadger-io/honeybadger-ruby/actions/runs/15972581736) due to an incompatibility between ruby-head and bundler. Avoiding bundling in the ruby-setup step should do the trick.

I ran into the same issue with #699.