### PR TITLE
feat: make RubyLLM insights subscriber configurable

### DIFF
--- a/lib/honeybadger/backtrace.rb
+++ b/lib/honeybadger/backtrace.rb
@@ -156,7 +156,7 @@ module Honeybadger
     end
 
     def to_s
-      lines.map(&:to_s).join("\n")
+      lines.join("\n")
     end
 
     def inspect

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -581,7 +581,7 @@ module Honeybadger
         type: Boolean
       },
       "ruby_llm.insights.subscriber": {
-        description: "Fully qualified class name of a custom subscriber for RubyLLM instrumentation. Defaults to Honeybadger::RubyLLMSubscriber.",
+        description: "Fully qualified class name of a custom subscriber for RubyLLM instrumentation. A class constant may also be given via Ruby configuration. Defaults to Honeybadger::RubyLLMSubscriber.",
         default: nil,
         type: String
       }

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -579,6 +579,11 @@ module Honeybadger
         description: "Enable automatic data collection for RubyLLM.",
         default: true,
         type: Boolean
+      },
+      "ruby_llm.insights.subscriber": {
+        description: "Fully qualified class name of a custom subscriber for RubyLLM instrumentation. Defaults to Honeybadger::RubyLLMSubscriber.",
+        default: nil,
+        type: String
       }
     }.freeze
 

--- a/lib/honeybadger/plugins/ruby_llm.rb
+++ b/lib/honeybadger/plugins/ruby_llm.rb
@@ -10,12 +10,24 @@ module Honeybadger
 
         execution do
           if config.load_plugin_insights?(:ruby_llm)
+            class_name = config[:"ruby_llm.insights.subscriber"].to_s.strip
+            subscriber = if class_name.empty?
+              Honeybadger::RubyLLMSubscriber.new
+            else
+              begin
+                Object.const_get(class_name).new
+              rescue => e
+                logger.error("Unable to load ruby_llm.insights.subscriber=#{class_name} (#{e.class}: #{e.message}); falling back to Honeybadger::RubyLLMSubscriber")
+                Honeybadger::RubyLLMSubscriber.new
+              end
+            end
+
             # request.ruby_llm is intentionally excluded: it fires for every
             # provider HTTP request (including retries and streams) and
             # duplicates chat-level metadata.
             ::ActiveSupport::Notifications.subscribe(
               /(chat|tool_call|embedding|image|moderation|transcription|models\.refresh)\.ruby_llm/,
-              Honeybadger::RubyLLMSubscriber.new
+              subscriber
             )
           end
         end

--- a/lib/honeybadger/plugins/ruby_llm.rb
+++ b/lib/honeybadger/plugins/ruby_llm.rb
@@ -15,7 +15,11 @@ module Honeybadger
               Honeybadger::RubyLLMSubscriber.new
             else
               begin
-                Object.const_get(class_name).new
+                candidate = Object.const_get(class_name).new
+                unless candidate.respond_to?(:start) && candidate.respond_to?(:finish)
+                  raise TypeError, "does not respond to #start and #finish"
+                end
+                candidate
               rescue => e
                 logger.error("Unable to load ruby_llm.insights.subscriber=#{class_name} (#{e.class}: #{e.message}); falling back to Honeybadger::RubyLLMSubscriber")
                 Honeybadger::RubyLLMSubscriber.new

--- a/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
+++ b/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
@@ -118,6 +118,27 @@ describe "RubyLLM Dependency" do
         end
       end
 
+      context "when the configured name has a leading ::" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "::CustomRubyLLMSubscriber") }
+
+        it "subscribes an instance of the configured class" do
+          expect(subscribed).to be_a(CustomRubyLLMSubscriber)
+        end
+      end
+
+      context "when the configured class is not a notification subscriber" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "NotASubscriber") }
+
+        before { stub_const("NotASubscriber", Class.new) }
+
+        it "logs an error and subscribes the default subscriber" do
+          allow(config.logger).to receive(:error)
+
+          expect(subscribed).to be_an_instance_of(Honeybadger::RubyLLMSubscriber)
+          expect(config.logger).to have_received(:error).with(/NotASubscriber.*start.*finish/)
+        end
+      end
+
       context "when the configured value is the class itself" do
         let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": CustomRubyLLMSubscriber) }
 

--- a/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
+++ b/spec/unit/honeybadger/plugins/ruby_llm_spec.rb
@@ -58,6 +58,127 @@ describe "RubyLLM Dependency" do
       end
     end
 
