### PR TITLE
fix: guard against joining current thread in worker kill! methods

### DIFF
--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -137,12 +137,14 @@ module Honeybadger
     def kill!
       d { "killing worker thread" }
 
-      if timeout_thread
+      current_thread = ::Thread.current
+
+      if timeout_thread && timeout_thread != current_thread
         Thread.kill(timeout_thread)
         timeout_thread.join # Allow ensure blocks to execute.
       end
 
-      if thread
+      if thread && thread != current_thread
         Thread.kill(thread)
         thread.join # Allow ensure blocks to execute.
       end

--- a/lib/honeybadger/metrics_worker.rb
+++ b/lib/honeybadger/metrics_worker.rb
@@ -103,7 +103,7 @@ module Honeybadger
     def kill!
       d { "killing worker thread" }
 
-      if thread
+      if thread && thread != ::Thread.current
         Thread.kill(thread)
         thread.join # Allow ensure blocks to execute.
       end

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -127,7 +127,7 @@ module Honeybadger
     def kill!
       d { "killing worker thread" }
 
-      if thread
+      if thread && thread != ::Thread.current
         Thread.kill(thread)
         thread.join # Allow ensure blocks to execute.
       end


### PR DESCRIPTION
## Summary

- When `suspend()` is called from the worker thread (e.g., on a 429/503 response), it invokes `kill!`, which calls `thread.join` on the current thread. This raises `ThreadError` ("Target thread must not be current thread").
- Adds a `thread != ::Thread.current` guard before joining in all three workers: `EventsWorker`, `Worker`, and `MetricsWorker`.
- Originally identified via Copilot review on #808 and applied to the 5.x backport; this PR brings the fix to master for all affected workers.

## Test plan

- [ ] Verify existing worker tests pass
- [ ] Confirm `suspend` → `kill!` path no longer raises `ThreadError` when called from the worker thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)