### PR TITLE
fix: respect logging.level with Rails logger

### DIFF
--- a/lib/honeybadger/logging.rb
+++ b/lib/honeybadger/logging.rb
@@ -124,12 +124,14 @@ module Honeybadger
 
       def initialize(config, logger = Logger.new(nil))
         @config = config
+        @log_level = @config.log_level
         @tty = $stdout.tty?
         @tty_level = @config.log_level(:"logging.tty_level")
         super(logger)
       end
 
       def add(severity, msg)
+        return true if suppress_log_level?(severity)
         return true if suppress_tty?(severity)
 
         # There is no debug level in Honeybadger. Debug logs will be logged at
@@ -147,6 +149,11 @@ module Honeybadger
       end
 
       private
+
+      def suppress_log_level?(severity)
+        effective_severity = (severity == Logger::Severity::DEBUG) ? Logger::Severity::INFO : severity
+        effective_severity < @log_level
+      end
 
       def suppress_debug?
         !debug?

--- a/spec/unit/honeybadger/logging_spec.rb
+++ b/spec/unit/honeybadger/logging_spec.rb
@@ -63,6 +63,32 @@ describe Honeybadger::Logging::ConfigLogger do
     it { should respond_to severity }
   end
 
+  context "when logging.level is above the shared logger level" do
+    let(:config) do
+      Honeybadger::Config.new(
+        debug: true,
+        "logging.level": "ERROR",
+        "logging.tty_level": "DEBUG"
+      )
+    end
+
+    before do
+      logger.level = Logger::DEBUG
+      allow(logger).to receive(:add).and_call_original
+    end
+
+    it "suppresses lower-severity Honeybadger logs without changing the shared logger" do
+      subject.info(:info)
+      subject.warn(:warn)
+      subject.error(:error)
+
+      expect(logger).not_to have_received(:add).with(Logger::Severity::INFO, :info, "honeybadger")
+      expect(logger).not_to have_received(:add).with(Logger::Severity::WARN, :warn, "honeybadger")
+      expect(logger).to have_received(:add).with(Logger::Severity::ERROR, :error, "honeybadger")
+      expect(logger.level).to eq(Logger::DEBUG)
+    end
+  end
+
   context "when not attached to terminal", unless: $stdout.tty? do
     LOG_SEVERITIES.each do |severity|
       it "delegates ##{severity} to configured logger" do


### PR DESCRIPTION
## What

- apply Honeybadger's configured `logging.level` inside `ConfigLogger`
- suppress only Honeybadger messages below that level without changing a shared Rails logger
- preserve debug messages being emitted at info severity when debug logging is enabled

## Why

The file and stdout loggers have their levels set directly, but the default Rails logger is shared and cannot be mutated. As a result, `logging.level` was ignored when Honeybadger used `Rails.logger`. Filtering inside the Honeybadger wrapper makes the setting consistent for shared and custom loggers.

Fixes #375

## Tests

- `bundle exec rspec spec/unit/honeybadger/logging_spec.rb` (38 examples, 0 failures)
- `bundle exec rake` (909 unit examples and 48 feature examples, 0 failures)
- `bundle exec standardrb --no-fix lib/honeybadger/logging.rb spec/unit/honeybadger/logging_spec.rb`