+    context "when a custom subscriber is configured" do
+      let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "CustomRubyLLMSubscriber") }
+
+      let(:custom_subscriber_class) do
+        Class.new(Honeybadger::RubyLLMSubscriber) do
+          def format_payload(name, payload)
+            super.merge(tenant: payload.dig(:chat, :tenant))
+          end
+        end
+      end
+
+      let(:subscribed) do
+        subscriber = nil
+        allow(ActiveSupport::Notifications).to receive(:subscribe) { |_, s| subscriber = s }
+        Honeybadger::Plugin.instances[:ruby_llm].load!(config)
+        subscriber
+      end
+
+      before do
+        # The constant is only defined during the example (long after the
+        # plugin file is required), so resolution must happen lazily at
+        # plugin execution time for these to pass.
+        stub_const("CustomRubyLLMSubscriber", custom_subscriber_class)
+      end
+
+      it "subscribes an instance of the configured class" do
+        expect(subscribed).to be_a(CustomRubyLLMSubscriber)
+      end
+
+      it "emits events formatted by the custom subscriber" do
+        allow(Honeybadger).to receive(:event)
+
+        payload = {provider: "openai", model: "gpt-4o-mini", chat: {tenant: "acme"}}
+        subscribed.start("chat.ruby_llm", "abc123", payload)
+        subscribed.finish("chat.ruby_llm", "abc123", payload)
+
+        expect(Honeybadger).to have_received(:event).with("chat.ruby_llm", hash_including(model: "gpt-4o-mini", tenant: "acme"))
+        expect(Honeybadger).to have_received(:event).with("chat.ruby_llm", hash_excluding(:chat))
+      end
+
+      context "when the custom subscriber gates events via process?" do
+        let(:custom_subscriber_class) do
+          Class.new(Honeybadger::RubyLLMSubscriber) do
+            def process?(name, payload)
+              payload[:tools].nil?
+            end
+          end
+        end
+
+        it "does not emit gated events" do
+          allow(Honeybadger).to receive(:event)
+
+          payload = {provider: "openai", model: "gpt-4o-mini", tools: [:weather]}
+          subscribed.start("chat.ruby_llm", "abc123", payload)
+          subscribed.finish("chat.ruby_llm", "abc123", payload)
+
+          expect(Honeybadger).not_to have_received(:event)
+        end
+      end
+
+      context "when the configured value is the class itself" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": CustomRubyLLMSubscriber) }
+
+        it "subscribes an instance of that class" do
+          expect(subscribed).to be_a(CustomRubyLLMSubscriber)
+        end
+      end
+
+      context "when the configured value is blank" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "") }
+
+        it "subscribes the default subscriber without logging an error" do
+          allow(config.logger).to receive(:error)
+
+          expect(subscribed).to be_an_instance_of(Honeybadger::RubyLLMSubscriber)
+          expect(config.logger).not_to have_received(:error)
+        end
+      end
+
+      context "when the configured class cannot be resolved" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "Nonexistent::Subscriber") }
+
+        it "logs an error and subscribes the default subscriber" do
+          allow(config.logger).to receive(:error)
+
+          expect(subscribed).to be_an_instance_of(Honeybadger::RubyLLMSubscriber)
+          expect(config.logger).to have_received(:error).with(/Nonexistent::Subscriber.*NameError/)
+        end
+      end
+
+      context "when the configured constant cannot be instantiated" do
+        let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": true, "ruby_llm.insights.enabled": true, "ruby_llm.insights.subscriber": "CustomRubyLLMModule") }
+
+        before { stub_const("CustomRubyLLMModule", Module.new) }
+
+        it "logs the underlying error and subscribes the default subscriber" do
+          allow(config.logger).to receive(:error)
+
+          expect(subscribed).to be_an_instance_of(Honeybadger::RubyLLMSubscriber)
+          expect(config.logger).to have_received(:error).with(/CustomRubyLLMModule.*NoMethodError/)
+        end
+      end
+
+      context "when the configured class raises on instantiation" do
+        let(:custom_subscriber_class) do
+          Class.new(Honeybadger::RubyLLMSubscriber) do
+            def initialize(dependency)
+              super()
+            end
+          end
+        end
+
+        it "logs the underlying error and subscribes the default subscriber" do
+          allow(config.logger).to receive(:error)
+
+          expect(subscribed).to be_an_instance_of(Honeybadger::RubyLLMSubscriber)
+          expect(config.logger).to have_received(:error).with(/CustomRubyLLMSubscriber.*ArgumentError/)
+        end
+      end
+    end
+
     context "when insights are disabled" do
       let(:config) { Honeybadger::Config.new(logger: NULL_LOGGER, debug: true, "insights.enabled": false) }
 


### PR DESCRIPTION
Adds a `ruby_llm.insights.subscriber` config option (String, default `nil`): the fully qualified class name of a custom `NotificationSubscriber` to subscribe in place of `Honeybadger::RubyLLMSubscriber`. Unset means today's behavior, unchanged.

```yaml
ruby_llm:
  insights:
    subscriber: "MyApp::RubyLLMSubscriber"
```

Also works from Ruby config and, via the existing env mapping, `HONEYBADGER_RUBY_LLM_INSIGHTS_SUBSCRIBER`.

## Why

We (ClickFunnels, multi-tenant SaaS) need a subscriber subclass for two things the stock one can't do:

- **Tenant attribution:** merging account/workspace keys into events from the raw `payload[:chat]` object. That data is only reachable inside `process?`/`format_payload` — the privacy slice (correctly) drops the chat object before `before_event`/`event_context` can see it.
- **Gating on raw payload data:** ruby_llm instruments tool-call rounds recursively and nested `chat.ruby_llm` events repeat the final round's token counts, so we skip multi-round chats in `process?`.

Subclassing works great; wiring it doesn't. Today it requires `skipped_plugins = [:ruby_llm]` plus hand-subscribing in an initializer, re-implementing the plugin's gating and risking double-subscription (two subscribers race on `payload[:_start_time]`).

## Design

- Resolved lazily (`Object.const_get`) inside the execution block — plugins load in `after_initialize`, so app classes are resolvable by then.
- String type so YAML/env work with no new casting; the value is `to_s`'d, so a Class assigned via the Ruby DSL also works.
- Fail-safe: blank treated as unset; any resolve/instantiate failure logs the underlying error and falls back to the stock subscriber (privacy-safe allowlist) instead of crashing boot or disabling the plugin.

The pattern could generalize to other single-subscriber plugins later (`<plugin>.insights.subscriber`), and I'm open to a different extension point (e.g. a pre-slice payload hook) if you'd prefer — this seemed like the minimal version.

## Tests

Default unchanged; custom class subscribed, with `format_payload`/`process?` overrides verified against emitted events; blank and Class values; unresolvable name, module, and failing initializer all fall back with a logged error; lazy resolution enforced via `stub_const` inside examples. `spec:units` green under rails8 appraisal (955 examples) and default bundle (908); standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)