### PR TITLE
feat!: use fiber storage for request context/execution state

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,24 +2,21 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   ruby:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
         ruby:
-          - '3.0'
-          - '3.1'
-          - '3.2'
-          - '3.3'
-          - '3.4'
-          - 'ruby-head'
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "ruby-head"
         gemfile:
           - binding_of_caller.gemfile
           - delayed_job.gemfile
@@ -37,19 +34,13 @@ jobs:
           - sidekiq7.gemfile
           - standalone.gemfile
         exclude:
-          - ruby: '3.0'
-            gemfile: rails7.2.gemfile
-          - ruby: '3.0'
-            gemfile: rails8.gemfile
-          - ruby: '3.1'
-            gemfile: rails8.gemfile
-          - ruby: '3.4'
+          - ruby: "3.4"
             gemfile: rails6.1.gemfile
-          - ruby: 'ruby-head'
+          - ruby: "ruby-head"
             gemfile: rails6.1.gemfile
-          - ruby: '3.4'
+          - ruby: "3.4"
             gemfile: rails7.0.gemfile
-          - ruby: 'ruby-head'
+          - ruby: "ruby-head"
             gemfile: rails7.0.gemfile
     # Has to be top level to cache properly
     env:
@@ -58,25 +49,25 @@ jobs:
       BUNDLE_PATH: "vendor/bundle"
       BUNDLE_WITHOUT: "development"
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: ${{ matrix.ruby != 'ruby-head' }} # Try to avoid problems with ruby-head breaking bundler
-      continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: ${{ matrix.ruby != 'ruby-head' }} # Try to avoid problems with ruby-head breaking bundler
+        continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
 
-    # Deal with a lack of bundler cache for ruby-head
-    - name: Install gems for ruby-head
-      if: matrix.ruby == 'ruby-head'
-      run: bundle install
-      continue-on-error: true
+      # Deal with a lack of bundler cache for ruby-head
+      - name: Install gems for ruby-head
+        if: matrix.ruby == 'ruby-head'
+        run: bundle install
+        continue-on-error: true
 
-    - name: Build and test regular ruby
-      run: |
-        bundle exec rake
-      continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
+      - name: Build and test regular ruby
+        run: |
+          bundle exec rake
+        continue-on-error: ${{ matrix.ruby == 'ruby-head' }}
 
   jruby:
     runs-on: ubuntu-22.04
@@ -84,19 +75,14 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 'jruby-9.4.14.0'
-          - 'jruby-10.0.2.0'
+          - "jruby-10.0.2.0"
         gemfile:
           - rails6.1.gemfile
           - rails7.1.gemfile
           - rails8.gemfile
           - rails.gemfile
         exclude:
-          - ruby: 'jruby-9.4.14.0'
-            gemfile: rails.gemfile
-          - ruby: 'jruby-9.4.14.0'
-            gemfile: rails8.gemfile
-          - ruby: 'jruby-10.0.2.0'
+          - ruby: "jruby-10.0.2.0"
             gemfile: rails6.1.gemfile
 
     # Has to be top level to cache properly
@@ -106,13 +92,13 @@ jobs:
       BUNDLE_PATH: "vendor/bundle"
       BUNDLE_WITHOUT: "development"
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JRuby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
+      - uses: actions/checkout@v4
+      - name: Set up JRuby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
-    - name: Build and test jruby
-      run: |
-        bundle exec rake spec:integrations spec:units
+      - name: Build and test jruby
+        run: |
+          bundle exec rake spec:integrations spec:units

--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/honeybadger-io/honeybadger-ruby"
   }
 
-  s.required_ruby_version = ">= 3.0.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.rdoc_options << "--markup=tomdoc"
   s.rdoc_options << "--main=README.md"

--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -637,7 +637,7 @@ module Honeybadger
     private
 
     attr_reader :error_context_manager, :event_context_manager,
-      :execution_context_manager, :breadcrumbs_storage_key
+      :execution_context_manager
 
     def strip_metadata(event)
       event.delete(:_hb)

--- a/lib/honeybadger/breadcrumbs/collector.rb
+++ b/lib/honeybadger/breadcrumbs/collector.rb
@@ -67,9 +67,11 @@ module Honeybadger
         }
       end
 
