### PR TITLE
chore: flatten Rails event payloads

### DIFF
--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -176,9 +176,13 @@ module Honeybadger
 
   class RailsEventSubscriber
     def emit(event)
-      return unless Honeybadger.config.load_plugin_insights?(:rails, feature: :structured_events)
-
-      Honeybadger.event(event[:name], event.except(:name, :timestamp))
+      payload = {}.tap do |hash|
+        hash[:source_location] = event[:source_location] if event.has_key?(:source_location)
+        hash.merge!(Hash(event[:tags])) if event.has_key?(:tags)
+        hash.merge!(Hash(event[:context])) if event.has_key?(:context)
+        hash.merge!(Hash(event[:payload])) if event.has_key?(:payload)
+      end
+      Honeybadger.event(event[:name], payload)
     end
   end
 end

--- a/spec/integration/rails/event_subscriber_spec.rb
+++ b/spec/integration/rails/event_subscriber_spec.rb
@@ -5,12 +5,38 @@ describe "Rails Insights Event Subscriber", if: (RAILS_PRESENT && defined?(Rails
 
   it "captures Rails.event events" do
     Honeybadger.flush do
-      Rails.event.notify("test.rails_event", {rails_key: "rails_value"})
+      Rails.event.set_context(user_agent: "TestAgent")
+      Rails.event.set_context(job_id: "abc123")
+      Rails.event.tagged("graphql") do
+        Rails.event.tagged(section: "admin") do
+          Rails.event.notify("test.rails_event", {rails_key: "rails value"})
+        end
+      end
     end
 
     rails_events = Honeybadger::Backend::Test.events.select { |e| e[:event_type] == "test.rails_event" }
     expect(rails_events).not_to be_empty
-    expect(rails_events.first[:payload][:rails_key]).to eq("rails_value")
+    expect(rails_events.first[:graphql]).to eq(true)
+    expect(rails_events.first[:section]).to eq("admin")
+    expect(rails_events.first[:user_agent]).to eq("TestAgent")
+    expect(rails_events.first[:job_id]).to eq("abc123")
+    expect(rails_events.first[:rails_key]).to eq("rails value")
+
     expect(rails_events.first[:name]).to be_blank
+  end
+
+  it "flattens tags -> context -> payload" do
+    Honeybadger.flush do
+      Rails.event.set_context(context_key: "context value")
+      Rails.event.tagged(tag_key: "tag value", context_key: "tag context value") do
+        Rails.event.notify("test.rails_event", {rails_key: "rails value", tag_key: "rails tag value"})
+      end
+    end
+
+    rails_events = Honeybadger::Backend::Test.events.select { |e| e[:event_type] == "test.rails_event" }
+    expect(rails_events).not_to be_empty
+    expect(rails_events.first[:context_key]).to eq("context value")
+    expect(rails_events.first[:tag_key]).to eq("rails tag value")
+    expect(rails_events.first[:rails_key]).to eq("rails value")
   end
 end


### PR DESCRIPTION
@stympy @rabidpraxis let me know what you think of this. The default `Rails.event` payloads look like this:

```ruby
{
  hostname: "Mac.lan",
  source_location: {
    filepath: "/Users/josh/Code/honeybadger-io/honeybadger-ruby/spec/integration/rails/event_subscriber_spec.rb",
    lineno: 12,
    label: "block (5 levels) in <top (required)>"
  },
  payload: {
    rails_key: "rails value"
  },
  tags: {
    graphql: true,
    section: "admin"
  },
  context: {
    user_agent: "TestAgent",
    job_id: "abc123"
  },
  ts: "2025-12-10T20:17:39.047Z",
  event_type: "rails.test_event"
}
```

This PR merges the `tags` -> `context` -> `payload` keys (in that order) so that you get an event like this:

```ruby
{
  hostname: "Mac.lan",
  source_location: {
    filepath: "/Users/josh/Code/honeybadger-io/honeybadger-ruby/spec/integration/rails/event_subscriber_spec.rb",
    lineno: 12,
    label: "block (5 levels) in <top (required)>"
  },
  graphql: true,
  section: "admin",
  user_agent: "TestAgent",
  job_id: "abc123",
  rails_key: "rails value",
  ts: "2025-12-10T20:24:17.531Z",
  event_type: "rails.test_event"
}
```

I'm considering this change because it fits our other Insights events better. Consider this example:

```ruby
Rails.event.set_context(user_id: 123)
Honeybadger.event_context(user_id: 123) # Note: I think this should eventually happen automatically when you call `Rails.event.set_context`, similar to our integration with `Rails.error.set_context`

Rails.event.notify("rails.test_event", { ... }) # Rails logs internal events this way
Honeybadger.event("request.net_http", { ... }) # We log some additional events this way
```

With the current Rails event payload, you'd get something like this:

```ruby
# Rails event:
{
  payload: { ... },
  context: {
    user_id: 123 # Rails event context
  },
  user_id: 123, # Honeybadger event context
  ts: "2025-12-10T20:17:39.047Z",
  event_type: "rails.test_event"
}

# Honeybadger event:
{
  ...,
  user_id: 123, # Honeybadger event context
  ts: "2025-12-10T20:17:39.047Z",
  event_type: "request.net_http"
}
```

After this change, you'd get something like this:

```ruby
# Rails event:
{
  ...,
  user_id: 123 # Rails event context
  ts: "2025-12-10T20:17:39.047Z",
  event_type: "rails.test_event"
}

# Honeybadger event:
{
  ...,
  user_id: 123, # Honeybadger event context
  ts: "2025-12-10T20:17:39.047Z",
  event_type: "request.net_http"
}
```

## Trade-offs

Current approach:

- It's clear where each key is coming from in Rails events
- It's closer to the internal events that Rails emits
- Rails/HB event context is duplicated
- You have to think about extra nested keys when writing queries

New approach:

- Resolves context duplication issue
- The event context across Rails and Honeybadger events should mostly align
- You could lose some context in the Rails events if the `tag`, `context`, or `payload` keys overlap (users could accidentally override any context values that Rails adds, for example)
- It's less clear where each key is coming from in the Rails events