### PR TITLE
fix: avoid duplicate BroadcastLogger breadcrumbs

### DIFF
--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -1,12 +1,23 @@
+require "logger"
 require "honeybadger/util/sanitizer"
 
 module Honeybadger
   module Breadcrumbs
     # @api private
     #
-    module LogWrapper
-      def add(severity, message = nil, progname = nil)
-        org_severity, org_message, org_progname = severity, message, progname
+    module LogHelper
+      LOG_SEVERITY_LABELS = {
+        ::Logger::DEBUG => "DEBUG",
+        ::Logger::INFO => "INFO",
+        ::Logger::WARN => "WARN",
+        ::Logger::ERROR => "ERROR",
+        ::Logger::FATAL => "FATAL",
+        ::Logger::UNKNOWN => "ANY"
+      }.freeze
+
+      private
+
+      def add_log_breadcrumb(severity, message = nil, progname = nil)
         if defined?(Dry::Logger::Entry) && progname.is_a?(Dry::Logger::Entry) # Hanami uses dry-logger
           message, progname = progname.message || progname.exception, progname.progname
         elsif message.nil?
@@ -15,21 +26,78 @@ module Honeybadger
         message &&= Util::Sanitizer.sanitize(message.to_s)&.strip
         unless should_ignore_log?(message, progname)
           Honeybadger.add_breadcrumb(message, category: :log, metadata: {
-            severity: format_severity(severity),
+            severity: log_severity_label(severity),
             progname: progname
           })
         end
-
-        super(org_severity, org_message, org_progname)
       end
 
-      private
+      def log_severity_label(severity)
+        if self.class.method_defined?(:format_severity) || self.class.private_method_defined?(:format_severity)
+          return format_severity(severity)
+        end
+
+        LOG_SEVERITY_LABELS.fetch(severity, severity)
+      end
 
       def should_ignore_log?(message, progname)
         message.nil? ||
           message == "" ||
           Thread.current[:__hb_within_log_subscriber] ||
+          Thread.current[:__hb_within_broadcast_logger] ||
           progname == "honeybadger"
+      end
+    end
+
+    module LogWrapper
+      include LogHelper
+
+      def add(severity, message = nil, progname = nil, &block)
+        org_severity, org_message, org_progname = severity, message, progname
+        add_log_breadcrumb(severity, message, progname)
+
+        super(org_severity, org_message, org_progname, &block)
+      end
+    end
+
+    # @api private
+    #
+    # ActiveSupport::BroadcastLogger forwards one logical log event to multiple
+    # Logger instances. Wrapping it separately records the event once while
+    # silencing the sink loggers for the duration of the broadcast.
+    module BroadcastLogWrapper
+      include LogHelper
+
+      LOG_METHOD_SEVERITIES = {
+        debug: ::Logger::DEBUG,
+        info: ::Logger::INFO,
+        warn: ::Logger::WARN,
+        error: ::Logger::ERROR,
+        fatal: ::Logger::FATAL,
+        unknown: ::Logger::UNKNOWN
+      }.freeze
+
+      def add(severity, message = nil, progname = nil, &block)
+        add_log_breadcrumb(severity, message, progname)
+        without_sink_breadcrumbs { super(severity, message, progname, &block) }
+      end
+      alias_method :log, :add
+
+      LOG_METHOD_SEVERITIES.each do |level, severity|
+        define_method(level) do |progname = nil, &block|
+          add_log_breadcrumb(severity, nil, progname)
+          without_sink_breadcrumbs { super(progname, &block) }
+        end
+      end
+
+      private
+
+      def without_sink_breadcrumbs
+        previous = Thread.current[:__hb_within_broadcast_logger]
+        Thread.current[:__hb_within_broadcast_logger] = true
+        yield
+      ensure
+        Thread.current[:__hb_within_broadcast_logger] = previous
       end
     end
 

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -113,7 +113,7 @@ module Honeybadger
           Thread.current[:__hb_within_log_subscriber] = true
           super(*args, &block)
         ensure
-          Thread.current[:__hb_within_log_subscriber] = previous.nil? ? false : previous
+          Thread.current[:__hb_within_log_subscriber] = previous
         end
       end
     end

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -33,9 +33,7 @@ module Honeybadger
       end
 
       def log_severity_label(severity)
-        if self.class.method_defined?(:format_severity) || self.class.private_method_defined?(:format_severity)
-          return format_severity(severity)
-        end
+        return format_severity(severity) if respond_to?(:format_severity, true)
 
         LOG_SEVERITY_LABELS.fetch(severity, severity)
       end

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -33,7 +33,9 @@ module Honeybadger
       end
 
       def log_severity_label(severity)