+      # @api private
+      attr_reader :config
+
       private
 
-      # @api private
       # Since the collector is shared with the worker thread, there is a chance
       # it can be cleared before we have prepared the request. We provide the
       # ability to duplicate a collector which should also duplicate the buffer

--- a/lib/honeybadger/breadcrumbs/collector.rb
+++ b/lib/honeybadger/breadcrumbs/collector.rb
@@ -5,6 +5,7 @@ module Honeybadger
     class Collector
       include Enumerable
       extend Forwardable
+
       # The Collector manages breadcrumbs and provides an interface for accessing
       # and affecting breadcrumbs
       #

--- a/lib/honeybadger/breadcrumbs/ring_buffer.rb
+++ b/lib/honeybadger/breadcrumbs/ring_buffer.rb
@@ -43,7 +43,7 @@ module Honeybadger
       private
 
       # The collection must be duplicated when duplicating the buffer to prevent
-      # conurrent modifications. This converts it to a plain array.
+      # concurrent modifications. This converts it to a plain array.
       def initialize_dup(source)
         @collection = source.to_a.dup
         super

--- a/lib/honeybadger/breadcrumbs/ring_buffer.rb
+++ b/lib/honeybadger/breadcrumbs/ring_buffer.rb
@@ -6,38 +6,47 @@ module Honeybadger
       # are pushed on the end of the stack.
       include Enumerable
 
-      attr_reader :buffer
-
-      def initialize(buffer_size = 40)
+      def initialize(buffer_size = 40, collection: BreadcrumbsCollection)
         @buffer_size = buffer_size
-        clear!
-      end
-
-      def add!(item)
-        @buffer << item
-        @ct += 1
-        @buffer.shift(1) if @ct > @buffer_size
-      end
-
-      def clear!
-        @buffer = []
+        @collection = collection
         @ct = 0
       end
 
-      def to_a
-        @buffer
+      def add!(item)
+        @collection << item
+        @ct += 1
+        @collection.shift(1) if @ct > @buffer_size
       end
 
+      def clear!
+        @collection.clear
+        @ct = 0
+      end
+
+      def buffer
+        @collection.to_a
+      end
+      alias_method :to_a, :buffer
+
       def each(&blk)
-        @buffer.each(&blk)
+        @collection.each(&blk)
       end
 
       def previous
-        @buffer.last
+        @collection.last
       end
 
       def drop
-        @buffer.pop
+        @collection.pop
+      end
+
+      private
+
+      # The collection must be duplicated when duplicating the buffer to prevent
+      # conurrent modifications. This converts it to a plain array.
+      def initialize_dup(source)
+        @collection = source.to_a.dup
+        super
       end
     end
   end

--- a/lib/honeybadger/context_manager.rb
+++ b/lib/honeybadger/context_manager.rb
@@ -19,13 +19,13 @@ module Honeybadger
       if block_given?
         existing = Fiber[context_key]
         begin
-          Fiber[context_key] = (existing || {}).merge(new_context)
+          Fiber[context_key] = (existing || EMPTY_CONTEXT).merge(new_context)
           yield
         ensure
           Fiber[context_key] = existing
         end
       else
-        Fiber[context_key] = (Fiber[context_key] || {}).merge(new_context)
+        Fiber[context_key] = (Fiber[context_key] || EMPTY_CONTEXT).merge(new_context)
       end
     end
     alias_method :context, :set_context
@@ -48,4 +48,47 @@ module Honeybadger
 
   # @api private
   ExecutionContext = ContextManager.new(:__hb_execution_context)
