### PR TITLE
fix: log the real reason for 403 responses

### DIFF
--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -50,6 +50,10 @@ module Honeybadger
 
       def error_message
         return message if code == :error
+        if code == 403
+          return error if NOT_BLANK.match?(error)
+          return FRIENDLY_ERRORS[code]
+        end
         return FRIENDLY_ERRORS[code] if FRIENDLY_ERRORS[code]
         return error if NOT_BLANK.match?(error)
         msg = "The server responded with #{code}"

--- a/lib/honeybadger/backend/base.rb
+++ b/lib/honeybadger/backend/base.rb
@@ -50,10 +50,7 @@ module Honeybadger
 
       def error_message
         return message if code == :error
-        if code == 403
-          return error if NOT_BLANK.match?(error)
-          return FRIENDLY_ERRORS[code]
-        end
+        return error if code == 403 && NOT_BLANK.match?(error)
         return FRIENDLY_ERRORS[code] if FRIENDLY_ERRORS[code]
         return error if NOT_BLANK.match?(error)
         msg = "The server responded with #{code}"

--- a/lib/honeybadger/events_worker.rb
+++ b/lib/honeybadger/events_worker.rb
@@ -294,7 +294,7 @@ module Honeybadger
         warn { sprintf("Insights Event send failed: payment is required. code=%s", response.code) }
         suspend(3600)
       when 403
-        warn { sprintf("Insights Event send failed: API key is invalid. code=%s", response.code) }
+        warn { sprintf("Insights Event send failed: %s code=%s", response.error_message, response.code) }
         suspend(3600)
       when 413
         warn { sprintf("Insights Event send failed: Payload is too large. code=%s", response.code) }

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -221,7 +221,7 @@ module Honeybadger
         warn { sprintf("Error report failed: payment is required. id=%s code=%s", msg.id, response.code) }
         suspend(3600)
       when 403
-        warn { sprintf("Error report failed: API key is invalid. id=%s code=%s", msg.id, response.code) }
+        warn { sprintf("Error report failed: %s id=%s code=%s", response.error_message, msg.id, response.code) }
         suspend(3600)
       when 413
         warn { sprintf("Error report failed: Payload is too large. id=%s code=%s", msg.id, response.code) }

--- a/spec/unit/honeybadger/backend/base_spec.rb
+++ b/spec/unit/honeybadger/backend/base_spec.rb
@@ -7,6 +7,24 @@ describe Honeybadger::Backend::Response do
     its(:error) { should be_nil }
   end
 
+  describe "#error_message" do
+    context "when code is 403 and body contains a JSON error" do
+      let(:response) { described_class.new(403, %({"error":"api key denied: Quota exceeded"}\n)) }
+
+      it "returns the server error" do
+        expect(response.error_message).to eq("api key denied: Quota exceeded")
+      end
+    end
+
+    context "when code is 403 and body is not valid JSON" do
+      let(:response) { described_class.new(403, "Forbidden") }
+
+      it "falls back to the friendly 403 error" do
+        expect(response.error_message).to match(/API key is invalid/i)
+      end
+    end
+  end
+
   context "when unsuccessful" do
     subject { described_class.new(403, body) }
 

--- a/spec/unit/honeybadger/events_worker_spec.rb
+++ b/spec/unit/honeybadger/events_worker_spec.rb
@@ -291,7 +291,7 @@ describe Honeybadger::EventsWorker do
       end
 
       it "warns the logger" do
-        expect(config.logger).to receive(:warn).with(/invalid/)
+        expect(config.logger).to receive(:warn).with(/unauthorized/)
         handle_response
       end
     end

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -332,7 +332,7 @@ describe Honeybadger::Worker do
       end
 
       it "warns the logger" do
-        expect(config.logger).to receive(:warn).with(/invalid/)
+        expect(config.logger).to receive(:warn).with(/unauthorized/)
         handle_response
       end
     end


### PR DESCRIPTION
Our API indicates _why_ a notification was rejected when the response is 403, but that info wasn't surfaced in the log. This PR fixes that by displaying the error contained in the API response, if present.