-        return format_severity(severity) if respond_to?(:format_severity, true)
+        if self.class.method_defined?(:format_severity) || self.class.private_method_defined?(:format_severity)
+          return format_severity(severity)
+        end
 
         LOG_SEVERITY_LABELS.fetch(severity, severity)
       end

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -109,10 +109,11 @@ module Honeybadger
     module LogSubscriberInjector
       %w[info debug warn error fatal unknown].each do |level|
         define_method(level) do |*args, &block|
+          previous = Thread.current[:__hb_within_log_subscriber]
           Thread.current[:__hb_within_log_subscriber] = true
           super(*args, &block)
         ensure
-          Thread.current[:__hb_within_log_subscriber] = false
+          Thread.current[:__hb_within_log_subscriber] = previous
         end
       end
     end

--- a/lib/honeybadger/breadcrumbs/logging.rb
+++ b/lib/honeybadger/breadcrumbs/logging.rb
@@ -113,7 +113,7 @@ module Honeybadger
           Thread.current[:__hb_within_log_subscriber] = true
           super(*args, &block)
         ensure
-          Thread.current[:__hb_within_log_subscriber] = previous
+          Thread.current[:__hb_within_log_subscriber] = previous.nil? ? false : previous
         end
       end
     end

--- a/lib/honeybadger/plugins/breadcrumbs.rb
+++ b/lib/honeybadger/plugins/breadcrumbs.rb
@@ -51,6 +51,7 @@ module Honeybadger
             RailsBreadcrumbs.subscribe_to_notification(name, config)
           end
           ActiveSupport::LogSubscriber.prepend(Honeybadger::Breadcrumbs::LogSubscriberInjector) if config[:"breadcrumbs.logging.enabled"]
+          ActiveSupport::BroadcastLogger.prepend(Honeybadger::Breadcrumbs::BroadcastLogWrapper) if config[:"breadcrumbs.logging.enabled"] && defined?(ActiveSupport::BroadcastLogger)
         end
 
         ::Logger.prepend(Honeybadger::Breadcrumbs::LogWrapper) if config[:"breadcrumbs.logging.enabled"]

--- a/lib/honeybadger/plugins/breadcrumbs.rb
+++ b/lib/honeybadger/plugins/breadcrumbs.rb
@@ -50,8 +50,11 @@ module Honeybadger
           config[:"breadcrumbs.active_support_notifications"].each do |name, config|
             RailsBreadcrumbs.subscribe_to_notification(name, config)
           end
-          ActiveSupport::LogSubscriber.prepend(Honeybadger::Breadcrumbs::LogSubscriberInjector) if config[:"breadcrumbs.logging.enabled"]
-          ActiveSupport::BroadcastLogger.prepend(Honeybadger::Breadcrumbs::BroadcastLogWrapper) if config[:"breadcrumbs.logging.enabled"] && defined?(ActiveSupport::BroadcastLogger)
+
+          if config[:"breadcrumbs.logging.enabled"]
+            ActiveSupport::LogSubscriber.prepend(Honeybadger::Breadcrumbs::LogSubscriberInjector)
+            ActiveSupport::BroadcastLogger.prepend(Honeybadger::Breadcrumbs::BroadcastLogWrapper) if defined?(ActiveSupport::BroadcastLogger)
+          end
         end
 
         ::Logger.prepend(Honeybadger::Breadcrumbs::LogWrapper) if config[:"breadcrumbs.logging.enabled"]

--- a/spec/unit/honeybadger/breadcrumbs/log_subscriber_injector_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/log_subscriber_injector_spec.rb
@@ -19,9 +19,12 @@ describe Honeybadger::Breadcrumbs::LogSubscriberInjector do
 
   subject { logger.new }
 
-  it "resets __hb_within_log_subscriber to false" do
+  before { Thread.current[:__hb_within_log_subscriber] = nil }
+  after { Thread.current[:__hb_within_log_subscriber] = nil }
+
+  it "restores __hb_within_log_subscriber to its prior value" do
     subject.info "test"
-    expect(Thread.current[:__hb_within_log_subscriber]).to eq(false)
+    expect(Thread.current[:__hb_within_log_subscriber]).to be_nil
   end
 
   it "works when message is a string" do

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -50,11 +50,14 @@ describe Honeybadger::Breadcrumbs::LogWrapper do
     logger = Logger.new(nil)
     logger.extend(Honeybadger::Breadcrumbs::LogWrapper)
 
-    bad = Class.new { def to_s; nil; end }.new
+    bad = Class.new do
+      def to_s
+        nil
+      end
+    end.new
 
     expect { logger.add(Logger::ERROR, bad) }.not_to raise_error
   end
