### PR TITLE
chore: update test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -83,16 +83,19 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 'jruby-9.4.12.0'
-          - 'jruby-10.0.0.0'
+          - 'jruby-9.4.14.0'
+          - 'jruby-10.0.2.0'
         gemfile:
-          - rails7.1.gemfile
           - rails6.1.gemfile
+          - rails7.1.gemfile
+          - rails8.gemfile
           - rails.gemfile
         exclude:
-          - ruby: 'jruby-9.4.12.0'
+          - ruby: 'jruby-9.4.14.0'
             gemfile: rails.gemfile
-          - ruby: 'jruby-10.0.0.0'
+          - ruby: 'jruby-9.4.14.0'
+            gemfile: rails8.gemfile
+          - ruby: 'jruby-10.0.2.0'
             gemfile: rails6.1.gemfile
 
     # Has to be top level to cache properly

--- a/gemfiles/rails.gemfile
+++ b/gemfiles/rails.gemfile
@@ -10,27 +10,44 @@ gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"
-gem "bigdecimal"
 gem "base64"
 gem "mutex_m"
 gem "capistrano", "~> 3.0"
 gem "rake"
 gem "rdoc"
 gem "bump", "~> 0.10.0"
-gem "activesupport", github: "rails"
-gem "activemodel", github: "rails"
-gem "activerecord", github: "rails"
-gem "activejob", github: "rails"
-gem "railties", github: "rails"
-gem "actionpack", github: "rails"
-gem "rack", github: "rack/rack", branch: "2-2-stable"
+gem "activesupport", "> 7", github: "rails", branch: "main"
+gem "activemodel", github: "rails", branch: "main"
+gem "activerecord", github: "rails", branch: "main"
+gem "activejob", github: "rails", branch: "main"
+gem "railties", github: "rails", branch: "main"
+gem "actionpack", github: "rails", branch: "main"
+gem "rack", github: "rack/rack"
 gem "arel", github: "rails/arel"
 gem "sqlite3", "~> 2", platforms: :mri
-gem "psych", "< 5.2.4", platforms: :jruby
 gem "better_errors", require: false, platforms: :mri
 gem "rspec-rails"
 gem "listen"
 gem "tzinfo-data"
+
+
+platform :jruby do
+  gem "activerecord-jdbcsqlite3-adapter"
+  
+  # Let Bundler pick the JRuby build of psych (>= 5.2.4 on java doesn’t pull the C-ext `date` gem)
+  gem "psych", "~> 5.2", require: false
+
+  # Keep IRB usable without dragging in `io-console` (MRI-only C ext)
+  gem "reline", "~> 0.5.10", require: false
+
+  gem "nokogiri"
+  gem "racc", ">= 1.7.3"
+
+  # Ensure MRI-only bits never try to build on JRuby
+  gem "io-console", platforms: [:ruby]
+  gem "date", platforms: [:ruby]
+  gem "bigdecimal", platforms: [:ruby]
+end
 
 group :development do
   gem "guard"

--- a/gemfiles/rails8.gemfile
+++ b/gemfiles/rails8.gemfile
@@ -10,7 +10,6 @@ gem "rspec-its", "~> 1.3.1"
 gem "ruby-prof", platforms: :mri, require: false
 gem "timecop"
 gem "webmock"
-gem "bigdecimal"
 gem "base64"
 gem "mutex_m"
 gem "capistrano"
@@ -24,12 +23,28 @@ gem "activejob", "~> 8.0.2"
 gem "railties", "~> 8.0.2"
 gem "actionpack", "~> 8.0.2"
 gem "sqlite3", "~> 2", platforms: :mri
-gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
-gem "psych", "< 5.2.4", platforms: :jruby
 gem "better_errors", require: false, platforms: :mri
 gem "rack-mini-profiler", require: false
 gem "rspec-rails"
 gem "tzinfo-data"
+
+platform :jruby do
+  gem "activerecord-jdbcsqlite3-adapter"
+  
+  # Let Bundler pick the JRuby build of psych (>= 5.2.4 on java doesn’t pull the C-ext `date` gem)
+  gem "psych", "~> 5.2", require: false
+
+  # Keep IRB usable without dragging in `io-console` (MRI-only C ext)
+  gem "reline", "~> 0.5.10", require: false
+
+  gem "nokogiri"
+  gem "racc", ">= 1.7.3"
+
+  # Ensure MRI-only bits never try to build on JRuby
+  gem "io-console", platforms: [:ruby]
+  gem "date", platforms: [:ruby]
+  gem "bigdecimal", platforms: [:ruby]
+end
 
 group :development do
   gem "guard"

--- a/spec/fixtures/rails/config/application.rb
+++ b/spec/fixtures/rails/config/application.rb
@@ -2,7 +2,7 @@ require "rails"
 require "action_controller/railtie"
 
 # Duplicating here as some specs don't use the rails helper
-SKIP_ACTIVE_RECORD = !!(defined?(JRUBY_VERSION) && Rails::VERSION::PRE == "alpha")
+SKIP_ACTIVE_RECORD = !!(defined?(JRUBY_VERSION) && (Rails::VERSION::PRE == "alpha" || Rails::VERSION::MAJOR >= 8))
 
 if SKIP_ACTIVE_RECORD
   module ActiveRecord

--- a/spec/integration/rails_helper.rb
+++ b/spec/integration/rails_helper.rb
@@ -9,7 +9,7 @@ begin
   # We are unable to run Activerecord with rails edge on jruby as the sqlite
   # adapter is not supported, so we are skipping activrecord specs just for
   # that runtime and Rails version
-  SKIP_ACTIVE_RECORD = !!(defined?(JRUBY_VERSION) && Rails::VERSION::PRE == "alpha")
+  SKIP_ACTIVE_RECORD = !!(defined?(JRUBY_VERSION) && (Rails::VERSION::PRE == "alpha" || Rails::VERSION::MAJOR >= 8))
 
   require FIXTURES_PATH.join("rails", "config", "application.rb")
   require "honeybadger/init/rails"


### PR DESCRIPTION
This PR brings in the following changes from #734 to support testing Rails 8+ with JRuby

* Update the JRuby versions
* Add Rails 8 to JRuby matrix