+
+  # @api private
+  class CollectionManager
+    include Enumerable
+    extend Forwardable
+
+    EMPTY_COLLECTION = [].freeze
+
+    def initialize(context_key)
+      @context_key = context_key
+    end
+
+    attr_reader :context_key
+
+    def push(...)
+      Fiber[context_key] = (Fiber[context_key] || []).dup.push(...)
+    end
+    alias_method :<<, :push
+
+    def pop(...)
+      Fiber[context_key] = (Fiber[context_key] || []).dup
+      Fiber[context_key].pop(...)
+    end
+
+    def shift(...)
+      Fiber[context_key] = (Fiber[context_key] || []).dup
+      Fiber[context_key].shift(...)
+    end
+
+    def get_collection
+      Fiber[context_key] || EMPTY_COLLECTION
+    end
+    alias_method :to_a, :get_collection
+
+    # Read-only delegators
+    def_delegators :get_collection, :each, :last
+
+    def clear
+      Fiber[context_key] = nil
+    end
+  end
+
+  BreadcrumbsCollection = CollectionManager.new(:__hb_breadcrumbs)
 end

--- a/lib/honeybadger/context_manager.rb
+++ b/lib/honeybadger/context_manager.rb
@@ -1,133 +1,51 @@
 require "honeybadger/conversions"
-require "monitor"
 
 module Honeybadger
   # @api private
   class ContextManager
     include Conversions
 
-    def self.current
-      Thread.current[:__hb_context_manager] ||= new
+    EMPTY_CONTEXT = {}.freeze
+
+    def initialize(context_key)
+      @context_key = context_key
     end
 
-    def initialize
-      @monitor = Monitor.new
-      _initialize
-    end
-
-    def clear!
-      _initialize
-    end
-
-    # Internal helpers
+    attr_reader :context_key
 
     def set_context(hash, &block)
-      local = block_given?
-      @monitor.synchronize do
-        @global_context ||= {}
-        @local_context ||= []
+      new_context = Context(hash)
 
-        new_context = Context(hash)
-
-        if local
-          @local_context << new_context
-        else
-          @global_context.update(new_context)
-        end
-      end
-
-      if local
+      if block_given?
+        existing = Fiber[context_key]
         begin
+          Fiber[context_key] = (existing || {}).merge(new_context)
           yield
         ensure
-          @monitor.synchronize { @local_context&.pop }
+          Fiber[context_key] = existing
         end
+      else
+        Fiber[context_key] = (Fiber[context_key] || {}).merge(new_context)
       end
     end
+    alias_method :context, :set_context
 
     def get_context
-      @monitor.synchronize do
-        return @global_context unless @local_context
-
-        @global_context.merge(@local_context.inject({}, :merge))
-      end
+      Fiber[context_key] || EMPTY_CONTEXT
     end
 
-    def clear_context
-      @monitor.synchronize do
-        @global_context = nil
-        @local_context = nil
-      end
+    def clear
+      Fiber[context_key] = nil
     end
-
-    def set_event_context(hash, &block)
-      local = block_given?
-      @monitor.synchronize do
-        @global_event_context ||= {}
-        @local_event_context ||= []
-
-        new_context = Context(hash)
-
-        if local
-          @local_event_context << new_context
-        else
-          @global_event_context.update(new_context)
-        end
-      end
-
-      if local
-        begin
-          yield
-        ensure
-          @monitor.synchronize { @local_event_context&.pop }
-        end
-      end
-    end
-
-    def get_event_context
-      @monitor.synchronize do
-        return @global_event_context unless @local_event_context
-
-        @global_event_context.merge(@local_event_context.inject({}, :merge))
-      end
-    end
-
-    def clear_event_context
-      @monitor.synchronize do
-        @global_event_context = nil
-        @local_event_context = nil
-      end
-    end
-
-    def set_rack_env(env)
-      @monitor.synchronize { @rack_env = env }
-    end
-
-    def get_rack_env
-      @monitor.synchronize { @rack_env }
-    end
-
-    def set_request_id(request_id)
-      @monitor.synchronize { @request_id = request_id }
-    end
-
-    def get_request_id
-      @monitor.synchronize { @request_id }
-    end
-
-    private
-
-    attr_accessor :custom, :rack_env, :request_id
-
-    def _initialize
-      @monitor.synchronize do
-        @global_context = nil
-        @local_context = nil
-        @global_event_context = nil
-        @local_event_context = nil
-        @rack_env = nil
-        @request_id = nil
-      end
-    end
+    alias_method :clear!, :clear
   end
+
+  # @api private
+  ErrorContext = ContextManager.new(:__hb_error_context)
+
+  # @api private
+  EventContext = ContextManager.new(:__hb_event_context)
+
+  # @api private
+  ExecutionContext = ContextManager.new(:__hb_execution_context)
 end

