### PR TITLE
fix: replace return with next in execution blocks to prevent LocalJumpError

### DIFF
--- a/lib/honeybadger/plugins/delayed_job.rb
+++ b/lib/honeybadger/plugins/delayed_job.rb
@@ -15,7 +15,7 @@ module Honeybadger
     end
 
     execution do
-      return unless Honeybadger.config[:"exceptions.enabled"]
+      next unless Honeybadger.config[:"exceptions.enabled"]
       require "honeybadger/plugins/delayed_job/plugin"
       ::Delayed::Worker.plugins << Plugins::DelayedJob::Plugin
     end

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -15,7 +15,7 @@ module Honeybadger
         requirement { defined?(::Faktory) }
 
         execution do
-          return unless Honeybadger.config[:"exceptions.enabled"]
+          next unless Honeybadger.config[:"exceptions.enabled"]
           ::Faktory.configure_worker do |faktory|
             faktory.worker_middleware do |chain|
               chain.prepend Middleware

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -64,7 +64,7 @@ module Honeybadger
         end
 
         execution do
-          return unless Honeybadger.config[:"exceptions.enabled"]
+          next unless Honeybadger.config[:"exceptions.enabled"]
           ::Resque::Job.send(:include, Installer)
         end
       end

--- a/lib/honeybadger/plugins/shoryuken.rb
+++ b/lib/honeybadger/plugins/shoryuken.rb
@@ -40,7 +40,7 @@ module Honeybadger
         requirement { defined?(::Shoryuken) }
 
         execution do
-          return unless Honeybadger.config[:"exceptions.enabled"]
+          next unless Honeybadger.config[:"exceptions.enabled"]
           ::Shoryuken.configure_server do |config|
             config.server_middleware do |chain|
               chain.add Middleware

--- a/lib/honeybadger/plugins/sucker_punch.rb
+++ b/lib/honeybadger/plugins/sucker_punch.rb
@@ -6,7 +6,7 @@ module Honeybadger
     requirement { defined?(::SuckerPunch) }
 
     execution do
-      return unless Honeybadger.config[:"exceptions.enabled"]
+      next unless Honeybadger.config[:"exceptions.enabled"]
       if SuckerPunch.respond_to?(:exception_handler=) # >= v2
         SuckerPunch.exception_handler = ->(ex, klass, args) { Honeybadger.notify(ex, component: klass, parameters: args) }
       else

--- a/lib/honeybadger/plugins/thor.rb
+++ b/lib/honeybadger/plugins/thor.rb
@@ -25,7 +25,7 @@ module Honeybadger
       requirement { defined?(::Thor.no_commands) }
 
       execution do
-        return unless Honeybadger.config[:"exceptions.enabled"]
+        next unless Honeybadger.config[:"exceptions.enabled"]
         ::Thor.send(:include, Thor)
       end
     end


### PR DESCRIPTION
Using `return` inside execution block can cause `LocalJumpError`. This change is replacing `return` with `next` to perform an early exit from the block instead.

Related error:
```
ERROR -- honeybadger: ** [Honeybadger] plugin error name=thor class=LocalJumpError message="unexpected return"
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugins/thor.rb:28:in 'block (2 levels) in <module:Plugins>'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:121:in 'BasicObject#instance_eval'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:121:in 'Honeybadger::Plugin::Execution#call'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:253:in 'block in Honeybadger::Plugin#load!'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:253:in 'Array#each'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:253:in 'Honeybadger::Plugin#load!'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:96:in 'block in Honeybadger::Plugin.load!'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:94:in 'Hash#each_pair'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/plugin.rb:94:in 'Honeybadger::Plugin.load!'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/singleton.rb:76:in 'Honeybadger#load_plugins!'
    /usr/local/bundle/gems/honeybadger-6.0.6/lib/honeybadger/init/rails.rb:35:in 'block in <class:Railtie>'
    [...]
```