### PR TITLE
perf: ignore more events by default

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -36,7 +36,13 @@ module Honeybadger
       {event_type: "sql.active_record", query: /^(begin|commit)( immediate)?( transaction)?$/i},
       {event_type: "sql.active_record", query: /(solid_queue|good_job)/i},
       {event_type: "sql.active_record", name: /^GoodJob/},
-      {event_type: "process_action.action_controller", controller: "Rails::HealthController"}
+      {event_type: "process_action.action_controller", controller: "Rails::HealthController"},
+      {event_type: "cache_exist?.active_support"},
+      {event_type: "cache_write.active_support"},
+      {event_type: "cache_generate.active_support"},
+      {event_type: "cache_delete.active_support"},
+      {event_type: "cache_increment.active_support"},
+      {event_type: "cache_decrement.active_support"}
     ].freeze
 
     DEVELOPMENT_ENVIRONMENTS = ["development", "test", "cucumber"].map(&:freeze).freeze


### PR DESCRIPTION
These cache events probably aren't that interesting, and they can generate a lot of events.