### PR TITLE
feat: add after_notify hooks

### DIFF
--- a/lib/honeybadger/config.rb
+++ b/lib/honeybadger/config.rb
@@ -92,6 +92,10 @@ module Honeybadger
       (ruby[:before_notify] || []).clone
     end
 
+    def after_notify_hooks
+      (ruby[:after_notify] || []).clone
+    end
+
     def before_event_hooks
       (ruby[:before_event] || []).clone
     end

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -103,9 +103,9 @@ module Honeybadger
       # The hook is called for every backend response, including successful
       # deliveries. Response codes are usually HTTP status integers, but may be
       # symbols such as :stubbed or :error for non-server backends or connection
-      # failures. Filter with exact response codes, such as `response.code == 413`,
-      # rather than integer comparisons, or use #success? and #error_message helper 
-      # methods on the response object.
+      # failures. Filter with exact response codes (e.g. `response.code == 413`)
+      # rather than broad integer comparisons, or use `response.success?`.
+      # (Note: `response.error_message` may raise for non-HTTP responses like `:stubbed`.)
       #
       # Prefer `Honeybadger.event` for reporting failed notice deliveries. Calling
       # `Honeybadger.notify` from this hook can trigger another after_notify call;

--- a/lib/honeybadger/config/ruby.rb
+++ b/lib/honeybadger/config/ruby.rb
@@ -89,21 +89,61 @@ module Honeybadger
       def before_notify(action = nil, &block)
         hooks = Array(get(:before_notify)).dup
 
-        if action && validate_before_action(action, "notify")
+        if action && validate_hook_action(action, "before notify", 1)
           hooks << action
-        elsif block_given? && validate_before_action(block, "notify")
+        elsif block_given? && validate_hook_action(block, "before notify", 1)
           hooks << block
         end
 
         hash[:before_notify] = hooks
       end
 
+      # Run a hook after each error notice delivery attempt.
+      #
+      # The hook is called for every backend response, including successful
+      # deliveries. Response codes are usually HTTP status integers, but may be
+      # symbols such as :stubbed or :error for non-server backends or connection
+      # failures. Filter with exact response codes, such as `response.code == 413`,
+      # rather than integer comparisons, or use #success? and #error_message helper 
+      # methods on the response object.
+      #
+      # Prefer `Honeybadger.event` for reporting failed notice deliveries. Calling
+      # `Honeybadger.notify` from this hook can trigger another after_notify call;
+      # guard against self-reporting loops if a notice must be sent.
+      #
+      # @example Report oversized notice payloads
+      #   config.after_notify do |notice, response|
+      #     next unless response.code == 413
+      #
+      #     Honeybadger.event("honeybadger.notice_rejected", {
+      #       reason: "payload_too_large",
+      #       notice_id: notice.id,
+      #       payload_bytes: notice.to_json.bytesize
+      #     })
+      #   end
+      #
+      # @yieldparam notice [Honeybadger::Notice] The notice that was sent.
+      # @yieldparam response [Honeybadger::Backend::Response] The backend response.
+      # @return [Array<Proc>] configured hooks
+      # @api public
+      def after_notify(action = nil, &block)
+        hooks = Array(get(:after_notify)).dup
+
+        if action && validate_hook_action(action, "after notify", 2)
+          hooks << action
+        elsif block_given? && validate_hook_action(block, "after notify", 2)
+          hooks << block
+        end
+
+        hash[:after_notify] = hooks
+      end
+
       def before_event(action = nil, &block)
         hooks = Array(get(:before_event)).dup
 
-        if action && validate_before_action(action, "event")
+        if action && validate_hook_action(action, "before event", 1)
           hooks << action
-        elsif block_given? && validate_before_action(block, "event")
+        elsif block_given? && validate_hook_action(block, "before event", 1)
           hooks << block
         end
 
@@ -139,18 +179,18 @@ module Honeybadger
 
       private
 
-      def validate_before_action(action, type)
+      def validate_hook_action(action, name, arity)
         if !action.respond_to?(:call)
           logger.warn(
-            "You attempted to add a before #{type} hook that does not respond " \
+            "You attempted to add a #{name} hook that does not respond " \
             "to #call. We are discarding this hook so your intended behavior " \
             "will not occur."
           )
           false
-        elsif action.arity != 1
+        elsif action.arity != arity
           logger.warn(
-            "You attempted to add a before #{type} hook that has an arity " \
-            "other than one. We are discarding this hook so your intended " \
+            "You attempted to add a #{name} hook that has an arity " \
+            "other than #{arity}. We are discarding this hook so your intended " \
             "behavior will not occur."
           )
           false

--- a/lib/honeybadger/worker.rb
+++ b/lib/honeybadger/worker.rb
@@ -46,7 +46,9 @@ module Honeybadger
     end
 
     def send_now(msg)
-      handle_response(msg, notify_backend(msg))
+      response = notify_backend(msg)
+      run_after_notify_hooks(msg, response)
+      handle_response(msg, response)
     end
 
     def shutdown(force = false)
@@ -187,6 +189,21 @@ module Honeybadger
     def notify_backend(payload)
       d { sprintf("worker notifying backend id=%s", payload.id) }
       backend.notify(:notices, payload)
