### PR TITLE
fix: allow jobs in active job subscriber payloads

### DIFF
--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -131,7 +131,7 @@ module Honeybadger
 
       if jobs
         base_payload.merge({
-          jobs: jobs.map { |j| {job_class: j.class.to_s, job_id: j.job_id, queue_name: j.queue_name} }
+          jobs: jobs.compact.map { |j| {job_class: j.class.to_s, job_id: j.job_id, queue_name: j.queue_name} }
         })
       elsif job
         base_payload.merge({

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -122,13 +122,26 @@ module Honeybadger
   class ActiveJobSubscriber < NotificationSubscriber
     def format_payload(payload)
       job = payload[:job]
+      jobs = payload[:jobs]
       adapter = payload[:adapter]
-      payload.except(:job, :adapter).merge({
-        adapter_class: adapter.class.to_s,
-        job_class: job.class.to_s,
-        job_id: job.job_id,
-        queue_name: job.queue_name
+
+      base_payload = payload.except(:job, :jobs, :adapter).merge({
+        adapter_class: adapter&.class&.to_s
       })
+
+      if jobs
+        base_payload.merge({
+          jobs: jobs.map { |j| {job_class: j.class.to_s, job_id: j.job_id, queue_name: j.queue_name} }
+        })
+      elsif job
+        base_payload.merge({
+          job_class: job.class.to_s,
+          job_id: job.job_id,
+          queue_name: job.queue_name
+        })
+      else
+        base_payload
+      end
     end
   end
 


### PR DESCRIPTION
This expands the job data into an array of objects if we see a jobs key in the message payload

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
