### PR TITLE
fix: don't use as_json to collect Sidekiq stats

### DIFF
--- a/spec/unit/honeybadger/plugins/sidekiq_spec.rb
+++ b/spec/unit/honeybadger/plugins/sidekiq_spec.rb
@@ -213,18 +213,7 @@ describe "Sidekiq Dependency" do
           def retry_size
           end
 
-          def as_json
-            {
-              "stats" => {
-                "processed" => 0,
-                "failed" => 0,
-                "scheduled_size" => 0,
-                "retry_size" => 0,
-                "dead_size" => 0,
-                "processes_size" => 0,
-                "default_queue_latency" => 0
-              }
-            }
+          def default_queue_latency
           end
         end
       end


### PR DESCRIPTION
Fixes #722
