### PR TITLE
feat: add Insights instrumentation plugin for ruby_llm

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -336,6 +336,11 @@ module Honeybadger
         default: true,
         type: Boolean
       },
+      "ruby_llm.insights.enabled": {
+        description: "Enable automatic data collection for ruby_llm.",
+        default: true,
+        type: Boolean
+      },
       "active_job.attempt_threshold": {
         description: "The number of attempts before notifications will be sent.",
         default: 0,

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -337,7 +337,7 @@ module Honeybadger
         type: Boolean
       },
       "ruby_llm.insights.enabled": {
-        description: "Enable automatic data collection for ruby_llm.",
+        description: "Enable automatic data collection for RubyLLM.",
         default: true,
         type: Boolean
       },

--- a/lib/honeybadger/plugins/ruby_llm.rb
+++ b/lib/honeybadger/plugins/ruby_llm.rb
@@ -1,0 +1,117 @@
+require "honeybadger/plugin"
+
+module Honeybadger
+  module Plugins
+    module RubyLLM
+      module ProviderInstrumentation
+        def complete(messages, tools:, temperature:, model:, **kwargs, &block)
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          response = super
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
+
+          payload = {
+            event_type: "complete.ruby_llm",
+            duration: duration,
+            provider: slug,
+            model: model.id,
+            stream: !block.nil?,
+            temperature: temperature,
+            tool_count: tools.size,
+            message_count: messages.size
+          }
+
+          if response.respond_to?(:tokens) && response.tokens
+            tokens = response.tokens
+            payload[:input_tokens] = tokens.input
+            payload[:output_tokens] = tokens.output
+            payload[:cached_tokens] = tokens.cached
+            payload[:thinking_tokens] = tokens.thinking
+          end
+
+          if response.respond_to?(:tool_calls) && response.tool_calls
+            payload[:tool_call_count] = response.tool_calls.size
+          end
+
+          Honeybadger.event(payload)
+          response
+        end
+
+        def embed(text, model:, dimensions:)
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          response = super
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
+
+          payload = {
+            event_type: "embed.ruby_llm",
+            duration: duration,
+            provider: slug,
+            model: model
+          }
+
+          payload[:input_tokens] = response.input_tokens if response.respond_to?(:input_tokens)
+
+          Honeybadger.event(payload)
+          response
+        end
+
+        def paint(prompt, model:, size:)
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          response = super
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
+
+          Honeybadger.event(
+            event_type: "paint.ruby_llm",
+            duration: duration,
+            provider: slug,
+            model: model,
+            size: size
+          )
+          response
+        end
+
+        def transcribe(audio_file, model:, language:, **options)
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          response = super
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
+
+          Honeybadger.event(
+            event_type: "transcribe.ruby_llm",
+            duration: duration,
+            provider: slug,
+            model: model,
+            language: language
+          )
+          response
+        end
+      end
+
+      module ChatInstrumentation
+        private
+
+        def execute_tool(tool_call)
+          started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result = super
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
+
+          Honeybadger.event(
+            event_type: "tool_call.ruby_llm",
+            duration: duration,
+            tool_name: tool_call.name
+          )
+          result
+        end
+      end
+
+      Plugin.register :ruby_llm do
+        requirement { defined?(::RubyLLM::Provider) }
+
+        execution do
+          if config.load_plugin_insights?(:ruby_llm)
+            ::RubyLLM::Provider.prepend(ProviderInstrumentation)
+            ::RubyLLM::Chat.prepend(ChatInstrumentation)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/honeybadger/plugins/ruby_llm.rb
+++ b/lib/honeybadger/plugins/ruby_llm.rb
@@ -9,11 +9,12 @@ module Honeybadger
           response = super
           duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
 
