### PR TITLE
fix: log fewer 429 responses in events worker

### DIFF
--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -285,6 +285,7 @@ module Honeybadger
       when 429, 503
         throttle = inc_throttle
         warn { sprintf("Event send failed: project is sending too many events. code=%s throttle=%s interval=%s", response.code, throttle, throttle_interval) }
+        suspend(3600)
       when 402
         warn { sprintf("Event send failed: payment is required. code=%s", response.code) }
         suspend(3600)


### PR DESCRIPTION
Since an app can be sending many more events than it does notices, and since the API can be returning a 429 response for hours (until the quota resets) we should be more sparing in outputting logs about being rate limited.

Fixes #713
