### PR TITLE
fix: use kwargs for .notify in plugins

### DIFF
--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -43,7 +43,7 @@ module Honeybadger
                 opts[:action] = "perform"
               end
 
-              Honeybadger.notify(ex, opts)
+              Honeybadger.notify(ex, **opts)
             end
           end
         end

--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -126,7 +126,7 @@ module Honeybadger
                     opts[:action] = "perform" if opts[:component]
                   end
 
-                  Honeybadger.notify(ex, opts)
+                  Honeybadger.notify(ex, **opts)
                 }
               end
             end

--- a/lib/honeybadger/plugins/sucker_punch.rb
+++ b/lib/honeybadger/plugins/sucker_punch.rb
@@ -8,7 +8,7 @@ module Honeybadger
     execution do
       return unless Honeybadger.config[:"exceptions.enabled"]
       if SuckerPunch.respond_to?(:exception_handler=) # >= v2
-        SuckerPunch.exception_handler = ->(ex, klass, args) { Honeybadger.notify(ex, {component: klass, parameters: args}) }
+        SuckerPunch.exception_handler = ->(ex, klass, args) { Honeybadger.notify(ex, component: klass, parameters: args) }
       else
         SuckerPunch.exception_handler do |ex, klass, args|
           Honeybadger.notify(ex, {component: klass, parameters: args})

--- a/spec/unit/honeybadger/plugins/faktory_spec.rb
+++ b/spec/unit/honeybadger/plugins/faktory_spec.rb
@@ -49,7 +49,7 @@ describe "Faktory Dependency" do
         let(:handler_context) { {context: "Failed Hard", event: {}} }
 
         it "notifies Honeybadger" do
-          expect(Honeybadger).to receive(:notify).with(exception, {parameters: handler_context}).once
+          expect(Honeybadger).to receive(:notify).with(exception, parameters: handler_context).once
           faktory_config.error_handlers[0].call(exception, handler_context)
         end
       end
@@ -72,7 +72,7 @@ describe "Faktory Dependency" do
         }
 
         it "notifies Honeybadger" do
-          expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+          expect(Honeybadger).to receive(:notify).with(exception, **error_payload).once
           faktory_config.error_handlers[0].call(exception, handler_context)
         end
 
@@ -92,7 +92,7 @@ describe "Faktory Dependency" do
             let(:retry_limit) { 0 }
 
             it "notifies Honeybadger" do
-              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              expect(Honeybadger).to receive(:notify).with(exception, **error_payload).once
               faktory_config.error_handlers[0].call(exception, handler_context)
             end
           end
@@ -102,7 +102,7 @@ describe "Faktory Dependency" do
             let(:retry_limit) { 3 }
 
             it "notifies Honeybadger" do
-              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              expect(Honeybadger).to receive(:notify).with(exception, **error_payload).once
               faktory_config.error_handlers[0].call(exception, handler_context)
             end
           end
@@ -112,7 +112,7 @@ describe "Faktory Dependency" do
             let(:retry_limit) { 10 }
 
             it "notifies Honeybadger" do
-              expect(Honeybadger).to receive(:notify).with(exception, error_payload).once
+              expect(Honeybadger).to receive(:notify).with(exception, **error_payload).once
               faktory_config.error_handlers[0].call(exception, handler_context)
             end
           end

--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -78,7 +78,7 @@ describe "Sidekiq Dependency" do
           let(:job_context) { {context: "Job raised exception", job: job} }
 
           it "notifies Honeybadger" do
-            expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+            expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
             sidekiq.error_handlers[0].call(exception, job_context)
           end
 
@@ -96,7 +96,7 @@ describe "Sidekiq Dependency" do
               let(:attempt) { 2 }
 
               it "notifies Honeybadger" do
-                expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+                expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
                 sidekiq.error_handlers[0].call(exception, job_context)
               end
             end
@@ -106,7 +106,7 @@ describe "Sidekiq Dependency" do
               let(:attempt) { 2 }
 
               it "notifies Honeybadger" do
-                expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+                expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
                 sidekiq.error_handlers[0].call(exception, job_context)
               end
             end
@@ -115,7 +115,7 @@ describe "Sidekiq Dependency" do
               let(:attempt) { 3 }
 
               it "notifies Honeybadger" do
-                expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+                expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
                 sidekiq.error_handlers[0].call(exception, job_context)
               end
             end
@@ -125,7 +125,7 @@ describe "Sidekiq Dependency" do
             let(:job) { {"class" => "HardWorker"} }
 
             it "includes the class as a component" do
-              expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: "HardWorker", action: "perform"}).once
+              expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: "HardWorker", action: "perform").once
               sidekiq.error_handlers[0].call(exception, job_context)
             end
           end
@@ -134,7 +134,7 @@ describe "Sidekiq Dependency" do
             let(:job) { {"class" => "HardWorker", "wrapped" => "WrappedWorker"} }
 
             it "includes the class as a component" do
-              expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: "WrappedWorker", action: "perform"}).once
+              expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: "WrappedWorker", action: "perform").once
               sidekiq.error_handlers[0].call(exception, job_context)
             end
           end
@@ -145,7 +145,7 @@ describe "Sidekiq Dependency" do
           let(:job_context) { job }
 
           it "notifies Honeybadger" do
-            expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+            expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
             sidekiq.error_handlers[0].call(exception, job_context)
           end
 
@@ -163,7 +163,7 @@ describe "Sidekiq Dependency" do
               let(:retry_config) { 1 }
 
               it "notifies Honeybadger" do
-                expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+                expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
                 sidekiq.error_handlers[0].call(exception, job_context)
               end
             end
@@ -172,7 +172,7 @@ describe "Sidekiq Dependency" do
               let(:attempt) { 3 }
 
               it "notifies Honeybadger" do
-                expect(Honeybadger).to receive(:notify).with(exception, {parameters: job_context, component: nil}).once
+                expect(Honeybadger).to receive(:notify).with(exception, parameters: job_context, component: nil).once
                 sidekiq.error_handlers[0].call(exception, job_context)
               end
             end


### PR DESCRIPTION
This PR makes the Plugins use the new keyword argument arity of `Honeybadger.notify(ex, **options_here)`.

The existing tests all passed, but these were using faking the old arity.

## Workaround

Until there's a release,

```ruby
gem "honeybadger", github: "olleolleolle/honeybadger-ruby", branch: "sidekiq-notify", ref: "a6125fd"
```

## Details

Changed the faking in tests for Sidekiq, Factory. 

I left Sucker Punch's tests alone (I don't know how Sucker Punch works) - it was lacking coverage of the changed code path, and I left it like that.

I assume it was introduced in #499.
