### PR TITLE
feat: add cached attribute to ActiveRecordSubscriber

### DIFF
--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -109,6 +109,7 @@ module Honeybadger
     def format_payload(payload)
       {
         query: Util::SQL.obfuscate(payload[:sql], payload[:connection]&.adapter_name),
+        cached: payload[:cached],
         async: payload[:async]
       }
     end


### PR DESCRIPTION
This will add the `cached` attribute value so that we can see the data in `sql.active_record` events.

**Before submitting a pull request,** please make sure the following is done:

  1. If you've fixed a bug or added code that should be tested, add tests!
  2. Run `rake spec` in the repository root.
  3. Use a pull request title that conforms to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
