### PR TITLE
feat: honor Retry-After header when EventsWorker is throttled

### DIFF
--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -57,7 +57,7 @@ module Honeybadger
       # @return [Integer, nil] The number of seconds to wait, or nil if not present
       def retry_after_seconds
         return nil unless @original_response
-        return nil unless (retry_after = @original_response["Retry-After"])
+        return nil unless (retry_after = @original_response["Retry-After"]&.strip)
 
         # Try to parse as an integer (seconds)
         if /^\d+$/.match?(retry_after)

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -285,7 +285,7 @@ module Honeybadger
       when 429, 503
         throttle = inc_throttle
         warn { sprintf("Event send failed: project is sending too many events. code=%s throttle=%s interval=%s", response.code, throttle, throttle_interval) }
-        suspend(3600)
+        suspend(response.retry_after_seconds || 3600)
       when 402
         warn { sprintf("Event send failed: payment is required. code=%s", response.code) }
         suspend(3600)

--- a/spec/unit/honeybadger/backend/base_spec.rb
+++ b/spec/unit/honeybadger/backend/base_spec.rb
@@ -35,6 +35,55 @@ describe Honeybadger::Backend::Response do
       its(:error) { should be_nil }
     end
   end
+
+  context "with Retry-After header" do
+    let(:response) do
+      mock_response = double("Net::HTTPResponse",
+        code: "429",
+        body: "",
+        message: "Too Many Requests")
+      # Make the mock respond to is_a? to return true for Net::HTTPResponse
+      allow(mock_response).to receive(:is_a?).with(Net::HTTPResponse).and_return(true)
+      allow(mock_response).to receive(:[]).with("Retry-After").and_return(retry_after_value)
+      mock_response
+    end
+
+    subject { described_class.new(response) }
+
+    context "when Retry-After is not present" do
+      let(:retry_after_value) { nil }
+
+      it "returns nil" do
+        expect(subject.retry_after_seconds).to be_nil
+      end
+    end
+
+    context "when Retry-After is an integer (seconds)" do
+      let(:retry_after_value) { "60" }
+
+      it "returns the number of seconds" do
+        expect(subject.retry_after_seconds).to eq(60)
+      end
+    end
+
+    context "when Retry-After is an HTTP date" do
+      let(:retry_after_value) { "Wed, 21 Oct 2015 07:28:00 GMT" }
+
+      it "returns the number of seconds until that time" do
+        # Mock Time.now to return a fixed time for predictable testing
+        allow(Time).to receive(:now).and_return(Time.parse("2015-10-21 07:27:00 GMT"))
+        expect(subject.retry_after_seconds).to eq(60)
+      end
+    end
+
+    context "when Retry-After has invalid format" do
+      let(:retry_after_value) { "invalid-date" }
+
+      it "returns nil" do
+        expect(subject.retry_after_seconds).to be_nil
+      end
+    end
+  end
 end
 
 describe Honeybadger::Backend::Base do


### PR DESCRIPTION
This prevents EventsWorker from attempting to log event payloads when it's known they won't be accepted.
