### PR TITLE
fix: attach environment and hostname to metric events

### DIFF
--- a/lib/honeybadger/event.rb
+++ b/lib/honeybadger/event.rb
@@ -23,11 +23,11 @@ module Honeybadger
         @event_type = event_type_or_payload
         @payload = payload
       elsif event_type_or_payload.is_a?(Hash)
-        @event_type = event_type_or_payload[:event_type] || event_type_or_payload["event_type"]
         @payload = payload.merge(event_type_or_payload)
+        @event_type = @payload[:event_type] || @payload["event_type"]
       end
 
-      @ts = payload[:ts] || Time.now.utc.strftime("%FT%T.%LZ")
+      @ts = @payload[:ts] || Time.now.utc.strftime("%FT%T.%LZ")
       @halted = false
     end
 

--- a/lib/honeybadger/event.rb
+++ b/lib/honeybadger/event.rb
@@ -24,7 +24,7 @@ module Honeybadger
         @payload = payload
       elsif event_type_or_payload.is_a?(Hash)
         @event_type = event_type_or_payload[:event_type] || event_type_or_payload["event_type"]
-        @payload = event_type_or_payload
+        @payload = payload.merge(event_type_or_payload)
       end
 
       @ts = payload[:ts] || Time.now.utc.strftime("%FT%T.%LZ")

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -904,6 +904,21 @@ describe Honeybadger::Agent do
         subject.event("test_event", some_data: "is here")
       end
     end
+
+    context "when called with a single Hash payload (as metrics do)" do
+      let(:config) { Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER, backend: :debug, env: "production", hostname: "test-host") }
+
+      it "still attaches environment and hostname to the payload" do
+        expect(events_worker).to receive(:push) do |msg|
+          expect(msg[:environment]).to eq("production")
+          expect(msg[:hostname]).to eq("test-host")
+          expect(msg[:event_type]).to eq("metric.hb")
+          expect(msg[:metric_name]).to eq("duration.process_action.action_controller")
+        end
+
+        subject.event(event_type: "metric.hb", metric_name: "duration.process_action.action_controller", interval: 60)
+      end
+    end
   end
 
   context "#collect" do

--- a/spec/unit/honeybadger/event_spec.rb
+++ b/spec/unit/honeybadger/event_spec.rb
@@ -50,14 +50,34 @@ describe Honeybadger::Event do
           expect(subject.payload[:environment]).to eq("staging")
         end
       end
+
+      context "when ts is provided in the first Hash argument" do
+        subject { described_class.new({event_type: "action", ts: "2026-05-04T12:00:00.000Z"}) }
+
+        its(:ts) { should eq "2026-05-04T12:00:00.000Z" }
+      end
+
+      context "when event_type is only present in the second argument" do
+        subject { described_class.new({some_data: 1}, {event_type: "action"}) }
+
+        its(:event_type) { should eq "action" }
+      end
     end
   end
 
   describe "ts" do
-    before { Timecop.freeze }
-    after { Timecop.unfreeze }
+    context "when ts is not provided" do
+      before { Timecop.freeze }
+      after { Timecop.unfreeze }
 
-    its(:ts) { should eq Time.now.utc.strftime("%FT%T.%LZ") }
+      its(:ts) { should eq Time.now.utc.strftime("%FT%T.%LZ") }
+    end
+
+    context "when ts is provided in the second payload argument (String form)" do
+      subject { described_class.new("action", ts: "2026-05-04T12:00:00.000Z") }
+
+      its(:ts) { should eq "2026-05-04T12:00:00.000Z" }
+    end
   end
 
   describe "halted" do

--- a/spec/unit/honeybadger/event_spec.rb
+++ b/spec/unit/honeybadger/event_spec.rb
@@ -24,6 +24,33 @@ describe Honeybadger::Event do
       its(:event_type) { should eq "action" }
       its(:payload) { should eq({event_type: "action"}) }
     end
+
+    context "event_type is passed as a Hash with a second payload argument" do
+      subject { described_class.new(event_type_or_payload, payload) }
+
+      let(:event_type_or_payload) { {event_type: "action", caller_key: "caller"} }
+      let(:payload) { {environment: "production", hostname: "host"} }
+
+      its(:event_type) { should eq "action" }
+
+      it "merges the second payload into the first, with the first winning on conflicts" do
+        expect(subject.payload).to eq({
+          event_type: "action",
+          caller_key: "caller",
+          environment: "production",
+          hostname: "host"
+        })
+      end
+
+      context "when the same key appears in both arguments" do
+        let(:event_type_or_payload) { {event_type: "action", environment: "staging"} }
+        let(:payload) { {environment: "production"} }
+
+        it "the first argument takes precedence" do
+          expect(subject.payload[:environment]).to eq("staging")
+        end
+      end
+    end
   end
 
   describe "ts" do


### PR DESCRIPTION
This PR fixes a customer-reported bug that environment info wasn't being included with metrics events.

## Summary

- When `Event` is initialized from a single Hash payload (the path used by metrics), the second `payload` argument (carrying `environment` and `hostname` from `Agent`) was discarded. Now both are merged, with the caller's hash taking precedence on conflicts.
- Added unit tests for `Event` merge behavior and for `Agent#event` verifying environment/hostname are present on metric payloads.

## Testing

- `bundle exec rspec spec/unit/honeybadger/event_spec.rb`
- `bundle exec rspec spec/unit/honeybadger/agent_spec.rb`
