### PR TITLE
Backport Insights improvements to 5.x

### DIFF
--- a/lib/honeybadger/agent.rb
+++ b/lib/honeybadger/agent.rb
@@ -413,6 +413,7 @@ module Honeybadger
       extra_payload = {}.tap do |p|
         p[:request_id] = context_manager.get_request_id if context_manager.get_request_id
         p[:hostname] = config[:hostname].to_s if config[:'events.attach_hostname']
+        p[:environment] = config[:env].to_s if config[:'events.attach_environment'] && config[:env].to_s.length > 0
         p.update(context_manager.get_event_context || {})
       end
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -36,7 +36,13 @@ module Honeybadger
       { event_type: 'sql.active_record', query: /^(begin|commit)( immediate)?( transaction)?$/i },
       { event_type: 'sql.active_record', query: /(solid_queue|good_job)/i },
       { event_type: 'sql.active_record', name: /^GoodJob/ },
-      { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' }
+      { event_type: 'process_action.action_controller', controller: 'Rails::HealthController' },
+      { event_type: 'cache_exist?.active_support' },
+      { event_type: 'cache_write.active_support' },
+      { event_type: 'cache_generate.active_support' },
+      { event_type: 'cache_delete.active_support' },
+      { event_type: 'cache_increment.active_support' },
+      { event_type: 'cache_decrement.active_support' }
     ].freeze
 
     DEVELOPMENT_ENVIRONMENTS = ['development', 'test', 'cucumber'].map(&:freeze).freeze

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -532,6 +532,11 @@ module Honeybadger
         description: 'Enable automatic metric data aggregation for Autotuner stats.',
         default: false,
         type: Boolean
+      },
+      :'flipper.insights.enabled' => {
+        description: 'Enable automatic data collection for Flipper.',
+        default: true,
+        type: Boolean
       }
     }.freeze
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -125,6 +125,11 @@ module Honeybadger
         default: true,
         type: Boolean
       },
