### PR TITLE
fix: truncate very large SQL queries instead of obfuscating them

### DIFF
--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -20,7 +20,7 @@ module Honeybadger
               if data[:sql]
                 connection = data.delete(:connection)
                 adapter = connection&.adapter_name&.downcase || active_record_connection_db_config[:adapter]
-                data[:sql] = Util::SQL.obfuscate(data[:sql], adapter)
+                data[:sql] = Util::SQL.obfuscate(data[:sql], adapter, max_length: Honeybadger.config[:"sql.max_length"])
               end
               data
             end,

--- a/lib/honeybadger/breadcrumbs/active_support.rb
+++ b/lib/honeybadger/breadcrumbs/active_support.rb
@@ -25,9 +25,10 @@ module Honeybadger
               data
             end,
             exclude_when: lambda do |data|
-              # Ignore schema, begin, and commit transaction queries
+              # Ignore schema, begin, and commit transaction queries. Those
+              # statements are tiny, so skip the scan for large queries.
               data[:name] == "SCHEMA" ||
-                (data[:sql] && (Util::SQL.force_utf_8(data[:sql].dup) =~ /^(begin|commit)( immediate)?( transaction)?$/i))
+                (data[:sql] && data[:sql].bytesize <= 64 && (Util::SQL.force_utf_8(data[:sql].dup) =~ /^(begin|commit)( immediate)?( transaction)?$/i))
             end
           },
 

--- a/lib/honeybadger/config/defaults.rb
+++ b/lib/honeybadger/config/defaults.rb
@@ -34,7 +34,7 @@ module Honeybadger
 
     IGNORE_EVENTS_DEFAULT = [
       {event_type: "sql.active_record", query: /^(begin|commit)( immediate)?( transaction)?$/i},
-      {event_type: "sql.active_record", query: /(solid_queue|good_job|solid_cable_messages)/i},
+      {event_type: "sql.active_record", query: /(solid_queue|solid_cache|good_job|solid_cable_messages)/i},
       {event_type: "sql.active_record", name: /^GoodJob/},
       {event_type: "process_action.action_controller", controller: "Rails::HealthController"},
       {event_type: "cache_read.active_support"},
@@ -151,6 +151,11 @@ module Honeybadger
       "events.sample_rate": {
         description: "Percentage of events to send to the API (0-100). A value of 0 means no events are sent, 100 means all events are sent.",
         default: 100,
+        type: Integer
+      },
+      "sql.max_length": {
+        description: "SQL queries larger than this many bytes are truncated instead of obfuscated (in Insights events and breadcrumbs). Scanning very large queries is slow and can exceed Regexp.timeout.",
+        default: 1_000_000,
         type: Integer
       },
       plugins: {

--- a/lib/honeybadger/notification_subscriber.rb
+++ b/lib/honeybadger/notification_subscriber.rb
@@ -20,6 +20,9 @@ module Honeybadger
 
       record(name, payload)
       record_metrics(name, payload)
+    rescue => e
+      # Instrumentation must never break the instrumented code.
+      Honeybadger.config.logger.error("Error in Honeybadger instrumentation for #{name}: #{e.class}: #{e.message}")
     end
 
     def record(name, payload)
@@ -116,7 +119,7 @@ module Honeybadger
   class ActiveRecordSubscriber < RailsSubscriber
     def format_payload(_name, payload)
       {
-        query: Util::SQL.obfuscate(payload[:sql], payload[:connection]&.adapter_name),
+        query: Util::SQL.obfuscate(payload[:sql], payload[:connection]&.adapter_name, max_length: Honeybadger.config[:"sql.max_length"]),
         cached: payload[:cached],
         async: payload[:async]
       }

--- a/lib/honeybadger/plugins/breadcrumbs.rb
+++ b/lib/honeybadger/plugins/breadcrumbs.rb
@@ -100,6 +100,9 @@ module Honeybadger
           category: notification_config[:category] || :custom,
           metadata: data
         )
+      rescue => e
+        # Instrumentation must never break the instrumented code.
+        Honeybadger.config.logger.error("Error in Honeybadger breadcrumb for #{name}: #{e.class}: #{e.message}")
       end
 
       # @api private

--- a/lib/honeybadger/util/sql.rb
+++ b/lib/honeybadger/util/sql.rb
@@ -5,10 +5,14 @@ module Honeybadger
       SQUOTE_DATA = /'(?:[^']|'')*'/
       DQUOTE_DATA = /"(?:[^"]|"")*"/
       NUMBER_DATA = /\b\d+\b/
