### PR TITLE
perf: stop adding events to the queue when the worker is suspended

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -256,6 +256,10 @@ module Honeybadger
       self[:"events.timeout"]
     end
 
+    def events_queue_when_suspended?
+      self[:"events.queue_when_suspended"]
+    end
+
     def params_filters
       Array(self[:"request.filter_keys"])
     end

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -134,6 +134,11 @@ module Honeybadger
         default: 100,
         type: Integer
       },
+      "events.queue_when_suspended": {
+        description: "Whether to allow events to be queued when the worker is suspended due to rate limiting. Defaults to false to prevent memory issues.",
+        default: false,
+        type: Boolean
+      },
       plugins: {
         description: "An optional list of plugins to load. Default is to load all plugins.",
         default: nil,

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -127,7 +127,7 @@ module Honeybadger
 
     def can_start?
       return false if shutdown?
-      return false if suspended? && !config.events_queue_when_suspended?
+      return false if suspended?
       true
     end
 

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -44,6 +44,7 @@ module Honeybadger
 
     def push(msg)
       return false unless start
+      return false if suspended? && !config.events_queue_when_suspended?
 
       if queue.size >= config.events_max_queue_size
         @dropped_events += 1
@@ -126,7 +127,7 @@ module Honeybadger
 
     def can_start?
       return false if shutdown?
-      return false if suspended?
+      return false if suspended? && !config.events_queue_when_suspended?
       true
     end
 

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -10,6 +10,19 @@ describe Honeybadger::Config do
   specify { expect(subject[:"delayed_job.attempt_threshold"]).to eq 0 }
   specify { expect(subject[:debug]).to eq false }
 
+  describe "#events_queue_when_suspended?" do
+    it "returns the configured value" do
+      config = Honeybadger::Config.new
+      config[:"events.queue_when_suspended"] = true
+      expect(config.events_queue_when_suspended?).to eq true
+    end
+
+    it "defaults to false" do
+      config = Honeybadger::Config.new
+      expect(config.events_queue_when_suspended?).to eq false
+    end
+  end
+
   describe "#init!" do
     let(:env) { {} }
     let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER) }

--- a/spec/unit/honeybadger/events_worker_spec.rb
+++ b/spec/unit/honeybadger/events_worker_spec.rb
@@ -125,6 +125,34 @@ describe Honeybadger::EventsWorker do
         expect(instance.push(event)).to eq false
       end
     end
+
+    context "when suspended" do
+      before do
+        instance.send(:suspend, 300)
+      end
+
+      context "and queue_when_suspended is false (default)" do
+        before do
+          allow(config).to receive(:events_queue_when_suspended?).and_return(false)
+        end
+
+        it "rejects the push" do
+          expect(instance.send(:queue)).not_to receive(:push)
+          expect(instance.push(event)).to eq false
+        end
+      end
+
+      context "and queue_when_suspended is true" do
+        before do
+          allow(config).to receive(:events_queue_when_suspended?).and_return(true)
+        end
+
+        it "allows the push" do
+          expect(instance.send(:queue)).to receive(:push).with(event)
+          expect(instance.push(event)).not_to eq false
+        end
+      end
+    end
   end
 
   describe "#start" do


### PR DESCRIPTION
If events are being blocked from being sent to the API, collecting more of them in the queue doesn't add a lot of value. They will just consume memory until the suspension is lifted or the app is restarted.