+    end
+
+    def run_after_notify_hooks(msg, response)
+      config.after_notify_hooks.each do |hook|
+        with_error_handling { hook.call(msg, response) }
+      end
+    end
+
+    def with_error_handling
+      yield
+    rescue => ex
+      error {
+        msg = "Rescued an error in an after notify hook class=%s message=%s\n\t%s"
+        sprintf(msg, ex.class, ex.message.dump, Array(ex.backtrace).join("\n\t"))
+      }
     end
 
     def calc_throttle_interval

--- a/spec/unit/honeybadger/config/ruby_spec.rb
+++ b/spec/unit/honeybadger/config/ruby_spec.rb
@@ -115,6 +115,50 @@ describe Honeybadger::Config::Ruby do
     end
   end
 
+  describe "#after_notify" do
+    it "adds a block as an after hook" do
+      block = ->(_notice, _response) {}
+
+      subject.after_notify(&block)
+
+      expect(subject.to_hash).to eq(after_notify: [block])
+    end
+
+    it "adds a callable as an after hook" do
+      callable = ->(_notice, _response) {}
+
+      subject.after_notify(callable)
+
+      expect(subject.to_hash).to eq(after_notify: [callable])
+    end
+
+    it "gives access to the after hooks when passed nothing" do
+      expect(subject.after_notify).to eq([])
+
+      callable = ->(_notice, _response) {}
+      subject.after_notify(callable)
+
+      expect(subject.after_notify).to eq([callable])
+    end
+
+    it "configures multiple hooks" do
+      subject.after_notify { |n, r| [n, r] }
+      subject.after_notify { |n, r| [n, r] }
+
+      expect(subject.after_notify.size).to eq(2)
+    end
+
+    it "rejects hooks with invalid arity" do
+      hook = ->(_notice) {}
+      allow(config.logger).to receive(:warn)
+
+      subject.after_notify(hook)
+
+      expect(config.logger).to have_received(:warn).with(/arity other than 2/)
+      expect(subject.after_notify).to eq([])
+    end
+  end
+
   describe "#exception_filter" do
     it "assigns the exception_filter" do
       block = -> {}

--- a/spec/unit/honeybadger/config_spec.rb
+++ b/spec/unit/honeybadger/config_spec.rb
@@ -362,6 +362,18 @@ describe Honeybadger::Config do
       expect(subject.before_notify_hooks.size).to eq(2)
     end
 
+    it "configures multiple after_notify hooks" do
+      subject.configure do |config|
+        config.after_notify { |n, r| [n, r] }
+      end
+
+      subject.configure do |config|
+        config.after_notify { |n, r| [n, r] }
+      end
+
+      expect(subject.after_notify_hooks.size).to eq(2)
+    end
+
     it "only responds to methods that correspond to default keys" do
       known_key_response = nil
       unknown_key_response = nil

--- a/spec/unit/honeybadger/worker_spec.rb
+++ b/spec/unit/honeybadger/worker_spec.rb
@@ -134,6 +134,62 @@ describe Honeybadger::Worker do
     end
   end
 
+  describe "#send_now" do
+    let(:response) { Honeybadger::Backend::Response.new(413, %({"error":"Payload exceeds maximum size"})) }
+
+    it "calls after_notify hooks with the notice and response" do
+      hook = spy("after notify hook", arity: 2)
+      config.configure { |config| config.after_notify(hook) }
+      allow(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_return(response)
+
+      instance.send_now(obj)
+
+      expect(hook).to have_received(:call).with(obj, response)
+    end
+
+    it "calls after_notify hooks for successful responses" do
+      response = Honeybadger::Backend::Response.new(201)
+      hook = spy("after notify hook", arity: 2)
+      config.configure { |config| config.after_notify(hook) }
+      allow(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_return(response)
+
+      instance.send_now(obj)
+
+      expect(hook).to have_received(:call).with(obj, response)
+    end
+
+    it "handles the response after calling after_notify hooks" do
+      config.configure do |config|
+        config.after_notify { |_notice, _response| expect(instance).not_to have_received(:handle_response) }
+      end
+      allow(instance.send(:backend)).to receive(:notify).with(:notices, obj).and_return(response)
+      allow(instance).to receive(:handle_response).and_call_original
+
+      instance.send_now(obj)
+
+      expect(instance).to have_received(:handle_response).with(obj, response)
+    end
+
+    it "continues processing even if an after_notify hook raises an error" do
+      config.configure do |config|
+        config.after_notify(->(_notice, _response) { raise ArgumentError, "bad hook" })
+      end
+
+      expect { instance.send_now(obj) }.not_to raise_error
+    end
+
+    it "logs hook errors with class and backtrace" do
+      config.configure do |config|
+        config.after_notify(->(_notice, _response) { raise ArgumentError, "bad hook" })
+      end
+      allow(config.logger).to receive(:error)
+
+      instance.send_now(obj)
+
+      expect(config.logger).to have_received(:error).with(/ArgumentError.*bad hook/m)
+    end
+  end
+
   describe "#start" do
     it "starts the thread" do
       expect { subject.start }.to change(subject, :thread).to(kind_of(Thread))


### PR DESCRIPTION
This provides a hook for doing something after an error is reported to the API. E.g, if an error is rejected because the payload was too large (a 413 response), one could log the error payload, record an Insights event, etc.