+      HEX_DATA = /\b0[xb][0-9a-f]+\b/i
       DOUBLE_QUOTERS = /(postgres|sqlite|postgis)/i
       TRUNCATED_HEAD_LENGTH = 200
-      # Leading run of characters that can't start a literal value or a
-      # comment in any supported adapter (no quotes, $, /, -, #, \ ...).
+      # Leading run of characters that can't start a string literal or a
+      # comment in any supported adapter: stops at ', $, /, -, #, \ and so
+      # on. Double quotes and backticks are kept because they quote
+      # identifiers; adapters that use double quotes for strings are cut
+      # at the first double quote in .truncate.
       TRUNCATED_HEAD_SAFE = /\A[\w\s.,()=*"`]*/
 
       # Obfuscates literal values in a SQL query. When +max_length+ is given
@@ -25,6 +29,7 @@ module Honeybadger
           s.gsub!(ESCAPE_QUOTES, "".freeze)
           s.gsub!(SQUOTE_DATA, "'?'".freeze)
           s.gsub!(DQUOTE_DATA, '"?"'.freeze) unless adapter.to_s.match?(DOUBLE_QUOTERS)
+          s.gsub!(HEX_DATA, "?".freeze)
           s.gsub!(NUMBER_DATA, "?".freeze)
           s.strip!
         end

--- a/lib/honeybadger/util/sql.rb
+++ b/lib/honeybadger/util/sql.rb
@@ -6,9 +6,18 @@ module Honeybadger
       DQUOTE_DATA = /"(?:[^"]|"")*"/
       NUMBER_DATA = /\b\d+\b/
       DOUBLE_QUOTERS = /(postgres|sqlite|postgis)/i
+      TRUNCATED_HEAD_LENGTH = 200
 
-      def self.obfuscate(sql, adapter)
-        force_utf_8(sql.to_s.dup).tap do |s|
+      # Obfuscates literal values in a SQL query. When +max_length+ is given
+      # and the query is larger than that many bytes, the query is truncated
+      # instead (see .truncate): scanning multi-megabyte queries (e.g. an
+      # INSERT of a serialized cache value) is slow, and can exceed the
+      # Regexp.timeout that Rails 8.1+ sets by default.
+      def self.obfuscate(sql, adapter, max_length: nil)
+        sql = sql.to_s
+        return truncate(sql, adapter, max_length) if max_length && sql.bytesize > max_length
+
+        force_utf_8(sql.dup).tap do |s|
           s.gsub!(/\s+/, " ")
           s.gsub!(ESCAPE_QUOTES, "".freeze)
           s.gsub!(SQUOTE_DATA, "'?'".freeze)
@@ -16,6 +25,16 @@ module Honeybadger
           s.gsub!(NUMBER_DATA, "?".freeze)
           s.strip!
         end
+      end
+
+      # Keeps only the head of the statement (up to the first quoted value)
+      # so that no literal data leaks, and notes the original size.
+      def self.truncate(sql, adapter, max_length)
+        head = force_utf_8(sql.byteslice(0, TRUNCATED_HEAD_LENGTH)).scrub("")
+        head = head[0, head.index("'")] if head.include?("'")
+        head = head[0, head.index('"')] if head.include?('"') && !adapter.to_s.match?(DOUBLE_QUOTERS)
+
+        "#{obfuscate(head, adapter)} ... [truncated #{sql.bytesize} bytes]"
       end
 
       def self.force_utf_8(string)

--- a/lib/honeybadger/util/sql.rb
+++ b/lib/honeybadger/util/sql.rb
@@ -7,6 +7,9 @@ module Honeybadger
       NUMBER_DATA = /\b\d+\b/
       DOUBLE_QUOTERS = /(postgres|sqlite|postgis)/i
       TRUNCATED_HEAD_LENGTH = 200
