### PR TITLE
fix: handle invalid byte sequence in breadcrumbs

### DIFF
--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -1,3 +1,5 @@
+require "honeybadger/util/sanitizer"
+
 module Honeybadger
   module Breadcrumbs
     # @api private
@@ -10,7 +12,7 @@ module Honeybadger
         elsif message.nil?
           message, progname = [progname, nil]
         end
-        message &&= message.to_s.strip
+        message &&= Util::Sanitizer.sanitize(message.to_s).strip
         unless should_ignore_log?(message, progname)
           Honeybadger.add_breadcrumb(message, category: :log, metadata: {
             severity: format_severity(severity),

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -33,6 +33,12 @@ describe Honeybadger::Breadcrumbs::LogWrapper do
     subject.add("DEBUG", {})
   end
 
+  it "handles invalid UTF-8 byte sequences" do
+    invalid_string = "\xE9s"
+    expect(Honeybadger).to receive(:add_breadcrumb).with("?s", anything)
+    subject.add("DEBUG", invalid_string)
+  end
+
   it "does not mutate the message" do
     subject.add("DEBUG", {}, "Honeybadger")
     expect(subject.severity).to eq("DEBUG")


### PR DESCRIPTION
Fixes #741 