### PR TITLE
feat: add RubyLLM monitoring plugin

### DIFF
--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -574,6 +574,11 @@ module Honeybadger
         description: "Enable automatic data collection for Flipper.",
         default: true,
         type: Boolean
+      },
+      "ruby_llm.insights.enabled": {
+        description: "Enable automatic data collection for RubyLLM.",
+        default: true,
+        type: Boolean
       }
     }.freeze
 

--- a/lib/honeybadger/plugins/ruby_llm.rb
+++ b/lib/honeybadger/plugins/ruby_llm.rb
@@ -1,0 +1,53 @@
+require "honeybadger/plugin"
+require "honeybadger/notification_subscriber"
+
+module Honeybadger
+  module Plugins
+    module RubyLLM
+      Plugin.register :ruby_llm do
+        requirement { defined?(::RubyLLM) }
+        requirement { defined?(::ActiveSupport::Notifications) }
+
+        execution do
+          if config.load_plugin_insights?(:ruby_llm)
+            # request.ruby_llm is intentionally excluded: it fires for every
+            # provider HTTP request (including retries and streams) and
+            # duplicates chat-level metadata.
+            ::ActiveSupport::Notifications.subscribe(
+              /(chat|tool_call|embedding|image|moderation|transcription|models\.refresh)\.ruby_llm/,
+              Honeybadger::RubyLLMSubscriber.new
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+module Honeybadger
+  class RubyLLMSubscriber < NotificationSubscriber
+    # Payloads carry full Ruby objects (chat, messages, responses, tool
+    # arguments, inputs), which may contain sensitive content. Allow only
+    # scalar metadata through.
+    def format_payload(name, payload)
+      case name
+      when "chat.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :message_count, :temperature, :tool_choice, :tool_call_limit, :streaming, :response_model, :response_role, :tool_call, :input_tokens, :output_tokens, :cached_tokens, :cache_creation_tokens, :thinking_tokens, :exception)
+      when "tool_call.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :tool_name, :tool_call_id, :result_class, :exception)
+      when "embedding.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :dimensions, :response_model, :input_tokens, :embedding_dimensions, :embedding_count, :exception)
+      when "image.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :size, :response_model, :exception)
+      when "moderation.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :flagged, :exception)
+      when "transcription.ruby_llm"
+        payload.slice(:provider, :provider_class, :model, :language, :response_model, :input_tokens, :output_tokens, :exception)
+      when "models.refresh.ruby_llm"
+        payload.slice(:remote_only, :model_count, :exception)
+      else
+        payload.slice(:provider, :provider_class, :model, :exception)
+      end
+    end
+  end
+end

--- a/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
+++ b/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
@@ -1,0 +1,169 @@
+require "honeybadger/plugins/ruby_llm"
+require "honeybadger/config"
+
+describe "RubyLLM Dependency" do
+  let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true) }
+
+  before do
+    Honeybadger::Plugin.instances[:ruby_llm].reset!
+  end
+
+  context "when RubyLLM is not installed" do
+    it "fails quietly" do
+      expect { Honeybadger::Plugin.instances[:ruby_llm].load!(config) }.not_to raise_error
+    end
+  end
+
+  context "when RubyLLM is installed", if: defined?(::ActiveSupport::Notifications) do
+    let(:ruby_llm_shim) do
+      Module.new
+    end
+
+    before do
+      Object.const_set(:RubyLLM, ruby_llm_shim)
+    end
+
+    after { Object.send(:remove_const, :RubyLLM) }
+
+    context "when insights are enabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true) }
+      let(:subscriber) { instance_double(Honeybadger::RubyLLMSubscriber) }
+
+      before do
+        allow(Honeybadger::RubyLLMSubscriber).to receive(:new).and_return(subscriber)
+        allow(ActiveSupport::Notifications).to receive(:subscribe)
+      end
+
+      it "subscribes to RubyLLM notifications" do
+        expect(ActiveSupport::Notifications).to receive(:subscribe).with(
+          match("chat.ruby_llm"),
+          subscriber
+        )
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+      end
+
+      it "subscribes with a pattern that matches all expected events" do
+        pattern = nil
+        allow(ActiveSupport::Notifications).to receive(:subscribe) { |p, _| pattern = p }
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+
+        expect(pattern).to match("chat.ruby_llm")
+        expect(pattern).to match("tool_call.ruby_llm")
+        expect(pattern).to match("embedding.ruby_llm")
+        expect(pattern).to match("image.ruby_llm")
+        expect(pattern).to match("moderation.ruby_llm")
+        expect(pattern).to match("transcription.ruby_llm")
+        expect(pattern).to match("models.refresh.ruby_llm")
+        expect(pattern).not_to match("request.ruby_llm")
+      end
+    end
+
+    context "when insights are disabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": false) }
+
+      before do
+        allow(ActiveSupport::Notifications).to receive(:subscribe)
+      end
+
+      it "does not subscribe to notifications" do
+        expect(ActiveSupport::Notifications).not_to receive(:subscribe)
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+      end
+    end
+
+    context "when RubyLLM insights are disabled" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": false) }
+
+      before do
+        allow(ActiveSupport::Notifications).to receive(:subscribe)
+      end
+
+      it "does not subscribe to notifications" do
+        expect(ActiveSupport::Notifications).not_to receive(:subscribe)
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+      end
+    end
+  end
+end
+
+describe Honeybadger::RubyLLMSubscriber do
+  let(:subscriber) { described_class.new }
+
+  it "is a NotificationSubscriber" do
+    expect(subscriber).to be_a(Honeybadger::NotificationSubscriber)
+  end
+
+  describe "#format_payload" do
+    context "with chat.ruby_llm event" do
+      it "excludes message content and object keys" do
+        expect(
+          subscriber.format_payload("chat.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "gpt-4o-mini", message_count: 2, streaming: false, response_model: "gpt-4o-mini", input_tokens: 10, output_tokens: 20, chat: :object, model_info: :object, input_messages: :value, messages_after: :value, response: :value, tool_calls: :value, params: :value, schema: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "gpt-4o-mini", message_count: 2, streaming: false, response_model: "gpt-4o-mini", input_tokens: 10, output_tokens: 20})
+      end
+    end
+
+    context "with tool_call.ruby_llm event" do
+      it "excludes tool arguments and results" do
+        expect(
+          subscriber.format_payload("tool_call.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "gpt-4o-mini", tool_name: "weather", tool_call_id: "1234", result_class: "String", chat: :object, model_info: :object, tool: :object, tool_call: :object, tool_arguments: :value, result: :value, result_content: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "gpt-4o-mini", tool_name: "weather", tool_call_id: "1234", result_class: "String"})
+      end
+    end
+
+    context "with embedding.ruby_llm event" do
+      it "excludes input text and result vectors" do
+        expect(
+          subscriber.format_payload("embedding.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "text-embedding-3-small", response_model: "text-embedding-3-small", input_tokens: 5, embedding_dimensions: 1536, embedding_count: 1, model_info: :object, input: :value, result: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "text-embedding-3-small", response_model: "text-embedding-3-small", input_tokens: 5, embedding_dimensions: 1536, embedding_count: 1})
+      end
+    end
+
+    context "with image.ruby_llm event" do
+      it "excludes the prompt and result" do
+        expect(
+          subscriber.format_payload("image.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "dall-e-3", size: "1024x1024", model_info: :object, prompt: :value, result: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "dall-e-3", size: "1024x1024"})
+      end
+    end
+
+    context "with moderation.ruby_llm event" do
+      it "excludes the input and result" do
+        expect(
+          subscriber.format_payload("moderation.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "omni-moderation-latest", flagged: true, model_info: :object, input: :value, result: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "omni-moderation-latest", flagged: true})
+      end
+    end
+
+    context "with transcription.ruby_llm event" do
+      it "excludes the result" do
+        expect(
+          subscriber.format_payload("transcription.ruby_llm", {provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "whisper-1", language: "en", input_tokens: 5, output_tokens: 10, model_info: :object, result: :value})
+        ).to eq({provider: "openai", provider_class: "RubyLLM::Providers::OpenAI", model: "whisper-1", language: "en", input_tokens: 5, output_tokens: 10})
+      end
+    end
+
+    context "with models.refresh.ruby_llm event" do
+      it "includes refresh metadata" do
+        expect(
+          subscriber.format_payload("models.refresh.ruby_llm", {remote_only: false, model_count: 100, exception_object: :object})
+        ).to eq({remote_only: false, model_count: 100})
+      end
+    end
+
+    context "with an exception in the payload" do
+      it "includes the exception class and message but not the exception object" do
+        expect(
+          subscriber.format_payload("chat.ruby_llm", {provider: "openai", model: "gpt-4o-mini", exception: ["RubyLLM::Error", "rate limited"], exception_object: :object})
+        ).to eq({provider: "openai", model: "gpt-4o-mini", exception: ["RubyLLM::Error", "rate limited"]})
+      end
+    end
+
+    context "with other events" do
+      it "allows only safe metadata keys through" do
+        expect(
+          subscriber.format_payload("other.ruby_llm", {provider: "openai", model: "gpt-4o-mini", input_messages: :value, unknown: :value})
+        ).to eq({provider: "openai", model: "gpt-4o-mini"})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `ruby_llm` plugin that subscribes to the ActiveSupport::Notifications instrumentation introduced in [ruby_llm 1.16.0](https://github.com/crmne/ruby_llm/releases/tag/1.16.0) and sends LLM telemetry (model, provider, token usage, durations, tool calls) to Honeybadger Insights. Modeled directly on the Active Agent plugin (#754).

## Events

| Event | Captured metadata |
|---|---|
| `chat.ruby_llm` | provider, model, message count, temperature, tool prefs, streaming, response model/role, input/output/cached/cache-creation/thinking tokens |
| `tool_call.ruby_llm` | provider, model, tool name, tool call id, result class |
| `embedding.ruby_llm` | provider, model, dimensions, input tokens, embedding count/dimensions |
| `image.ruby_llm`* | provider, model, size, response model |
| `moderation.ruby_llm`* | provider, model, flagged |
| `transcription.ruby_llm`* | provider, model, language, input/output tokens |
| `models.refresh.ruby_llm` | remote_only, model count |

\* Emitted by ruby_llm > 1.16.0 (currently on main); the subscription is harmlessly dormant on 1.16.0.

`request.ruby_llm` is intentionally excluded — it fires for every provider HTTP request (including retries and streams) and duplicates chat-level metadata, the same reasoning #754 used to exclude `stream_chunk.active_agent`.

## Data safety

ruby_llm payloads carry full Ruby objects (chat history, messages, responses, tool arguments, embedding inputs, prompts). `format_payload` strictly allowlists scalar metadata per event; unknown event names also get a conservative slice (`provider`, `provider_class`, `model`, `exception`) rather than passing through, so a future ruby_llm event can never leak prompt content. The `exception` `[class, message]` pair is kept for error visibility; `exception_object` is always dropped.

## Config

- `ruby_llm.insights.enabled` (default `true`), gated by the global `insights.enabled` — same single-key pattern as `active_agent` and `flipper`.

## Notes for users

- In Rails, ruby_llm >= 1.16.0 sets `RubyLLM.config.instrumenter ||= ActiveSupport::Notifications` via its Railtie, so this works out of the box.
- Outside Rails, ruby_llm's instrumenter defaults to `nil`; apps must opt in with `RubyLLM.configure { |c| c.instrumenter = ActiveSupport::Notifications }`. The plugin deliberately does not set it itself.

## Testing

- `bundle exec rspec spec/unit/honeybadger/plugins/ruby_llm_spec.rb` — 11 examples under the default bundle, 15 under a Rails appraisal (the ActiveSupport-gated contexts), 0 failures
- Full unit suite: 908 examples, 0 failures
- `standardrb` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)