### PR TITLE
feat: Discontinue dependency from ostruct (OpenStruct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We use [YARD](https://yardoc.org/) to document our API. Classes and methods whic
 
 1. Fork it.
 2. Create a topic branch `git checkout -b my_branch`
-3. Make your changes and add an entry to the [CHANGELOG](CHANGELOG.md).
+3. Make your changes.
 4. Commit your changes `git commit -am "Boom"`
 5. Push to your branch `git push origin my_branch`
 6. Send a [pull request](https://github.com/honeybadger-io/honeybadger-ruby/pulls)

--- a/honeybadger.gemspec
+++ b/honeybadger.gemspec
@@ -36,5 +36,4 @@ Gem::Specification.new do |s|
   s.executables << "honeybadger"
 
   s.add_dependency "logger"
-  s.add_dependency "ostruct"
 end

--- a/lib/honeybadger/cli/exec.rb
+++ b/lib/honeybadger/cli/exec.rb
@@ -5,7 +5,6 @@ require "honeybadger/cli/helpers"
 require "honeybadger/util/http"
 require "honeybadger/util/stats"
 require "open3"
-require "ostruct"
 require "thor/shell"
 
 module Honeybadger
@@ -17,14 +16,14 @@ module Honeybadger
       FAILED_TEMPLATE = <<~MSG
         Honeybadger detected failure or error output for the command:
         `<%= args.join(' ') %>`
-        
+
         PROCESS ID: <%= pid %>
-        
+
         RESULT CODE: <%= code %>
-        
+
         ERROR OUTPUT:
         <%= stderr %>
-        
+
         STANDARD OUTPUT:
         <%= stdout %>
       MSG
@@ -32,14 +31,14 @@ module Honeybadger
       NO_EXEC_TEMPLATE = <<~MSG
         Honeybadger failed to execute the following command:
         `<%= args.join(' ') %>`
-        
+
         The command was not executable. Try adjusting permissions on the file.
       MSG
 
       NOT_FOUND_TEMPLATE = <<~MSG
         Honeybadger failed to execute the following command:
         `<%= args.join(' ') %>`
-        
+
         The command was not found. Make sure it exists in your PATH.
       MSG
 
@@ -119,7 +118,7 @@ module Honeybadger
         code = status.to_i
         msg = ERB.new(FAILED_TEMPLATE).result(binding) unless success
 
-        OpenStruct.new(
+        ExecResult.new(
           msg: msg,
           pid: pid,
           code: code,
@@ -128,16 +127,18 @@ module Honeybadger
           success: success
         )
       rescue Errno::EACCES, Errno::ENOEXEC
-        OpenStruct.new(
+        ExecResult.new(
           msg: ERB.new(NO_EXEC_TEMPLATE).result(binding),
           code: 126
         )
       rescue Errno::ENOENT
-        OpenStruct.new(
+        ExecResult.new(
           msg: ERB.new(NOT_FOUND_TEMPLATE).result(binding),
           code: 127
         )
       end
+
+      ExecResult = Struct.new(:msg, :pid, :code, :stdout, :stderr, :success, keyword_init: true)
     end
   end
 end

--- a/spec/integration/sidekiq_spec.rb
+++ b/spec/integration/sidekiq_spec.rb
@@ -1,5 +1,4 @@
 begin
-  require "ostruct"
   require "sidekiq"
   SIDEKIQ_PRESENT = true
 rescue LoadError
@@ -18,10 +17,11 @@ def run_sidekiq_job(klass, args)
   config = (Sidekiq::VERSION >= "7") ? ::Sidekiq.default_configuration.default_capsule : ::Sidekiq
   processor = Sidekiq::Processor.new(config)
 
+  unit_of_work_class = Struct.new(:acknowledge, :job, :queue, :queue_name, keyword_init: true)
   job_str = {
     "args" => args, "class" => klass.to_s, "jid" => SecureRandom.uuid
   }.to_json
-  unit_of_work = OpenStruct.new(job: job_str, queue: "default")
+  unit_of_work = unit_of_work_class.new(job: job_str, queue: "default")
   processor.__send__(:process, unit_of_work)
 end
 


### PR DESCRIPTION
The less dependencies injected by a library, the better. And Ruby [dislikes `OpenStruct` a lot, nowadays][1], and recommends:
    
>  For all these reasons, consider not using OpenStruct at all.

The few occurences have been replaced with alternatives which behave reasonably similar (i.e., it was never about to store more random properties after instantiation). Eventually, all `require "ostruct"` could be removed.

This might be a "breaking" change for an application which uses `OpenStruct`, but never declared an own dependency from `ostruct` (and/or did not `require "ostruct"` where effectively demanded by the code).

Piggy-backed: README conforms to actual contribution process.

[1]: https://docs.ruby-lang.org/en/3.4/OpenStruct.html#class-OpenStruct-label-Caveats

Note: sidekiq actually accesses `uow.queue_name` (only). Looks like `queue: "default"` (and the related property) is actually superfluous.