### PR TITLE
feat: ignore solid_cable_messages queries

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -33,7 +33,7 @@ module Honeybadger
 
     IGNORE_EVENTS_DEFAULT = [
       {event_type: "sql.active_record", query: /^(begin|commit)( immediate)?( transaction)?$/i},
-      {event_type: "sql.active_record", query: /(solid_queue|good_job)/i},
+      {event_type: "sql.active_record", query: /(solid_queue|good_job|solid_cable_messages)/i},
       {event_type: "sql.active_record", name: /^GoodJob/},
       {event_type: "process_action.action_controller", controller: "Rails::HealthController"},
       {event_type: "cache_read.active_support"},

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -602,6 +602,16 @@ describe Honeybadger::Agent do
         end
       end
 
+      context "by default ignores solid_cable_messages processor sql events" do
+        let(:ignored_events) { [] }
+        let(:event_type) { "sql.active_record" }
+        let(:payload) { {query: 'SELECT * FROM "solid_cable_messages"'} }
+
+        it "does not push an event" do
+          expect(events_worker).not_to receive(:push)
+        end
+      end
+
       context "override default ignores" do
         let(:config) { Honeybadger::Config.new(api_key: "fake api key", logger: NULL_LOGGER, backend: :debug, "events.ignore_only": ignore_only) }
         let(:ignore_only) { [] }


### PR DESCRIPTION
These are about as useful as  good_job and solid_queue queries, which we already ignore. :)