+      :'events.attach_environment' => {
+        description: 'Add the environment to all event payloads.',
+        default: true,
+        type: Boolean
+      },
       :'events.ignore' => {
         description: 'A list of additional events to ignore. Use a hash to query nested payloads, match using a string or regex. Non-hash will match on the event_type.',
         default: IGNORE_EVENTS_DEFAULT,

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -137,9 +137,13 @@ module Honeybadger
     def kill!
       d { 'killing worker thread' }
 
+      if timeout_thread
+        Thread.kill(timeout_thread)
+        timeout_thread.join # Allow ensure blocks to execute.
+      end
+
       if thread
         Thread.kill(thread)
-        Thread.kill(timeout_thread)
         thread.join # Allow ensure blocks to execute.
       end
 

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -137,14 +137,12 @@ module Honeybadger
     def kill!
       d { 'killing worker thread' }
 
-      current_thread = ::Thread.current
-
-      if timeout_thread && timeout_thread != current_thread
+      if timeout_thread
         Thread.kill(timeout_thread)
         timeout_thread.join # Allow ensure blocks to execute.
       end
 
-      if thread && thread != current_thread
+      if thread
         Thread.kill(thread)
         thread.join # Allow ensure blocks to execute.
       end

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -286,28 +286,28 @@ module Honeybadger
       case response.code
       when 429, 503
         throttle = inc_throttle
-        warn { sprintf('Event send failed: project is sending too many events. code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
+        debug { sprintf('Insights Event send failed: project is sending too many events. code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
         suspend(3600)
       when 402
-        warn { sprintf('Event send failed: payment is required. code=%s', response.code) }
+        warn { sprintf('Insights Event send failed: payment is required. code=%s', response.code) }
         suspend(3600)
       when 403
-        warn { sprintf('Event send failed: API key is invalid. code=%s', response.code) }
+        warn { sprintf('Insights Event send failed: API key is invalid. code=%s', response.code) }
         suspend(3600)
       when 413
-        warn { sprintf('Event send failed: Payload is too large. code=%s', response.code) }
+        warn { sprintf('Insights Event send failed: Payload is too large. code=%s', response.code) }
       when 201
         if throttle = dec_throttle
-          debug { sprintf('Success ⚡ Event sent code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
+          debug { sprintf('Success ⚡ Insights Event sent code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
         else
-          debug { sprintf('Success ⚡ Event sent code=%s', response.code) }
+          debug { sprintf('Success ⚡ Insights Event sent code=%s', response.code) }
         end
       when :stubbed
-        info { sprintf('Success ⚡ Development mode is enabled; This event will be sent after app is deployed.') }
+        info { 'Success ⚡ Development mode is enabled; This event will be sent after app is deployed.' }
       when :error
-        warn { sprintf('Event send failed: an unknown error occurred. code=%s error=%s', response.code, response.message.to_s.dump) }
+        warn { sprintf('Insights Event send failed: an unknown error occurred. code=%s error=%s', response.code, response.message.to_s.dump) }
       else
-        warn { sprintf('Event send failed: unknown response from server. code=%s', response.code) }
+        warn { sprintf('Insights Event send failed: unknown response from server. code=%s', response.code) }
       end
     end
 

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -137,12 +137,14 @@ module Honeybadger
     def kill!
       d { 'killing worker thread' }
 
-      if timeout_thread
+      current_thread = ::Thread.current
+
+      if timeout_thread && timeout_thread != current_thread
         Thread.kill(timeout_thread)
         timeout_thread.join # Allow ensure blocks to execute.
       end
 
-      if thread
+      if thread && thread != current_thread
         Thread.kill(thread)
         thread.join # Allow ensure blocks to execute.
       end

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -287,6 +287,7 @@ module Honeybadger
       when 429, 503
         throttle = inc_throttle
         warn { sprintf('Event send failed: project is sending too many events. code=%s throttle=%s interval=%s', response.code, throttle, throttle_interval) }
+        suspend(3600)
       when 402
         warn { sprintf('Event send failed: payment is required. code=%s', response.code) }
         suspend(3600)

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -109,6 +109,7 @@ module Honeybadger
     def format_payload(payload)
       {
         query: Util::SQL.obfuscate(payload[:sql], payload[:connection]&.adapter_name),
+        cached: payload[:cached],
         async: payload[:async]
       }
     end

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -122,13 +122,26 @@ module Honeybadger
   class ActiveJobSubscriber < NotificationSubscriber
     def format_payload(payload)
       job = payload[:job]
+      jobs = payload[:jobs]
       adapter = payload[:adapter]
-      payload.except(:job, :adapter).merge({
-        adapter_class: adapter.class.to_s,
-        job_class: job.class.to_s,
-        job_id: job.job_id,
-        queue_name: job.queue_name
+
+      base_payload = payload.except(:job, :jobs, :adapter).merge({
+        adapter_class: adapter&.class&.to_s
       })
+
+      if jobs
+        base_payload.merge({
+          jobs: jobs.compact.map { |j| { job_class: j.class.to_s, job_id: j.job_id, queue_name: j.queue_name } }
+        })
+      elsif job
+        base_payload.merge({
+          job_class: job.class.to_s,
+          job_id: job.job_id,
+          queue_name: job.queue_name
+        })
+      else
+        base_payload
+      end
     end
   end
 

--- a/lib/honeybadger/plugins/delayed_job.rb
+++ b/lib/honeybadger/plugins/delayed_job.rb
@@ -15,7 +15,7 @@ module Honeybadger
     end
 
     execution do
-      return unless Honeybadger.config[:'exceptions.enabled']
+      next unless Honeybadger.config[:'exceptions.enabled']
       require 'honeybadger/plugins/delayed_job/plugin'
       ::Delayed::Worker.plugins << Plugins::DelayedJob::Plugin
     end

--- a/lib/honeybadger/plugins/faktory.rb
+++ b/lib/honeybadger/plugins/faktory.rb
@@ -15,7 +15,7 @@ module Honeybadger
         requirement { defined?(::Faktory) }
 
         execution do
-          return unless Honeybadger.config[:'exceptions.enabled']
+          next unless Honeybadger.config[:'exceptions.enabled']
           ::Faktory.configure_worker do |faktory|
             faktory.worker_middleware do |chain|
               chain.prepend Middleware

--- a/lib/honeybadger/plugins/flipper.rb
+++ b/lib/honeybadger/plugins/flipper.rb
@@ -1,0 +1,33 @@
+require 'honeybadger/notification_subscriber'
+
+module Honeybadger
+  module Plugins
+    module Flipper
+      Plugin.register :flipper do
+        requirement { defined?(::Flipper) }
+        requirement { defined?(::ActiveSupport::Notifications) }
+
+        execution do
+          if config.load_plugin_insights?(:flipper)
+            ::ActiveSupport::Notifications.subscribe(
+              'feature_operation.flipper',
+              Honeybadger::FlipperSubscriber.new
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+module Honeybadger
+  class FlipperSubscriber < NotificationSubscriber
+    def format_payload(payload)
+      payload.slice(:feature_name, :operation, :result)
+    end
+
+    def record(name, payload)
+      Honeybadger.event(name, payload)
+    end
+  end
+end

--- a/lib/honeybadger/plugins/resque.rb
+++ b/lib/honeybadger/plugins/resque.rb
@@ -64,7 +64,7 @@ module Honeybadger
         end
 
         execution do
-          return unless Honeybadger.config[:'exceptions.enabled']
+          next unless Honeybadger.config[:'exceptions.enabled']
           ::Resque::Job.send(:include, Installer)
         end
       end

--- a/lib/honeybadger/plugins/shoryuken.rb
+++ b/lib/honeybadger/plugins/shoryuken.rb
@@ -40,7 +40,7 @@ module Honeybadger
         requirement { defined?(::Shoryuken) }
 
         execution do
-          return unless Honeybadger.config[:'exceptions.enabled']
+          next unless Honeybadger.config[:'exceptions.enabled']
           ::Shoryuken.configure_server do |config|
             config.server_middleware do |chain|
               chain.add Middleware

--- a/lib/honeybadger/plugins/sucker_punch.rb
+++ b/lib/honeybadger/plugins/sucker_punch.rb
@@ -6,7 +6,7 @@ module Honeybadger
     requirement { defined?(::SuckerPunch) }
 
     execution do
-      return unless Honeybadger.config[:'exceptions.enabled']
+      next unless Honeybadger.config[:'exceptions.enabled']
       if SuckerPunch.respond_to?(:exception_handler=) # >= v2
         SuckerPunch.exception_handler = ->(ex, klass, args) { Honeybadger.notify(ex, { :component => klass, :parameters => args }) }
       else

--- a/lib/honeybadger/plugins/thor.rb
+++ b/lib/honeybadger/plugins/thor.rb
@@ -25,7 +25,7 @@ module Honeybadger
       requirement { defined?(::Thor.no_commands) }
 
       execution do
-        return unless Honeybadger.config[:'exceptions.enabled']
+        next unless Honeybadger.config[:'exceptions.enabled']
         ::Thor.send(:include, Thor)
       end
     end


### PR DESCRIPTION
## Summary

- Backports 9 Insights-related improvements from the 6.x series onto v5.29.1 for customers who cannot yet upgrade to Ruby 3.0+
- Includes bug fixes (thread leak, LocalJumpError, logging noise), performance improvements (ignore high-volume cache events, suspend on 429), and new features (environment in event payloads, Flipper plugin, cached attribute on AR events, batch job payloads)
- All changes were manually ported to preserve the v5.x single-quote code style (the 6.x series had a full standardrb reformat)

## Backported changes

| Original | Type | Description |
|----------|------|-------------|
| f49977a | fix | Replace `return` with `next` in execution blocks to prevent LocalJumpError |
| 91c7fc2 | fix | Log fewer 429 responses in events worker (suspend 1hr) |
| cc4756d | fix | Reduce Insights logging (prefix messages, downgrade 429 to debug) |
| 09ad0f7 | fix | Prevent thread leak in EventsWorker#kill! |
| 1f7c757 | perf | Ignore cache_* ActiveSupport events by default |
| cc22434 | fix | Allow jobs in Active Job subscriber payloads |
| 09d7cd6 | feat | Add cached attribute to ActiveRecordSubscriber |
| 97d1db1 | feat | Attach environment to Insights event payloads |
| 12d5010 | feat | Send Flipper events to Insights |

## Not backported

- Enabling Insights by default (intentionally omitted)
- MetricsWorker-dependent changes (too much new infrastructure)
- Rails.event subscriber (added then removed in 6.x, net zero)

## Test plan

- [x] All 840 unit tests pass on Ruby 2.7.8 + Rails 5.1
- [ ] Manual smoke test with a Ruby 2.7 / Rails 5.1 app sending Insights events
- [ ] Verify Flipper plugin activates when Flipper gem is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)