-
 
   describe "ignores messages on" do
     before { expect(Honeybadger).to_not receive(:add_breadcrumb) }
@@ -76,5 +79,77 @@ describe Honeybadger::Breadcrumbs::LogWrapper do
       subject.add("test", "a message")
       Thread.current[:__hb_within_log_subscriber] = false
     end
+
+    it "within broadcast logger call" do
+      Thread.current[:__hb_within_broadcast_logger] = true
+      subject.add("test", "a message")
+      Thread.current[:__hb_within_broadcast_logger] = false
+    end
+  end
+end
+
+describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
+  let(:sink_logger) do
+    Class.new do
+      prepend Honeybadger::Breadcrumbs::LogWrapper
+
+      attr_reader :entries
+
+      def initialize
+        @entries = []
+      end
+
+      def add(severity, message = nil, progname = nil)
+        @entries << [severity, message, progname]
+        true
+      end
+
+      def format_severity(str)
+        str
+      end
+    end
+  end
+
+  let(:broadcast_logger) do
+    Class.new do
+      prepend Honeybadger::Breadcrumbs::BroadcastLogWrapper
+
+      def initialize(*loggers)
+        @loggers = loggers
+      end
+
+      def add(*args, &block)
+        @loggers.each { |logger| logger.add(*args, &block) }
+        true
+      end
+
+      def info(message = nil, &block)
+        @loggers.each { |logger| logger.add(::Logger::INFO, nil, message, &block) }
+        true
+      end
+    end
+  end
+
+  let(:first_sink) { sink_logger.new }
+  let(:second_sink) { sink_logger.new }
+
+  before { Thread.current[:__hb_within_broadcast_logger] = nil }
+  after { Thread.current[:__hb_within_broadcast_logger] = nil }
+
+  subject { broadcast_logger.new(first_sink, second_sink) }
+
+  it "adds one breadcrumb for one broadcast log event" do
+    expect(Honeybadger).to receive(:add_breadcrumb).once.with("Message", hash_including(category: :log, metadata: hash_including(severity: "INFO", progname: nil)))
+
+    subject.info("Message")
+
+    expect(first_sink.entries).to eq([[::Logger::INFO, nil, "Message"]])
+    expect(second_sink.entries).to eq([[::Logger::INFO, nil, "Message"]])
+  end
+
+  it "restores the broadcast logger thread flag" do
+    subject.info("Message")
+
+    expect(Thread.current[:__hb_within_broadcast_logger]).to be_nil
   end
 end

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -156,4 +156,10 @@ describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
 
     expect(Thread.current[:__hb_within_broadcast_logger]).to be_nil
   end
+
+  it "labels severity using the constant fallback when format_severity is undefined" do
+    expect(Honeybadger).to receive(:add_breadcrumb).with("msg", hash_including(metadata: hash_including(severity: "WARN")))
+
+    subject.add(::Logger::WARN, "msg")
+  end
 end

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -163,23 +163,3 @@ describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
     subject.add(::Logger::WARN, "msg")
   end
 end
-
-describe Honeybadger::Breadcrumbs::LogSubscriberInjector do
-  let(:subscriber_class) do
-    Class.new do
-      prepend Honeybadger::Breadcrumbs::LogSubscriberInjector
-
-      def info(*)
-      end
-    end
-  end
-
-  before { Thread.current[:__hb_within_log_subscriber] = nil }
-  after { Thread.current[:__hb_within_log_subscriber] = nil }
-
-  it "restores the log subscriber thread flag" do
-    subscriber_class.new.info("Message")
-
-    expect(Thread.current[:__hb_within_log_subscriber]).to be_nil
-  end
-end

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -104,6 +104,10 @@ describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
         true
       end
 
+      def info(message = nil, &block)
+        add(::Logger::INFO, nil, message, &block)
+      end
+
       def format_severity(str)
         str
       end
@@ -124,7 +128,7 @@ describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
       end
 
       def info(message = nil, &block)
-        @loggers.each { |logger| logger.add(::Logger::INFO, nil, message, &block) }
+        @loggers.each { |logger| logger.info(message, &block) }
         true
       end
     end

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -163,3 +163,41 @@ describe Honeybadger::Breadcrumbs::BroadcastLogWrapper do
     subject.add(::Logger::WARN, "msg")
   end
 end