--- a/lib/honeybadger/rack/error_notifier.rb
+++ b/lib/honeybadger/rack/error_notifier.rb
@@ -29,7 +29,7 @@ module Honeybadger
       def call(env)
         agent.execution_context(
           rack_env: env,
-          request_id: rack_env["action_dispatch.request_id"] || SecureRandom.uuid
+          request_id: env["action_dispatch.request_id"] || SecureRandom.uuid
         )
 
         begin

--- a/lib/honeybadger/singleton.rb
+++ b/lib/honeybadger/singleton.rb
@@ -57,7 +57,6 @@ module Honeybadger
   #     @see Agent#$2
   def_delegator :"Honeybadger::Agent.instance", :config
   def_delegator :"Honeybadger::Agent.instance", :init!
-  def_delegator :"Honeybadger::Agent.instance", :with_rack_env
 
   # @!method notify(...)
   # Forwards to {Agent.instance}.

--- a/spec/unit/honeybadger/breadcrumbs/ring_buffer_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/ring_buffer_spec.rb
@@ -49,4 +49,18 @@ describe Honeybadger::Breadcrumbs::RingBuffer do
       expect(subject.previous).to eq(:b)
     end
   end
+
+  describe "#dup" do
+    it "duplicates the buffer" do
+      subject.add!(:a)
+      subject.add!(:b)
+
+      dup = subject.dup
+
+      dup.add!(:c)
+
+      expect(subject.buffer).to eq([:a, :b])
+      expect(dup.buffer).to eq([:a, :b, :c])
+    end
+  end
 end