+      # Leading run of characters that can't start a literal value or a
+      # comment in any supported adapter (no quotes, $, /, -, #, \ ...).
+      TRUNCATED_HEAD_SAFE = /\A[\w\s.,()=*"`]*/
 
       # Obfuscates literal values in a SQL query. When +max_length+ is given
       # and the query is larger than that many bytes, the query is truncated
@@ -27,11 +30,10 @@ module Honeybadger
         end
       end
 
-      # Keeps only the head of the statement (up to the first quoted value)
-      # so that no literal data leaks, and notes the original size.
+      # Keeps only the head of the statement (up to the first quoted value or
+      # comment) so that no literal data leaks, and notes the original size.
       def self.truncate(sql, adapter, max_length)
-        head = force_utf_8(sql.byteslice(0, TRUNCATED_HEAD_LENGTH)).scrub("")
-        head = head[0, head.index("'")] if head.include?("'")
+        head = force_utf_8(sql.byteslice(0, TRUNCATED_HEAD_LENGTH)).scrub("")[TRUNCATED_HEAD_SAFE]
         head = head[0, head.index('"')] if head.include?('"') && !adapter.to_s.match?(DOUBLE_QUOTERS)
 
         "#{obfuscate(head, adapter)} ... [truncated #{sql.bytesize} bytes]"

--- a/spec/unit/honeybadger/agent_spec.rb
+++ b/spec/unit/honeybadger/agent_spec.rb
@@ -592,6 +592,16 @@ describe Honeybadger::Agent do
         end
       end
 
+      context "by default ignores solid_cache sql events" do
+        let(:ignored_events) { [] }
+        let(:event_type) { "sql.active_record" }
+        let(:payload) { {query: 'INSERT INTO "solid_cache_entries" ("key","value","key_hash","byte_size","created_at") VALUES (?, ?, ?, ?, ?)'} }
+
+        it "does not push an event" do
+          expect(events_worker).not_to receive(:push)
+        end
+      end
+
       context "by default ignores good_job processor sql events" do
         let(:ignored_events) { [] }
         let(:event_type) { "sql.active_record" }

--- a/spec/unit/honeybadger/breadcrumbs/active_support_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/active_support_spec.rb
@@ -1,0 +1,24 @@
+require "honeybadger/breadcrumbs/active_support"
+
+describe Honeybadger::Breadcrumbs::ActiveSupport do
+  describe "sql.active_record" do
+    let(:notification) { described_class.default_notifications["sql.active_record"] }
+    let(:connection) { double("connection", adapter_name: "PostgreSQL") }
+
+    it "obfuscates the sql" do
+      data = notification[:transform].call({sql: "SELECT * FROM users WHERE id = 1", connection: connection})
+      expect(data[:sql]).to eq "SELECT * FROM users WHERE id = ?"
+    end
+
+    context "when the sql is longer than sql.max_length" do
+      before { Honeybadger.config[:"sql.max_length"] = 20 }
+      after { Honeybadger.config[:"sql.max_length"] = Honeybadger::Config::DEFAULTS[:"sql.max_length"] }
+
+      it "truncates the sql instead of obfuscating it" do
+        data = notification[:transform].call({sql: "SELECT * FROM users WHERE name = 'secret'", connection: connection})
+        expect(data[:sql]).to include("[truncated")
+        expect(data[:sql]).not_to include("secret")
+      end
+    end
+  end
+end

--- a/spec/unit/honeybadger/breadcrumbs/active_support_spec.rb
+++ b/spec/unit/honeybadger/breadcrumbs/active_support_spec.rb
@@ -20,5 +20,20 @@ describe Honeybadger::Breadcrumbs::ActiveSupport do
         expect(data[:sql]).not_to include("secret")
       end
     end
+
+    describe "exclude_when" do
+      it "excludes transaction statements" do
+        expect(notification[:exclude_when].call({sql: "BEGIN"})).to be_truthy
+        expect(notification[:exclude_when].call({sql: "COMMIT"})).to be_truthy
+      end
+
+      it "keeps other queries" do
+        expect(notification[:exclude_when].call({sql: "SELECT 1"})).to be_falsey
+      end
+
+      it "does not scan long queries for transaction statements" do
+        expect(notification[:exclude_when].call({sql: "#{"x" * 200}\nCOMMIT"})).to be_falsey
+      end
+    end
   end
 end

--- a/spec/unit/honeybadger/notification_subscriber_spec.rb
+++ b/spec/unit/honeybadger/notification_subscriber_spec.rb
@@ -217,3 +217,53 @@ describe Honeybadger::ActiveJobSubscriber do
     end
   end
 end
+
+describe Honeybadger::ActiveRecordSubscriber do
+  let(:connection) { double("connection", adapter_name: "PostgreSQL") }
+
+  describe "#format_payload" do
+    it "obfuscates the query" do
+      payload = {sql: "SELECT * FROM users WHERE id = 1", connection: connection}
+      expect(described_class.new.format_payload("sql.active_record", payload)[:query]).to eq "SELECT * FROM users WHERE id = ?"
+    end
+
+    context "when the query is longer than sql.max_length" do
+      before { Honeybadger.config[:"sql.max_length"] = 20 }
+      after { Honeybadger.config[:"sql.max_length"] = Honeybadger::Config::DEFAULTS[:"sql.max_length"] }
+
+      it "truncates the query instead of obfuscating it" do
+        payload = {sql: "SELECT * FROM users WHERE name = 'secret'", connection: connection}
+        query = described_class.new.format_payload("sql.active_record", payload)[:query]
+        expect(query).to start_with("SELECT * FROM users WHERE name = ")
+        expect(query).to include("[truncated")
+        expect(query).not_to include("secret")
+      end
+    end
+  end
+
+  describe "#finish" do
+    let(:subscriber) { described_class.new }
+    let(:payload) { {sql: "SELECT 1", connection: connection} }
+
+    before do
+      allow(Honeybadger).to receive(:event)
+      subscriber.start("sql.active_record", "id", payload)
+    end
+
+    it "does not raise when formatting the payload fails" do
+      allow(subscriber).to receive(:format_payload).and_raise(RuntimeError.new("regexp match timeout"))
+      expect { subscriber.finish("sql.active_record", "id", payload) }.not_to raise_error
+    end
+
+    it "logs the error when formatting the payload fails" do
+      allow(subscriber).to receive(:format_payload).and_raise(RuntimeError.new("regexp match timeout"))
+      expect(Honeybadger.config.logger).to receive(:error).with(/regexp match timeout/)
+      subscriber.finish("sql.active_record", "id", payload)
+    end
+
+    it "records the event when nothing fails" do
+      expect(Honeybadger).to receive(:event).with("sql.active_record", hash_including(query: "SELECT ?"))
+      subscriber.finish("sql.active_record", "id", payload)
+    end
+  end
+end

--- a/spec/unit/honeybadger/plugins/breadcrumbs_spec.rb
+++ b/spec/unit/honeybadger/plugins/breadcrumbs_spec.rb
@@ -67,6 +67,18 @@ describe "Breadcrumbs Plugin" do
         described_class.send_breadcrumb_notification("message", nil, config, {})
       end
 
+      it "does not raise when the transform fails" do
+        config = {transform: ->(_data) { raise "boom" }}
+        expect(Honeybadger).not_to receive(:add_breadcrumb)
+        expect { described_class.send_breadcrumb_notification("message", 1, config, {}) }.not_to raise_error
+      end
+
+      it "logs the error when the transform fails" do
+        config = {transform: ->(_data) { raise "boom" }}
+        expect(Honeybadger.config.logger).to receive(:error).with(/boom/)
+        described_class.send_breadcrumb_notification("message", 1, config, {})
+      end
+
       describe ":message" do
         it "can allow a string" do
           config = {message: "config message"}

--- a/spec/unit/honeybadger/util/sql_spec.rb
+++ b/spec/unit/honeybadger/util/sql_spec.rb
@@ -59,6 +59,23 @@ describe Honeybadger::Util::SQL do
         sql = "SELECT * FROM users WHERE id IN (#{(1..1000).to_a.join(", ")})"
         expect(described_class.obfuscate(sql, "postgres", max_length: 100).bytesize).to be < 300
       end
+
+      it "does not include dollar-quoted data from oversized SQL" do
+        sql = "SELECT $$secret#{"x" * 200}$$"
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100)).not_to include("secret")
+      end
+
+      it "does not include comments from oversized SQL" do
+        sql = "/* secret */ SELECT * FROM users WHERE id IN (#{(1..1000).to_a.join(", ")})"
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100)).not_to include("secret")
+        sql = "-- secret\nSELECT * FROM users WHERE id IN (#{(1..1000).to_a.join(", ")})"
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100)).not_to include("secret")
+      end
+
+      it "keeps backtick-quoted identifiers in the head of oversized SQL" do
+        sql = "INSERT INTO `solid_cache_entries` (`key`, `value`) VALUES ('a', '#{"x" * 200}')"
+        expect(described_class.obfuscate(sql, "mysql", max_length: 100)).to start_with("INSERT INTO `solid_cache_entries` (`key`, `value`) VALUES ( ...")
+      end
     end
   end
 end