+          model_id = model.respond_to?(:id) ? model.id : model
+
           payload = {
-            event_type: "complete.ruby_llm",
             duration: duration,
             provider: slug,
-            model: model.id,
+            model: model_id,
             stream: !block.nil?,
             temperature: temperature,
             tool_count: tools.size,
@@ -32,17 +33,16 @@ module Honeybadger
             payload[:tool_call_count] = response.tool_calls.size
           end
 
-          Honeybadger.event(payload)
+          Honeybadger.event("complete.ruby_llm", payload)
           response
         end
 
-        def embed(text, model:, dimensions:)
+        def embed(text, model:, dimensions:, **kwargs)
           started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           response = super
           duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
 
           payload = {
-            event_type: "embed.ruby_llm",
             duration: duration,
             provider: slug,
             model: model
@@ -50,37 +50,37 @@ module Honeybadger
 
           payload[:input_tokens] = response.input_tokens if response.respond_to?(:input_tokens)
 
-          Honeybadger.event(payload)
+          Honeybadger.event("embed.ruby_llm", payload)
           response
         end
 
-        def paint(prompt, model:, size:)
+        def paint(prompt, model:, size:, **kwargs)
           started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           response = super
           duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
 
-          Honeybadger.event(
-            event_type: "paint.ruby_llm",
+          Honeybadger.event("paint.ruby_llm", {
             duration: duration,
             provider: slug,
             model: model,
             size: size
-          )
+          })
           response
         end
 
-        def transcribe(audio_file, model:, language:, **options)
+        def transcribe(audio_file, model:, **kwargs)
           started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           response = super
           duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
 
-          Honeybadger.event(
-            event_type: "transcribe.ruby_llm",
+          payload = {
             duration: duration,
             provider: slug,
-            model: model,
-            language: language
-          )
+            model: model
+          }
+          payload[:language] = kwargs[:language] if kwargs[:language]
+
+          Honeybadger.event("transcribe.ruby_llm", payload)
           response
         end
       end
@@ -93,17 +93,16 @@ module Honeybadger
           result = super
           duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round(2)
 
-          Honeybadger.event(
-            event_type: "tool_call.ruby_llm",
+          Honeybadger.event("tool_call.ruby_llm", {
             duration: duration,
             tool_name: tool_call.name
-          )
+          })
           result
         end
       end
 
       Plugin.register :ruby_llm do
-        requirement { defined?(::RubyLLM::Provider) }
+        requirement { defined?(::RubyLLM::Provider) && defined?(::RubyLLM::Chat) }
 
         execution do
           if config.load_plugin_insights?(:ruby_llm)

--- a/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
+++ b/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
@@ -25,15 +25,15 @@ describe "RubyLLM Plugin" do
           "response"
         end
 
-        def embed(text, model:, dimensions:)
+        def embed(text, model:, dimensions:, **kwargs)
           "embedding"
         end
 
-        def paint(prompt, model:, size:)
+        def paint(prompt, model:, size:, **kwargs)
           "image"
         end
 
-        def transcribe(audio_file, model:, language:, **options)
+        def transcribe(audio_file, model:, **kwargs)
           "transcription"
         end
       end
@@ -61,7 +61,7 @@ describe "RubyLLM Plugin" do
     end
 
     after do
-      # Remove prepended modules by restoring original classes
+      # Remove the RubyLLM constant so the requirement check can be re-evaluated
       Object.send(:remove_const, :RubyLLM)
     end
 
@@ -122,15 +122,15 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
         @response
       end
 
-      def embed(text, model:, dimensions:)
+      def embed(text, model:, dimensions:, **kwargs)
         @embed_response
       end
 
-      def paint(prompt, model:, size:)
+      def paint(prompt, model:, size:, **kwargs)
         @paint_response
       end
 
-      def transcribe(audio_file, model:, language:, **options)
+      def transcribe(audio_file, model:, **kwargs)
         @transcribe_response
       end
     end.prepend(described_class)
@@ -150,8 +150,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "calls Honeybadger.event with complete payload" do
       provider.complete(["msg1", "msg2"], tools: [:tool1], temperature: 0.7, model: model_info)
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(
-        event_type: "complete.ruby_llm",
+      expect(Honeybadger).to have_received(:event).with("complete.ruby_llm", hash_including(
         provider: "openai",
         model: "gpt-4o",
         stream: false,
@@ -169,7 +168,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "includes duration" do
       provider.complete(["msg"], tools: [], temperature: 0.5, model: model_info)
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(
+      expect(Honeybadger).to have_received(:event).with("complete.ruby_llm", hash_including(
         duration: a_kind_of(Numeric)
       ))
     end
@@ -182,7 +181,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "detects streaming when a block is given" do
       provider.complete(["msg"], tools: [], temperature: 0.5, model: model_info) { |chunk| }
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(stream: true))
+      expect(Honeybadger).to have_received(:event).with("complete.ruby_llm", hash_including(stream: true))
     end
   end
 
@@ -196,8 +195,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "calls Honeybadger.event with embed payload" do
       provider.embed("hello", model: "text-embedding-3-small", dimensions: 1536)
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(
-        event_type: "embed.ruby_llm",
+      expect(Honeybadger).to have_received(:event).with("embed.ruby_llm", hash_including(
         provider: "openai",
         model: "text-embedding-3-small",
         input_tokens: 42
@@ -220,8 +218,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "calls Honeybadger.event with paint payload" do
       provider.paint("a cat", model: "dall-e-3", size: "1024x1024")
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(
-        event_type: "paint.ruby_llm",
+      expect(Honeybadger).to have_received(:event).with("paint.ruby_llm", hash_including(
         provider: "openai",
         model: "dall-e-3",
         size: "1024x1024"
@@ -244,8 +241,7 @@ describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
     it "calls Honeybadger.event with transcribe payload" do
       provider.transcribe("audio.mp3", model: "whisper-1", language: "en")
 
-      expect(Honeybadger).to have_received(:event).with(hash_including(
-        event_type: "transcribe.ruby_llm",
+      expect(Honeybadger).to have_received(:event).with("transcribe.ruby_llm", hash_including(
         provider: "openai",
         model: "whisper-1",
         language: "en"
@@ -281,8 +277,7 @@ describe Honeybadger::Plugins::RubyLLM::ChatInstrumentation do
   it "calls Honeybadger.event with tool_call payload" do
     chat.send(:execute_tool, tool_call)
 
-    expect(Honeybadger).to have_received(:event).with(hash_including(
-      event_type: "tool_call.ruby_llm",
+    expect(Honeybadger).to have_received(:event).with("tool_call.ruby_llm", hash_including(
       tool_name: "search",
       duration: a_kind_of(Numeric)
     ))

--- a/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
+++ b/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
@@ -1,0 +1,295 @@
+require "honeybadger/plugins/ruby_llm"
+require "honeybadger/config"
+
+describe "RubyLLM Plugin" do
+  let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }
+
+  before do
+    Honeybadger::Plugin.instances[:ruby_llm].reset!
+  end
+
+  context "when ruby_llm is not installed" do
+    it "fails quietly" do
+      expect { Honeybadger::Plugin.instances[:ruby_llm].load!(config) }.not_to raise_error
+    end
+  end
+
+  context "when ruby_llm is installed" do
+    let(:provider_class) do
+      Class.new do
+        def slug
+          "test"
+        end
+
+        def complete(messages, tools:, temperature:, model:, **kwargs, &block)
+          "response"
+        end
+
+        def embed(text, model:, dimensions:)
+          "embedding"
+        end
+
+        def paint(prompt, model:, size:)
+          "image"
+        end
+
+        def transcribe(audio_file, model:, language:, **options)
+          "transcription"
+        end
+      end
+    end
+
+    let(:chat_class) do
+      Class.new do
+        private
+
+        def execute_tool(tool_call)
+          "result"
+        end
+      end
+    end
+
+    let(:ruby_llm_shim) do
+      mod = Module.new
+      mod.const_set(:Provider, provider_class)
+      mod.const_set(:Chat, chat_class)
+      mod
+    end
+
+    before do
+      Object.const_set(:RubyLLM, ruby_llm_shim)
+    end
+
+    after do
+      # Remove prepended modules by restoring original classes
+      Object.send(:remove_const, :RubyLLM)
+    end
+
+    context "when insights are enabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true) }
+
+      it "prepends instrumentation on Provider" do
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+        expect(provider_class.ancestors).to include(Honeybadger::Plugins::RubyLLM::ProviderInstrumentation)
+      end
+
+      it "prepends instrumentation on Chat" do
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+        expect(chat_class.ancestors).to include(Honeybadger::Plugins::RubyLLM::ChatInstrumentation)
+      end
+    end
+
+    context "when insights are disabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": false) }
+
+      it "does not prepend instrumentation" do
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+        expect(provider_class.ancestors).not_to include(Honeybadger::Plugins::RubyLLM::ProviderInstrumentation)
+      end
+    end
+
+    context "when ruby_llm insights are disabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": false) }
+
+      it "does not prepend instrumentation" do
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+        expect(provider_class.ancestors).not_to include(Honeybadger::Plugins::RubyLLM::ProviderInstrumentation)
+      end
+    end
+  end
+end
+
+describe Honeybadger::Plugins::RubyLLM::ProviderInstrumentation do
+  let(:model_info) do
+    double("ModelInfo", id: "gpt-4o")
+  end
+
+  let(:tokens) do
+    double("Tokens", input: 100, output: 50, cached: 10, thinking: 5)
+  end
+
+  let(:response) do
+    double("Message", tokens: tokens, tool_calls: [double("ToolCall")])
+  end
+
+  let(:provider_class) do
+    Class.new do
+      def slug
+        "openai"
+      end
+
+      def complete(messages, tools:, temperature:, model:, **kwargs, &block)
+        @response
+      end
+
+      def embed(text, model:, dimensions:)
+        @embed_response
+      end
+
+      def paint(prompt, model:, size:)
+        @paint_response
+      end
+
+      def transcribe(audio_file, model:, language:, **options)
+        @transcribe_response
+      end
+    end.prepend(described_class)
+  end
+
+  let(:provider) { provider_class.new }
+
+  before do
+    allow(Honeybadger).to receive(:event)
+  end
+
+  describe "#complete" do
+    before do
+      provider.instance_variable_set(:@response, response)
+    end
+
+    it "calls Honeybadger.event with complete payload" do
+      provider.complete(["msg1", "msg2"], tools: [:tool1], temperature: 0.7, model: model_info)
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(
+        event_type: "complete.ruby_llm",
+        provider: "openai",
+        model: "gpt-4o",
+        stream: false,
+        temperature: 0.7,
+        tool_count: 1,
+        message_count: 2,
+        input_tokens: 100,
+        output_tokens: 50,
+        cached_tokens: 10,
+        thinking_tokens: 5,
+        tool_call_count: 1
+      ))
+    end
+
+    it "includes duration" do
+      provider.complete(["msg"], tools: [], temperature: 0.5, model: model_info)
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(
+        duration: a_kind_of(Numeric)
+      ))
+    end
+
+    it "returns the response" do
+      result = provider.complete(["msg"], tools: [], temperature: 0.5, model: model_info)
+      expect(result).to eq(response)
+    end
+
+    it "detects streaming when a block is given" do
+      provider.complete(["msg"], tools: [], temperature: 0.5, model: model_info) { |chunk| }
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(stream: true))
+    end
+  end
+
+  describe "#embed" do
+    let(:embed_response) { double("Embedding", input_tokens: 42) }
+
+    before do
+      provider.instance_variable_set(:@embed_response, embed_response)
+    end
+
+    it "calls Honeybadger.event with embed payload" do
+      provider.embed("hello", model: "text-embedding-3-small", dimensions: 1536)
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(
+        event_type: "embed.ruby_llm",
+        provider: "openai",
+        model: "text-embedding-3-small",
+        input_tokens: 42
+      ))
+    end
+
+    it "returns the response" do
+      result = provider.embed("hello", model: "text-embedding-3-small", dimensions: 1536)
+      expect(result).to eq(embed_response)
+    end
+  end
+
+  describe "#paint" do
+    let(:paint_response) { double("Image") }
+
+    before do
+      provider.instance_variable_set(:@paint_response, paint_response)
+    end
+
+    it "calls Honeybadger.event with paint payload" do
+      provider.paint("a cat", model: "dall-e-3", size: "1024x1024")
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(
+        event_type: "paint.ruby_llm",
+        provider: "openai",
+        model: "dall-e-3",
+        size: "1024x1024"
+      ))
+    end
+
+    it "returns the response" do
+      result = provider.paint("a cat", model: "dall-e-3", size: "1024x1024")
+      expect(result).to eq(paint_response)
+    end
+  end
+
+  describe "#transcribe" do
+    let(:transcribe_response) { double("Transcription") }
+
+    before do
+      provider.instance_variable_set(:@transcribe_response, transcribe_response)
+    end
+
+    it "calls Honeybadger.event with transcribe payload" do
+      provider.transcribe("audio.mp3", model: "whisper-1", language: "en")
+
+      expect(Honeybadger).to have_received(:event).with(hash_including(
+        event_type: "transcribe.ruby_llm",
+        provider: "openai",
+        model: "whisper-1",
+        language: "en"
+      ))
+    end
+
+    it "returns the response" do
+      result = provider.transcribe("audio.mp3", model: "whisper-1", language: "en")
+      expect(result).to eq(transcribe_response)
+    end
+  end
+end
+
+describe Honeybadger::Plugins::RubyLLM::ChatInstrumentation do
+  let(:tool_call) { double("ToolCall", name: "search") }
+
+  let(:chat_class) do
+    Class.new do
+      private
+
+      def execute_tool(tool_call)
+        "tool result"
+      end
+    end.prepend(described_class)
+  end
+
+  let(:chat) { chat_class.new }
+
+  before do
+    allow(Honeybadger).to receive(:event)
+  end
+
+  it "calls Honeybadger.event with tool_call payload" do
+    chat.send(:execute_tool, tool_call)
+
+    expect(Honeybadger).to have_received(:event).with(hash_including(
+      event_type: "tool_call.ruby_llm",
+      tool_name: "search",
+      duration: a_kind_of(Numeric)
+    ))
+  end
+
+  it "returns the result" do
+    result = chat.send(:execute_tool, tool_call)
+    expect(result).to eq("tool result")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new Honeybadger plugin that instruments `RubyLLM::Provider` and `RubyLLM::Chat` using `Module#prepend`
- Emits Insights events (`complete.ruby_llm`, `embed.ruby_llm`, `paint.ruby_llm`, `transcribe.ruby_llm`, `tool_call.ruby_llm`) with timing and usage metadata
- Adds `ruby_llm.insights.enabled` config option (default: `true`)
- No changes required to the ruby_llm gem; no ActiveSupport dependency

## Test plan
- [x] `bundle exec rspec spec/unit/honeybadger/plugins/ruby_llm_spec.rb` — 17 examples, 0 failures
- [x] `bundle exec standardrb --no-fix` — no offenses
- [ ] Manual verification with a ruby_llm application

🤖 Generated with [Claude Code](https://claude.com/claude-code)