--- a/spec/unit/honeybadger/context_manager_spec.rb
+++ b/spec/unit/honeybadger/context_manager_spec.rb
@@ -1,0 +1,187 @@
+require "honeybadger/context_manager"
+
+TestContext = Honeybadger::ContextManager.new(:__hb_test_context)
+
+RSpec.describe TestContext do
+  subject(:context_manager) { described_class }
+
+  before do
+    context_manager.clear
+  end
+
+  describe "#set_context" do
+    it "retrieves the context" do
+      context_manager.set_context(shop_id: :expected_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :expected_shop_id)
+    end
+  end
+
+  describe "#set_context" do
+    it "sets context" do
+      context_manager.set_context(shop_id: :expected_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :expected_shop_id)
+    end
+
+    it "merges context" do
+      context_manager.set_context(shop_id: :expected_shop_id)
+      context_manager.set_context(api_client_id: :expected_api_client_id)
+      expect(context_manager.get_context).to eq(shop_id: :expected_shop_id, api_client_id: :expected_api_client_id)
+    end
+
+    it "overwrites existing keys" do
+      context_manager.set_context(shop_id: :old_shop_id)
+      context_manager.set_context(shop_id: :new_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :new_shop_id)
+    end
+
+    it "returns empty hash by default" do
+      expect(context_manager.get_context).to eq({})
+    end
+  end
+
+  describe "local context with block" do
+    it "isolates context inside block" do
+      context_manager.set_context(shop_id: :global_shop_id)
+
+      local_context = nil
+      context_manager.set_context(api_client_id: :local_api_client_id) do
+        local_context = context_manager.get_context
+      end
+
+      expect(local_context).to eq(shop_id: :global_shop_id, api_client_id: :local_api_client_id)
+      expect(context_manager.get_context).to eq(shop_id: :global_shop_id)
+    end
+
+    it "supports nested local contexts" do
+      context_manager.set_context(shop_id: :global_shop_id)
+
+      level_1_context = nil
+      level_2_context = nil
+      context_manager.set_context(api_client_id: :level_1_api_client_id) do
+        context_manager.set_context(user_id: :level_2_user_id) do
+          level_2_context = context_manager.get_context
+        end
+        level_1_context = context_manager.get_context
+      end
+
+      expect(level_1_context).to eq(shop_id: :global_shop_id, api_client_id: :level_1_api_client_id)
+      expect(level_2_context).to eq(shop_id: :global_shop_id, api_client_id: :level_1_api_client_id, user_id: :level_2_user_id)
+      expect(context_manager.get_context).to eq(shop_id: :global_shop_id)
+    end
+
+    it "overrides global context inside the block" do
+      context_manager.set_context(shop_id: :global_shop_id)
+
+      local_context = nil
+      context_manager.set_context(shop_id: :local_shop_id) do
+        local_context = context_manager.get_context
+      end
+
+      expect(local_context).to eq(shop_id: :local_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :global_shop_id)
+    end
+
+    it "localizes global context inside the block" do
+      context_manager.set_context(shop_id: :global_shop_id)
+
+      local_context = nil
+      context_manager.set_context(shop_id: :local_shop_id) do
+        context_manager.set_context(user_id: :global_user_id)
+        local_context = context_manager.get_context
+      end
+
+      expect(local_context).to eq(shop_id: :local_shop_id, user_id: :global_user_id)
+      expect(context_manager.get_context).to eq(shop_id: :global_shop_id)
+    end
+  end
+
+  describe "#clear" do
+    it "clears all context" do
+      context_manager.set_context(shop_id: :expected_shop_id)
+      context_manager.clear
+      expect(context_manager.get_context).to eq({})
+    end
+  end
+
+  describe "fiber isolation" do
+    it "child fiber inherits parent context" do
+      context_manager.set_context(shop_id: :parent_shop_id)
+
+      child_context = nil
+      Fiber.new { child_context = context_manager.get_context }.resume
+
+      expect(child_context).to eq(shop_id: :parent_shop_id)
+    end
+
+    it "child fiber mutations don't affect parent" do
+      context_manager.set_context(shop_id: :parent_shop_id)
+
+      Fiber.new do
+        context_manager.set_context(shop_id: :child_shop_id)
+      end.resume
+
+      expect(context_manager.get_context).to eq(shop_id: :parent_shop_id)
+    end
+
+    it "isolates context set after fiber creation" do
+      context_manager.set_context(shop_id: :initial_shop_id)
+
+      fiber = Fiber.new do
+        context_manager.get_context
+      end
+
+      context_manager.set_context(api_client_id: :later_api_client_id)
+      child_context = fiber.resume
+
+      # Child sees context at fiber creation time, not the later update
+      expect(child_context).to eq(shop_id: :initial_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :initial_shop_id, api_client_id: :later_api_client_id)
+    end
+  end
+
+  describe "thread isolation" do
+    it "isolates context between threads" do
+      context_manager.set_context(shop_id: :main_thread_shop_id)
+
+      thread_context = nil
+      thread = Thread.new do
+        context_manager.set_context(shop_id: :other_thread_shop_id)
+        thread_context = context_manager.get_context
+      end
+      thread.join
+
+      expect(thread_context).to eq(shop_id: :other_thread_shop_id)
+      expect(context_manager.get_context).to eq(shop_id: :main_thread_shop_id)
+    end
+  end
+end
+
+RSpec.describe Honeybadger::ErrorContext do
+  it "inherits from AbstractContext" do
+    expect(described_class).to be_a(Honeybadger::ContextManager)
+  end
+
+  it "implements #context_key" do
+    expect(described_class.context_key).to eq(:__hb_error_context)
+  end
+end
+
+RSpec.describe Honeybadger::EventContext do
+  it "inherits from AbstractContext" do
+    expect(described_class).to be_a(Honeybadger::ContextManager)
+  end
+
+  it "implements #context_key" do
+    expect(described_class.context_key).to eq(:__hb_event_context)
+  end
+end
+
+RSpec.describe Honeybadger::ExecutionContext do
+  it "inherits from AbstractContext" do
+    expect(described_class).to be_a(Honeybadger::ContextManager)
+  end
+
+  it "implements #context_key" do
+    expect(described_class.context_key).to eq(:__hb_execution_context)
+  end
+end

--- a/spec/unit/honeybadger/context_manager_spec.rb
+++ b/spec/unit/honeybadger/context_manager_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TestContext do
     context_manager.clear
   end
 
-  describe "#set_context" do
+  describe "#get_context" do
     it "retrieves the context" do
       context_manager.set_context(shop_id: :expected_shop_id)
       expect(context_manager.get_context).to eq(shop_id: :expected_shop_id)

