### PR TITLE
feat: add Rails.event subscriber

### DIFF
--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -17,14 +17,7 @@ gem "capistrano", "~> 3.0"
 gem "rake"
 gem "rdoc"
 gem "bump", "~> 0.10.0"
-gem "activesupport", github: "rails"
-gem "activemodel", github: "rails"
-gem "activerecord", github: "rails"
-gem "activejob", github: "rails"
-gem "railties", github: "rails"
-gem "actionpack", github: "rails"
-gem "rack", github: "rack/rack", branch: "2-2-stable"
-gem "arel", github: "rails/arel"
+gem "rails", github: "rails/rails", branch: "main"
 gem "sqlite3", "~> 2", platforms: :mri
 gem "psych", "< 5.2.4", platforms: :jruby
 gem "better_errors", require: false, platforms: :mri

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -164,4 +164,13 @@ module Honeybadger
 
   class ActiveStorageSubscriber < NotificationSubscriber
   end
+
+  class RailsEventSubscriber
+    def emit(event)
+      return unless Honeybadger.config.load_plugin_insights_events?(:rails)
+
+      event_name = event.delete(:name)
+      Honeybadger.event(event_name, event.except(:timestamp))
+    end
+  end
 end

--- a/lib/honeybadger/plugins/rails.rb
+++ b/lib/honeybadger/plugins/rails.rb
@@ -93,6 +93,11 @@ module Honeybadger
             ::ActiveSupport::Notifications.subscribe("sql.active_record", Honeybadger::ActiveRecordSubscriber.new)
             ::ActiveSupport::Notifications.subscribe("process.action_mailer", Honeybadger::ActionMailerSubscriber.new)
             ::ActiveSupport::Notifications.subscribe(/(service_upload|service_download)\.active_storage/, Honeybadger::ActiveStorageSubscriber.new)
+            
+            # Subscribe to Rails.event for structured event logging (Rails 8.1+)
+            if defined?(::Rails.event)
+              ::Rails.event.subscribe(Honeybadger::RailsEventSubscriber.new) 
+            end
           end
         end
       end

--- a/spec/integration/rails/event_subscriber_spec.rb
+++ b/spec/integration/rails/event_subscriber_spec.rb
@@ -1,0 +1,26 @@
+require_relative "../rails_helper"
+
+describe "Rails Insights Event Subscriber", if: RAILS_PRESENT, type: :request do
+  load_rails_hooks(self)
+
+  before do
+    Honeybadger.config[:"insights.enabled"] = true
+    Honeybadger.config[:"events.batch_size"] = 0
+
+    Honeybadger::Backend::Test.events.clear
+  end
+
+  it "subscribes to Rails.event when available", if: defined?(Rails.event) do
+    Rails.event.notify("test.rails_event", {rails_key: "rails_value"})
+
+    sleep(0.1)
+
+    rails_events = Honeybadger::Backend::Test.events.select { |e| e[:event_type] == "test.rails_event" }
+    expect(rails_events).not_to be_empty
+    expect(rails_events.first[:payload][:rails_key]).to eq("rails_value")
+  end
+
+  it "gracefully handles Rails.event when not available", unless: defined?(Rails.event) do
+    expect { Honeybadger::Plugin.instances[:rails].load!(Honeybadger.config) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Send events recorded by calling `Rails.event.notify` to Insights.