### PR TITLE
feat: remove Sidekiq server configuration from payloads

### DIFF
--- a/lib/honeybadger/plugins/sidekiq.rb
+++ b/lib/honeybadger/plugins/sidekiq.rb
@@ -84,9 +84,6 @@ module Honeybadger
 
             if defined?(::Sidekiq::VERSION) && ::Sidekiq::VERSION > "3"
               ::Sidekiq.configure_server do |sidekiq|
-                sidekiq_default_configuration = (::Sidekiq::VERSION > "7") ?
-                  ::Sidekiq.default_configuration : Class.new
-
                 sidekiq.error_handlers << lambda { |ex, sidekiq_params, _sidekiq_config = nil|
                   params = sidekiq_params.dup
 
@@ -136,6 +133,7 @@ module Honeybadger
 
                 class SidekiqClusterCollectionChecker
                   include ::Sidekiq::Component
+
                   def initialize(config)
                     @config = config
                   end


### PR DESCRIPTION
Remove extraction and transmission of Sidekiq server configuration (@options) from error payloads. This configuration data was:

- Rarely useful for debugging individual job errors
- Often very large (400+ lines with sidekiq-scheduler)
- Mostly static server settings that don't help diagnose failures
- Including Proc objects that couldn't serialize properly

All job-specific debugging info (parameters, class, queue, retry count, stack trace) is still captured.

Fixes #767