--- a/spec/unit/honeybadger/plugins/resque_spec.rb
+++ b/spec/unit/honeybadger/plugins/resque_spec.rb
@@ -37,7 +37,7 @@ describe TestWorker do
       expect {
         Honeybadger.context(badgers: true)
         described_class.on_failure_with_honeybadger(error, 1, 2, 3)
-      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
+      }.not_to change { Honeybadger.get_context }.from({})
     end
 
     describe "with worker not extending Resque::Plugins::Retry" do
@@ -119,7 +119,7 @@ describe TestWorker do
       expect {
         Honeybadger.context(badgers: true)
         described_class.after_perform_with_honeybadger
-      }.not_to change { Honeybadger::ContextManager.current.get_context }.from(nil)
+      }.not_to change { Honeybadger.get_context }.from({})
     end
   end
 end

--- a/spec/unit/honeybadger/rack/error_notifier_spec.rb
+++ b/spec/unit/honeybadger/rack/error_notifier_spec.rb
@@ -101,6 +101,6 @@ describe Honeybadger::Rack::ErrorNotifier do
 
     stack.call({})
 
-    expect(Honeybadger.get_context).to be_nil
+    expect(Honeybadger.get_context).to be_empty
   end
 end

--- a/spec/unit/honeybadger_spec.rb
+++ b/spec/unit/honeybadger_spec.rb
@@ -76,7 +76,7 @@ describe Honeybadger do
     end
 
     it "clears the context" do
-      expect { described_class.context.clear! }.to change { described_class.get_context }.from(c).to(nil)
+      expect { described_class.context.clear! }.to change { described_class.get_context }.from(c).to({})
     end
 
     context "with local context" do
@@ -104,20 +104,16 @@ describe Honeybadger do
         expect(described_class).to have_received(:get_context).at_least(:twice)
       end
 
-      it "tracks local context correctly" do
+      it "localizes global context" do
         allow(described_class).to receive(:get_context).and_call_original
 
-        begin
-          described_class.context({bar: :qux}) do
-            described_class.context({baz: :qux})
-
-            raise "exception"
-          end
-        rescue
-          # noop
+        described_class.context({bar: :baz}) do
+          described_class.context({baz: :qux})
+          expect(described_class.get_context).to eq({foo: :bar, bar: :baz, baz: :qux})
         end
+        expect(described_class.get_context).to eq({foo: :bar})
 
-        expect(described_class.get_context).to eq({foo: :bar, baz: :qux})
+        expect(described_class).to have_received(:get_context).at_least(:twice)
       end
     end
   end


### PR DESCRIPTION
See https://docs.ruby-lang.org/en/master/Fiber.html#method-c-5B-5D

Breaking changes:

- `Honeybadger.context` (without arguments) now returns `Honeybadger::ErrorContext` instead of `Honeybadger::Agent`
- Honeybadger.event_context (without arguments) now returns `Honeybadger::EventContext` instead of `Honeybadger::Agent`
- Block context now localizes global context to the block:
    ```ruby
    Honeybadger.context(job_id: 1) do
      Honeybadger.context(user_id: 2)
      Honeybadger.get_context # => {job_id: 1, user_id: 2}
    end
    Honeybadger.get_context # => {}
    ```
- MRI 3.2+
- JRuby 10+

Additions:

- `Honeybadger.execution_context`, a private API for managing Honeybadger-internal context like `request_id`, `rack_env`, etc.

Benefits:

- This is how Rails now handles request/job context (See also: #764)
- It's compatible with threads and fibers
- When using fibers, child fibers inherit the parent's context
- It generally improves our context implementation (block context is fully isolated, for example)

TODO:

- [ ] Decide if this approach works (it requires a breaking change and drops support for Ruby < 3.2 and JRuby 9)
- [ ] Do some hands-on testing with fibers, maybe with [falcon](https://github.com/socketry/falcon)?
- [ ] Test on Ruby < 3.2 w/ the [fiber-storage gem](https://github.com/ioquatix/fiber-storage) (which provides a shim)
- [ ] We could also do a beta and run this on prod