--- a/spec/unit/honeybadger/util/sql_spec.rb
+++ b/spec/unit/honeybadger/util/sql_spec.rb
@@ -76,6 +76,17 @@ describe Honeybadger::Util::SQL do
         sql = "INSERT INTO `solid_cache_entries` (`key`, `value`) VALUES ('a', '#{"x" * 200}')"
         expect(described_class.obfuscate(sql, "mysql", max_length: 100)).to start_with("INSERT INTO `solid_cache_entries` (`key`, `value`) VALUES ( ...")
       end
+
+      it "does not include unquoted hexadecimal or binary literals from oversized SQL" do
+        sql = "INSERT INTO t (a, b) VALUES (0xDEADBEEF, 0b1010) #{"x" * 200}"
+        result = described_class.obfuscate(sql, "mysql", max_length: 100)
+        expect(result).not_to include("DEADBEEF")
+        expect(result).not_to include("1010")
+      end
+    end
+
+    it "sanitizes unquoted hexadecimal and binary literals" do
+      expect(described_class.obfuscate("INSERT INTO t (a, b) VALUES (0xDEADBEEF, 0b1010)", "mysql")).to eq "INSERT INTO t (a, b) VALUES (?, ?)"
     end
   end
 end

--- a/spec/unit/honeybadger/util/sql_spec.rb
+++ b/spec/unit/honeybadger/util/sql_spec.rb
@@ -34,5 +34,31 @@ describe Honeybadger::Util::SQL do
     it "handles double-quoted strings" do
       expect(described_class.obfuscate(%(SELECT * FROM "users" WHERE name = 'foo'), "postgres")).to eq %(SELECT * FROM "users" WHERE name = '?')
     end