+
+describe Honeybadger::Breadcrumbs::LogSubscriberInjector do
+  let(:subscriber_class) do
+    Class.new do
+      prepend Honeybadger::Breadcrumbs::LogSubscriberInjector
+
+      attr_reader :flag_after_nested
+
+      def info(*)
+        # leaf level method — relies on the injector wrapping to set the flag
+      end
+
+      def warn(*)
+        # outer call: invokes another injector-wrapped level method, then
+        # records the thread flag after the nested call returns.
+        info("nested")
+        @flag_after_nested = Thread.current[:__hb_within_log_subscriber]
+      end
+    end
+  end
+
+  before { Thread.current[:__hb_within_log_subscriber] = nil }
+  after { Thread.current[:__hb_within_log_subscriber] = nil }
+
+  it "preserves the outer flag while a nested subscriber call is in flight" do
+    instance = subscriber_class.new
+    instance.warn("outer")
+
+    expect(instance.flag_after_nested).to be(true)
+  end
+
+  it "restores the flag after the outer call returns" do
+    instance = subscriber_class.new
+    instance.warn("outer")
+
+    expect(Thread.current[:__hb_within_log_subscriber]).to be_nil
+  end
+end

--- a/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/logging_spec.rb
@@ -169,17 +169,7 @@ describe Honeybadger::Breadcrumbs::LogSubscriberInjector do
     Class.new do
       prepend Honeybadger::Breadcrumbs::LogSubscriberInjector
 
-      attr_reader :flag_after_nested
-
       def info(*)
-        # leaf level method — relies on the injector wrapping to set the flag
-      end
-
-      def warn(*)
-        # outer call: invokes another injector-wrapped level method, then
-        # records the thread flag after the nested call returns.
-        info("nested")
-        @flag_after_nested = Thread.current[:__hb_within_log_subscriber]
       end
     end
   end
@@ -187,16 +177,8 @@ describe Honeybadger::Breadcrumbs::LogSubscriberInjector do
   before { Thread.current[:__hb_within_log_subscriber] = nil }
   after { Thread.current[:__hb_within_log_subscriber] = nil }
 
-  it "preserves the outer flag while a nested subscriber call is in flight" do
-    instance = subscriber_class.new
-    instance.warn("outer")
-
-    expect(instance.flag_after_nested).to be(true)
-  end
-
-  it "restores the flag after the outer call returns" do
-    instance = subscriber_class.new
-    instance.warn("outer")
+  it "restores the log subscriber thread flag" do
+    subscriber_class.new.info("Message")
 
     expect(Thread.current[:__hb_within_log_subscriber]).to be_nil
   end

--- a/spec/unit/honeybadger/plugins/breadcrumbs_spec.rb
+++ b/spec/unit/honeybadger/plugins/breadcrumbs_spec.rb
@@ -10,6 +10,19 @@ describe "Breadcrumbs Plugin" do
     stub_const("ActiveSupport::Notifications", active_support)
   end
 
+  describe ".load!" do
+    it "prepends the broadcast logger wrapper when BroadcastLogger is available" do
+      stub_const("Rails", double(application: true))
+      stub_const("ActiveSupport::LogSubscriber", Class.new)
+      stub_const("ActiveSupport::BroadcastLogger", Class.new)
+      allow(active_support).to receive(:subscribe)
+
+      Honeybadger::Plugin.instances[:breadcrumbs].load!(config)
+
+      expect(ActiveSupport::BroadcastLogger.ancestors).to include(Honeybadger::Breadcrumbs::BroadcastLogWrapper)
+    end
+  end
+
   describe Honeybadger::Plugins::RailsBreadcrumbs do
     describe ".subscribe_to_notification" do
       let(:name) { "a.notification" }


### PR DESCRIPTION
## Summary

Fixes #765.

When Rails 7.1+ uses `ActiveSupport::BroadcastLogger`, one logical log event is forwarded to each underlying logger. Honeybadger was wrapping `Logger`, so each sink logger added its own breadcrumb.

This PR adds a `BroadcastLogWrapper` that records the broadcast log event once, then suppresses breadcrumb capture while the broadcast dispatches to its sink loggers.

## Changes

- Add shared log breadcrumb formatting/sanitization helper.
- Add `Honeybadger::Breadcrumbs::BroadcastLogWrapper`.
- Prepend the broadcast wrapper when `ActiveSupport::BroadcastLogger` is available.
- Add unit coverage for single-breadcrumb broadcast behavior and plugin registration.

## Validation

- [x] Added tests for the bug fix.
- [x] Ran `bundle exec rake spec` in the repository root.
- [x] Ran focused specs:
  - `bundle exec rspec spec/unit/honeybadger/breadcrumbs/logging_spec.rb spec/unit/honeybadger/plugins/breadcrumbs_spec.rb`
- [x] Verified with a real `ActiveSupport::BroadcastLogger` 7.1.6 smoke script that one broadcast log event creates exactly one breadcrumb.