+
+    describe "with max_length" do
+      it "obfuscates normally when the SQL is within max_length" do
+        expect(described_class.obfuscate("SELECT * FROM users WHERE name = 'foo'", "mysql", max_length: 1000)).to eq "SELECT * FROM users WHERE name = '?'"
+      end
+
+      it "replaces oversized SQL with a placeholder that keeps the statement head" do
+        sql = %(INSERT INTO "solid_cache_entries" ("key", "value") VALUES ('\\xabc', '\\x#{"ff" * 100}'))
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100)).to eq "INSERT INTO \"solid_cache_entries\" (\"key\", \"value\") VALUES ( ... [truncated #{sql.bytesize} bytes]"
+      end
+
+      it "does not include single-quoted data from oversized SQL" do
+        sql = "SELECT * FROM users WHERE name = 'secret#{"x" * 200}'"
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100)).not_to include("secret")
+      end
+
+      it "does not include double-quoted data from oversized SQL for adapters that quote data with double quotes" do
+        sql = %(SELECT * FROM users WHERE name = "secret#{"x" * 200}")
+        expect(described_class.obfuscate(sql, "mysql", max_length: 100)).not_to include("secret")
+      end
+
+      it "limits the head of oversized SQL to a short prefix" do
+        sql = "SELECT * FROM users WHERE id IN (#{(1..1000).to_a.join(", ")})"
+        expect(described_class.obfuscate(sql, "postgres", max_length: 100).bytesize).to be < 300
+      end
+    end
   end
 end


### PR DESCRIPTION
## Why

`Honeybadger::Util::SQL.obfuscate` scans the full SQL text of every `sql.active_record` notification, once for Insights events and once for breadcrumbs. On a multi-megabyte query (for example a Solid Cache `INSERT` of a serialized cache value, ~40MB of bytea hex) that scan can exceed the 1s `Regexp.timeout` that Rails 8.1 sets by default. The resulting `Regexp::TimeoutError` escaped our `ActiveSupport::Notifications` subscriber and failed the user's request. See https://github.com/sul-dlss/argo-b3/pull/427.

## What

- Add `sql.max_length` (default 1MB). Larger queries are not scanned. We keep only the head of the statement (a short run of characters that cannot start a literal or a comment), obfuscate that, and append the original byte size, e.g. `INSERT INTO "solid_cache_entries" ("key","value") VALUES ( ... [truncated 40000222 bytes]`.
- Rescue and log errors in the Insights notification subscriber and the breadcrumb handler, so instrumentation can never break the instrumented code.
- Skip the breadcrumb `BEGIN`/`COMMIT` scan for queries over 64 bytes.
- Ignore `solid_cache` SQL events by default, like `solid_queue` and `solid_cable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV18U9VG4WD5LvfnqjbrNP
